### PR TITLE
Better codecov conf

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,19 @@
+codecov:
+  notify:
+    after_n_builds: 3
+    wait_for_ci: yes
+
+coverage:
+  range: 70..100
+  round: down
+  precision: 2
+  project:
+    default:
+      target: auto
+      threshold: 0.1%
+
+comment:
+  require_changes: true
+
 fixes:
   - "/source::"


### PR DESCRIPTION
- wait all 3 build before reporting
- color range between 70 and 100
- round down with 2 precision
- treshold of 0.1% for success in ci
- require coverange change for commenting