### PR TITLE
Improve CI

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update && apt install -y \
     help2man \
     lcov \
     libx11-dev \
+    libxt-dev \
     openssh-client \
     software-properties-common \
     wget \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,11 @@ jobs:
         path: './dependencies/vtk'
         ref: ${{env.VTK_SHA}}
 
-    - name: Patch VTK 9.0.1 source macos
+    - name: Patch VTK 9.0 source macos
       if: |
         steps.cache-vtk.outputs.cache-hit != 'true' &&
         matrix.os == 'macos-latest' &&
-        matrix.vtk_version == 'v9.0.1'
+        matrix.vtk_version == 'v9.0.0'
       working-directory: ${{github.workspace}}/dependencies/vtk
       run: |
         sed -i '' '57i\'$'\n''herr_t H5O__fsinfo_set_version(H5F_t *f, H5O_fsinfo_t *fsinfo);' ThirdParty/hdf5/vtkhdf5/src/H5Fsuper.c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        vtk_version: [c36e214568, v9.1.0, v9.0.0]
+        vtk_version: [c36e214568, v9.1.0, v9.0.1]
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-latest' && 'ghcr.io/f3d-app/f3d-ci' || null }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         vtk_version: [c36e214568, v9.1.0, v9.0.0]
 
-    needs: occt
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-latest' && 'ghcr.io/f3d-app/f3d-ci' || null }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        vtk_version: [c36e214568, v9.1.0, v9.0.1]
+        vtk_version: [c36e214568, v9.1.0, v9.0.0]
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-latest' && 'ghcr.io/f3d-app/f3d-ci' || null }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         vtk_version: [c36e214568, v9.1.0, v9.0.0]
 
+    needs: occt
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-latest' && 'ghcr.io/f3d-app/f3d-ci' || null }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
         git clone --bare https://github.com/Kitware/VTK.git bare
 
     - name: Set VTK env var
+      if: steps.cache-vtk.outputs.cache-hit != 'true'
       working-directory: ${{github.workspace}}/dependencies/bare
       shell: bash
       run: echo "VTK_SHA=$(git rev-parse ${{matrix.vtk_version}})" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,15 @@ on:
       - master
 
 jobs:
-  ci:
+  occt:
     if: github.event.pull_request.draft == false
 
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        vtk_version: [c36e214568, v9.1.0, v9.0.0]
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-latest' && 'ghcr.io/f3d-app/f3d-ci' || null }}
-
-    env:
-      DISPLAY: :0
 
     steps:
     - name: Dependencies Dir
@@ -86,6 +82,36 @@ jobs:
         matrix.os == 'ubuntu-latest'
       working-directory: ${{github.workspace}}/dependencies
       run: sed -i 's/OpenCASCADE_LIBRARIES [A-Za-z0-9;]\+/OpenCASCADE_LIBRARIES TKSTEP;TKSTEPAttr;TKSTEP209;TKSTEPBase;TKIGES;TKBool;TKMesh;TKXSBase;TKBO;TKPrim;TKShHealing;TKTopAlgo;TKBRep;TKGeomAlgo;TKGeomBase;TKG3d;TKG2d;TKMath;TKernel/' occt_install/lib/cmake/opencascade/OpenCASCADEConfig.cmake
+
+  ci:
+    if: github.event.pull_request.draft == false
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        vtk_version: [c36e214568, v9.1.0, v9.0.0]
+
+    runs-on: ${{matrix.os}}
+    container: ${{ matrix.os == 'ubuntu-latest' && 'ghcr.io/f3d-app/f3d-ci' || null }}
+
+    env:
+      DISPLAY: :0
+
+    steps:
+    - name: Dependencies Dir
+      working-directory: ${{github.workspace}}
+      run: mkdir dependencies
+
+    - name: Cache OCCT
+      id: cache-occt
+      uses: actions/cache@v2
+      with:
+        path: dependencies/occt_install
+        key: occt-V7_6_0-${{matrix.os}}
+
+    - name: Check OCCT
+      if: steps.cache-occt.outputs.cache-hit != 'true'
+      run: exit 1
 
     - name: Cache VTK
       id: cache-vtk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Cross Platform Build And Test
+name: Build And Test
 
 on:
   pull_request:
@@ -87,13 +87,12 @@ jobs:
       working-directory: ${{github.workspace}}/dependencies
       run: sed -i 's/OpenCASCADE_LIBRARIES [A-Za-z0-9;]\+/OpenCASCADE_LIBRARIES TKSTEP;TKSTEPAttr;TKSTEP209;TKSTEPBase;TKIGES;TKBool;TKMesh;TKXSBase;TKBO;TKPrim;TKShHealing;TKTopAlgo;TKBRep;TKGeomAlgo;TKGeomBase;TKG3d;TKG2d;TKMath;TKernel/' occt_install/lib/cmake/opencascade/OpenCASCADEConfig.cmake
 
-    # TODO rename cache 25/11
     - name: Cache VTK
       id: cache-vtk
       uses: actions/cache@v2
       with:
         path: dependencies/vtk_install
-        key: vtk-unversioned-${{matrix.vtk_version}}-${{matrix.os}}
+        key: vtk-${{matrix.vtk_version}}-${{matrix.os}}
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        vtk_version: [c36e214568a58be23f963e70f342e4b1480c8cc9, v9.1.0, v9.0.1]
+        vtk_version: [c36e214568, v9.1.0, v9.0.0]
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-latest' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -101,6 +101,11 @@ jobs:
         mkdir vtk_build
         mkdir vtk_install
 
+    - name: Set VTK env var
+      working-directory: ${{github.workspace}}/source
+      shell: bash
+      run: echo "VTK_SHA=$(git rev-parse ${{matrix.vtk_version}})" >> $GITHUB_ENV
+
     - name: Checkout VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
@@ -108,7 +113,7 @@ jobs:
         repository: Kitware/VTK
         submodules: 'true'
         path: './dependencies/vtk'
-        ref: ${{matrix.vtk_version}}
+        ref: ${{env.VTK_SHA}}
 
     - name: Patch VTK 9.0.1 source macos
       if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,19 @@ on:
       - master
 
 jobs:
-  occt:
+  ci:
     if: github.event.pull_request.draft == false
 
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        vtk_version: [c36e214568, v9.1.0, v9.0.0]
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-latest' && 'ghcr.io/f3d-app/f3d-ci' || null }}
+
+    env:
+      DISPLAY: :0
 
     steps:
     - name: Dependencies Dir
@@ -82,36 +86,6 @@ jobs:
         matrix.os == 'ubuntu-latest'
       working-directory: ${{github.workspace}}/dependencies
       run: sed -i 's/OpenCASCADE_LIBRARIES [A-Za-z0-9;]\+/OpenCASCADE_LIBRARIES TKSTEP;TKSTEPAttr;TKSTEP209;TKSTEPBase;TKIGES;TKBool;TKMesh;TKXSBase;TKBO;TKPrim;TKShHealing;TKTopAlgo;TKBRep;TKGeomAlgo;TKGeomBase;TKG3d;TKG2d;TKMath;TKernel/' occt_install/lib/cmake/opencascade/OpenCASCADEConfig.cmake
-
-  ci:
-    if: github.event.pull_request.draft == false
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        vtk_version: [c36e214568, v9.1.0, v9.0.0]
-
-    runs-on: ${{matrix.os}}
-    container: ${{ matrix.os == 'ubuntu-latest' && 'ghcr.io/f3d-app/f3d-ci' || null }}
-
-    env:
-      DISPLAY: :0
-
-    steps:
-    - name: Dependencies Dir
-      working-directory: ${{github.workspace}}
-      run: mkdir dependencies
-
-    - name: Cache OCCT
-      id: cache-occt
-      uses: actions/cache@v2
-      with:
-        path: dependencies/occt_install
-        key: occt-V7_6_0-${{matrix.os}}
-
-    - name: Check OCCT
-      if: steps.cache-occt.outputs.cache-hit != 'true'
-      run: exit 1
 
     - name: Cache VTK
       id: cache-vtk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,15 +121,16 @@ jobs:
         path: dependencies/vtk_install
         key: vtk-${{matrix.vtk_version}}-${{matrix.os}}
 
-    - name: Setup VTK
+    - name: Setup VTK and clone bare
       if: steps.cache-vtk.outputs.cache-hit != 'true'
       working-directory: ${{github.workspace}}/dependencies
       run: |
         mkdir vtk_build
         mkdir vtk_install
+        git clone --bare https://github.com/Kitware/VTK.git bare
 
     - name: Set VTK env var
-      working-directory: ${{github.workspace}}/source
+      working-directory: ${{github.workspace}}/dependencies/bare
       shell: bash
       run: echo "VTK_SHA=$(git rev-parse ${{matrix.vtk_version}})" >> $GITHUB_ENV
 


### PR DESCRIPTION
- Build and Test VTK 9.0.0, as we claim to support it in the ReadMe, which requires libXt in the docker image
- Use short SHA for VTK version