### PR TITLE
DRAFT: Add 2D interactor and image readers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,10 +67,12 @@ declare_f3d_reader(F3D3DSReader)
 declare_f3d_reader(F3DCityGMLReader)
 declare_f3d_reader(F3DDICOMReader)
 declare_f3d_reader(F3DGLTFReader)
+declare_f3d_reader(F3DJPEGReader)
 declare_f3d_reader(F3DMetaImageReader)
 declare_f3d_reader(F3DNrrdReader)
 declare_f3d_reader(F3DOBJReader)
 declare_f3d_reader(F3DPLYReader)
+declare_f3d_reader(F3DPNGReader)
 declare_f3d_reader(F3DPTSReader)
 declare_f3d_reader(F3DSTLReader)
 declare_f3d_reader(F3DTIFFReader)
@@ -83,9 +85,9 @@ if(F3D_MODULE_OCCT)
   set(MODULES_SPECIFIC_INCLUDE_DIRS ${MODULES_SPECIFIC_INCLUDE_DIRS} ${OpenCASCADE_INCLUDE_DIR})
   # Note: OpenCASCADE does not declare the libs in the correct dependency order.
   # This could be an issue on Linux when linking with static libraries.
-  # See .github/workflows/ci.yml for a scripted fix 
+  # See .github/workflows/ci.yml for a scripted fix
   set(MODULES_SPECIFIC_LIBRARIES ${MODULES_SPECIFIC_LIBRARIES} ${OpenCASCADE_LIBRARIES})
-  
+
   declare_f3d_reader(F3DOpenCascadeReader)
 endif()
 
@@ -168,7 +170,9 @@ set(F3D_SOURCE_FILES
   vtkF3DConsoleOutputWindow.cxx
   vtkF3DGenericImporter.cxx
   vtkF3DInteractorEventRecorder.cxx
-  vtkF3DInteractorStyle.cxx
+  vtkF3DInteractorStyle2D.cxx
+  vtkF3DInteractorStyle3D.cxx
+  vtkF3DInteractionHandler.cxx
   vtkF3DMetaReader.cxx
   vtkF3DObjectFactory.cxx
   vtkF3DOpenGLGridMapper.cxx
@@ -192,7 +196,9 @@ set(F3D_HEADER_FILES
   vtkF3DConsoleOutputWindow.h
   vtkF3DGenericImporter.h
   vtkF3DInteractorEventRecorder.h
-  vtkF3DInteractorStyle.h
+  vtkF3DInteractorStyle2D.h
+  vtkF3DInteractorStyle3D.h
+  vtkF3DInteractionHandler.h
   vtkF3DMetaReader.h
   vtkF3DObjectFactory.h
   vtkF3DOpenGLGridMapper.h

--- a/src/F3DLoader.cxx
+++ b/src/F3DLoader.cxx
@@ -103,23 +103,23 @@ int F3DLoader::Start(int argc, char** argv, vtkImageData* image)
     this->RenWin->SetMultiSamples(0); // Disable hardware antialiasing
     this->RenWin->SetWindowName(f3d::AppTitle.c_str());
 
-    vtkF3DInteractionHandler* keyHandler = vtkF3DInteractionHandler::GetInstance();
+    this->InteractionHandler = vtkSmartPointer<vtkF3DInteractionHandler>::New();
 
     // Setup the observers for the interactor style events
     vtkNew<vtkCallbackCommand> newFilesCallback;
     newFilesCallback->SetClientData(this);
     newFilesCallback->SetCallback(F3DLoader::OnNewFiles);
-    keyHandler->AddObserver(F3DLoader::NewFilesEvent, newFilesCallback);
+    this->InteractionHandler->AddObserver(F3DLoader::NewFilesEvent, newFilesCallback);
 
     vtkNew<vtkCallbackCommand> loadFileCallback;
     loadFileCallback->SetClientData(this);
     loadFileCallback->SetCallback(F3DLoader::OnLoadFile);
-    keyHandler->AddObserver(F3DLoader::LoadFileEvent, loadFileCallback);
+    this->InteractionHandler->AddObserver(F3DLoader::LoadFileEvent, loadFileCallback);
 
     vtkNew<vtkCallbackCommand> toggleAnimationCallback;
     toggleAnimationCallback->SetClientData(&this->AnimationManager);
     toggleAnimationCallback->SetCallback(F3DLoader::OnToggleAnimation);
-    keyHandler->AddObserver(F3DLoader::ToggleAnimationEvent, toggleAnimationCallback);
+    this->InteractionHandler->AddObserver(F3DLoader::ToggleAnimationEvent, toggleAnimationCallback);
 
     // Offscreen rendering must be set before initializing interactor
     if (!this->CommandLineOptions.Reference.empty() || !this->CommandLineOptions.Output.empty() ||
@@ -129,7 +129,7 @@ int F3DLoader::Start(int argc, char** argv, vtkImageData* image)
     }
 
     interactor->SetRenderWindow(this->RenWin);
-    keyHandler->SetupInteractorStyles(interactor, &this->AnimationManager, &this->Options);
+    this->InteractionHandler->SetupInteractorStyles(interactor, &this->AnimationManager, &this->Options);
     interactor->Initialize();
 
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 0, 20200615)
@@ -526,6 +526,8 @@ bool F3DLoader::LoadFile(int load)
     this->Renderer->SetupRenderPasses();
     this->Renderer->UpdateInternalActors();
     this->Renderer->ShowOptions();
+
+    this->InteractionHandler->SetDefaultStyle(this->Renderer);
 
     // Set the initial camera once all options
     // have been shown as they may have an effect on it

--- a/src/F3DLoader.h
+++ b/src/F3DLoader.h
@@ -13,6 +13,7 @@
 
 #include "F3DAnimationManager.h"
 
+class vtkF3DInteractionHandler;
 class vtkF3DRenderer;
 class vtkImageData;
 class vtkImporter;
@@ -84,6 +85,7 @@ protected:
   vtkSmartPointer<vtkF3DRenderer> Renderer;
   vtkSmartPointer<vtkImporter> Importer;
   vtkSmartPointer<vtkRenderWindow> RenWin;
+  vtkSmartPointer<vtkF3DInteractionHandler> InteractionHandler;
   F3DReaderInstantiator* ReaderInstantiator;
 
 private:

--- a/src/F3DLoader.h
+++ b/src/F3DLoader.h
@@ -71,6 +71,10 @@ protected:
   static vtkSmartPointer<vtkImporter> GetImporter(
     const F3DOptions& options, const std::string& fileName);
 
+  static void OnNewFiles(vtkObject*, unsigned long, void*, void*);
+  static void OnLoadFile(vtkObject*, unsigned long, void*, void*);
+  static void OnToggleAnimation(vtkObject*, unsigned long, void*, void*);
+
   std::vector<std::string> FilesList;
   int CurrentFileIndex = 0;
   F3DOptionsParser Parser;

--- a/src/readers/F3D3DSReader.h
+++ b/src/readers/F3D3DSReader.h
@@ -40,7 +40,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "application/vnd.3ds" };
     return types;

--- a/src/readers/F3DAssimpReader.h
+++ b/src/readers/F3DAssimpReader.h
@@ -40,7 +40,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "application/vnd.fbx", "application/vnd.dae", "image/vnd.dxf", "application/vnd.off" };
     return types;

--- a/src/readers/F3DCityGMLReader.h
+++ b/src/readers/F3DCityGMLReader.h
@@ -40,7 +40,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "application/gml+xml" };
     return types;

--- a/src/readers/F3DExodusIIReader.h
+++ b/src/readers/F3DExodusIIReader.h
@@ -42,7 +42,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "application/vnd.exodus" };
     return types;

--- a/src/readers/F3DGLTFReader.h
+++ b/src/readers/F3DGLTFReader.h
@@ -41,7 +41,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "model/gltf-binary", "model/gltf+json" };
     return types;

--- a/src/readers/F3DJPEGReader.h
+++ b/src/readers/F3DJPEGReader.h
@@ -47,14 +47,9 @@ public:
   }
 
   /*
-   * Get the data dimension
-   */
-  int DataDimension() const override { return 2; }
-
-  /*
    * Get the data type
    */
-  int DataType() const override  { return DATA_TYPE_IMAGE; }
+  int GetDataType() const override  { return DATA_TYPE_IMAGE; }
 
 #ifndef F3D_NO_VTK
   /*

--- a/src/readers/F3DJPEGReader.h
+++ b/src/readers/F3DJPEGReader.h
@@ -1,39 +1,39 @@
 /**
- * @class   F3DTIFFReader
- * @brief   The TIFF reader class
+ * @class   F3DJPEGReader
+ * @brief   The JPEG reader class
  *
  */
 
-#ifndef F3DTIFFReader_h
-#define F3DTIFFReader_h
+#ifndef F3DJPEGReader_h
+#define F3DJPEGReader_h
 
 #include "F3DReaderFactory.h"
 
 #ifndef F3D_NO_VTK
-#include <vtkTIFFReader.h>
+#include <vtkJPEGReader.h>
 #endif
 
-class F3DTIFFReader : public F3DReader
+class F3DJPEGReader : public F3DReader
 {
 public:
-  F3DTIFFReader() = default;
+  F3DJPEGReader() = default;
 
   /*
    * Get the name of this reader
    */
-  const std::string GetName() const override { return "TIFFReader"; }
+  const std::string GetName() const override { return "JPEGReader"; }
 
   /*
    * Get the short description of this reader
    */
-  const std::string GetShortDescription() const override { return "TIFF files reader"; }
+  const std::string GetShortDescription() const override { return "JPEG files reader"; }
 
   /*
    * Get the extensions supported by this reader
    */
   const std::vector<std::string> GetExtensions() const override
   {
-    static const std::vector<std::string> ext = { ".tif", ".tiff" };
+    static const std::vector<std::string> ext = { ".jpg", ".jpeg" };
     return ext;
   }
 
@@ -42,19 +42,19 @@ public:
    */
   const std::vector<std::string> GetMimeTypes() const override
   {
-    static const std::vector<std::string> types = { "application/x-tgif" };
+    static const std::vector<std::string> types = { "image/jpeg" };
     return types;
   }
 
   /*
    * Get the data dimension
    */
-  virtual int DataDimension() const { return 2; }
+  int DataDimension() const override { return 2; }
 
   /*
    * Get the data type
    */
-  virtual int DataType() const { return DATA_TYPE_IMAGE; }
+  int DataType() const override  { return DATA_TYPE_IMAGE; }
 
 #ifndef F3D_NO_VTK
   /*
@@ -62,7 +62,7 @@ public:
    */
   vtkSmartPointer<vtkAlgorithm> CreateGeometryReader(const std::string& fileName) const override
   {
-    vtkSmartPointer<vtkTIFFReader> reader = vtkSmartPointer<vtkTIFFReader>::New();
+    vtkSmartPointer<vtkJPEGReader> reader = vtkSmartPointer<vtkJPEGReader>::New();
     reader->SetFileName(fileName.c_str());
     return reader;
   }

--- a/src/readers/F3DMetaImageReader.h
+++ b/src/readers/F3DMetaImageReader.h
@@ -40,7 +40,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "application/vnd.mhd" };
     return types;

--- a/src/readers/F3DNrrdReader.h
+++ b/src/readers/F3DNrrdReader.h
@@ -40,7 +40,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "application/vnd.nrrd" };
     return types;

--- a/src/readers/F3DOBJReader.h
+++ b/src/readers/F3DOBJReader.h
@@ -43,7 +43,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "model/obj" };
     return types;

--- a/src/readers/F3DOpenCascadeReader.h
+++ b/src/readers/F3DOpenCascadeReader.h
@@ -42,7 +42,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "model/iges", "application/vnd.step" };
     return types;

--- a/src/readers/F3DPLYReader.h
+++ b/src/readers/F3DPLYReader.h
@@ -40,7 +40,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "application/vnd.ply" };
     return types;

--- a/src/readers/F3DPNGReader.h
+++ b/src/readers/F3DPNGReader.h
@@ -47,14 +47,9 @@ public:
   }
 
   /*
-   * Get the data dimension
-   */
-  virtual int DataDimension() const { return 2; }
-
-  /*
    * Get the data type
    */
-  virtual int DataType() const { return DATA_TYPE_IMAGE; }
+  virtual int GetDataType() const { return DATA_TYPE_IMAGE; }
 
 #ifndef F3D_NO_VTK
   /*

--- a/src/readers/F3DPNGReader.h
+++ b/src/readers/F3DPNGReader.h
@@ -1,39 +1,39 @@
 /**
- * @class   F3DDICOMReader
- * @brief   The DICOM reader class
+ * @class   F3DPNGReader
+ * @brief   The PNG reader class
  *
  */
 
-#ifndef F3DDICOMReader_h
-#define F3DDICOMReader_h
+#ifndef F3DPNGReader_h
+#define F3DPNGReader_h
 
 #include "F3DReaderFactory.h"
 
 #ifndef F3D_NO_VTK
-#include <vtkDICOMImageReader.h>
+#include <vtkPNGReader.h>
 #endif
 
-class F3DDICOMReader : public F3DReader
+class F3DPNGReader : public F3DReader
 {
 public:
-  F3DDICOMReader() = default;
+  F3DPNGReader() = default;
 
   /*
    * Get the name of this reader
    */
-  const std::string GetName() const override { return "DICOMReader"; }
+  const std::string GetName() const override { return "PNGReader"; }
 
   /*
    * Get the short description of this reader
    */
-  const std::string GetShortDescription() const override { return "DICOM images files reader"; }
+  const std::string GetShortDescription() const override { return "PNG files reader"; }
 
   /*
    * Get the extensions supported by this reader
    */
   const std::vector<std::string> GetExtensions() const override
   {
-    static const std::vector<std::string> ext = { ".dcm" };
+    static const std::vector<std::string> ext = { ".png" };
     return ext;
   }
 
@@ -42,9 +42,19 @@ public:
    */
   const std::vector<std::string> GetMimeTypes() const override
   {
-    static const std::vector<std::string> types = { "application/dicom" };
+    static const std::vector<std::string> types = { "image/png" };
     return types;
   }
+
+  /*
+   * Get the data dimension
+   */
+  virtual int DataDimension() const { return 2; }
+
+  /*
+   * Get the data type
+   */
+  virtual int DataType() const { return DATA_TYPE_IMAGE; }
 
 #ifndef F3D_NO_VTK
   /*
@@ -52,7 +62,7 @@ public:
    */
   vtkSmartPointer<vtkAlgorithm> CreateGeometryReader(const std::string& fileName) const override
   {
-    vtkSmartPointer<vtkDICOMImageReader> reader = vtkSmartPointer<vtkDICOMImageReader>::New();
+    vtkSmartPointer<vtkPNGReader> reader = vtkSmartPointer<vtkPNGReader>::New();
     reader->SetFileName(fileName.c_str());
     return reader;
   }

--- a/src/readers/F3DPTSReader.h
+++ b/src/readers/F3DPTSReader.h
@@ -40,7 +40,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "application/vnd.pts" };
     return types;

--- a/src/readers/F3DReader.h
+++ b/src/readers/F3DReader.h
@@ -65,14 +65,9 @@ public:
   virtual bool CanRead(const std::string& fileName) const;
 
   /*
-   * Get the data dimension (3 or 2 for respectively 3D or 2D)
-   */
-  virtual int DataDimension() const { return 3; }
-
-  /*
    * Get the data type ()
    */
-  virtual int DataType() const { return DATA_TYPE_MESH; }
+  virtual int GetDataType() const { return DATA_TYPE_MESH; }
 
 #ifndef F3D_NO_VTK
   /*

--- a/src/readers/F3DReader.h
+++ b/src/readers/F3DReader.h
@@ -25,6 +25,12 @@
 class F3DReader
 {
 public:
+  enum DataTypeEnum
+  {
+    DATA_TYPE_MESH = 0,
+    DATA_TYPE_IMAGE = 1
+  };
+
   F3DReader() = default;
   virtual ~F3DReader() = default;
 
@@ -57,6 +63,16 @@ public:
    * Check if this reader can read the given filename - generally according its extension
    */
   virtual bool CanRead(const std::string& fileName) const;
+
+  /*
+   * Get the data dimension (3 or 2 for respectively 3D or 2D)
+   */
+  virtual int DataDimension() const { return 3; }
+
+  /*
+   * Get the data type ()
+   */
+  virtual int DataType() const { return DATA_TYPE_MESH; }
 
 #ifndef F3D_NO_VTK
   /*

--- a/src/readers/F3DSTLReader.h
+++ b/src/readers/F3DSTLReader.h
@@ -41,7 +41,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "model/stl" };
     return types;

--- a/src/readers/F3DTIFFReader.h
+++ b/src/readers/F3DTIFFReader.h
@@ -47,14 +47,9 @@ public:
   }
 
   /*
-   * Get the data dimension
-   */
-  virtual int DataDimension() const { return 2; }
-
-  /*
    * Get the data type
    */
-  virtual int DataType() const { return DATA_TYPE_IMAGE; }
+  virtual int GetDataType() const { return DATA_TYPE_IMAGE; }
 
 #ifndef F3D_NO_VTK
   /*

--- a/src/readers/F3DVRMLReader.h
+++ b/src/readers/F3DVRMLReader.h
@@ -40,7 +40,7 @@ public:
   /*
    * Get the mimetypes supported by this reader
    */
-  virtual const std::vector<std::string> GetMimeTypes() const override
+  const std::vector<std::string> GetMimeTypes() const override
   {
     static const std::vector<std::string> types = { "model/vrml" };
     return types;

--- a/src/vtkF3DGenericImporter.cxx
+++ b/src/vtkF3DGenericImporter.cxx
@@ -2,6 +2,7 @@
 
 #include "F3DLog.h"
 #include "F3DOptions.h"
+#include "F3DReader.h"
 
 #include <vtkActor.h>
 #include <vtkAppendPolyData.h>
@@ -332,7 +333,7 @@ void vtkF3DGenericImporter::ImportLights(vtkRenderer* ren)
   ren->RemoveAllLights();
   ren->AutomaticLightCreationOff();
 
-  if (!ren->GetUseImageBasedLighting())
+  if (!ren->GetUseImageBasedLighting() && this->Reader->GetReader()->GetDataType() == F3DReader::DATA_TYPE_MESH)
   {
     vtkNew<vtkLightKit> lightKit;
     lightKit->AddLightsToRenderer(ren);

--- a/src/vtkF3DInteractionHandler.cxx
+++ b/src/vtkF3DInteractionHandler.cxx
@@ -1,7 +1,9 @@
 #include "vtkF3DInteractionHandler.h"
 
+#include <vtkBoundingBox.h>
 #include <vtkInteractorStyle.h>
 #include <vtkObjectFactory.h>
+#include <vtkRenderer.h>
 #include <vtkRendererCollection.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
@@ -14,7 +16,6 @@
 #include "F3DOptions.h"
 #include "vtkF3DRendererWithColoring.h"
 
-vtkF3DInteractionHandler* vtkF3DInteractionHandler::Instance = nullptr;
 
 vtkStandardNewMacro(vtkF3DInteractionHandler);
 
@@ -23,15 +24,35 @@ void vtkF3DInteractionHandler::SetupInteractorStyles(
   vtkRenderWindowInteractor* interactor, F3DAnimationManager* animManager, F3DOptions* options)
 {
   this->Style3D->SetAnimationManager(*animManager);
+  this->Style3D->SetInteractionHandler(this);
   // Will only be used when interacting with a animated file
   this->Style3D->SetOptions(*options);
 
   this->Style2D->SetAnimationManager(*animManager);
+  this->Style2D->SetInteractionHandler(this);
   // Will only be used when interacting with a animated file
   this->Style2D->SetOptions(*options);
 
   interactor->SetInteractorStyle(this->Style2D);
   this->Interactor = interactor;
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractionHandler::SetDefaultStyle(vtkRenderer* renderer)
+{
+  double bounds[6], lengths[3];
+  renderer->ComputeVisiblePropBounds(bounds);
+  vtkBoundingBox box(bounds);
+  box.GetLengths(lengths);
+  bool is2D = (lengths[0] == 0 || lengths[1] == 0 || lengths[2] == 0);
+  if (is2D)
+  {
+    this->Interactor->SetInteractorStyle(this->Style2D);
+  }
+  else
+  {
+    this->Interactor->SetInteractorStyle(this->Style3D);
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/src/vtkF3DInteractionHandler.h
+++ b/src/vtkF3DInteractionHandler.h
@@ -16,23 +16,18 @@
 class F3DAnimationManager;
 class vtkInteractorStyle;
 class vtkStringArray;
+class vtkRenderer;
 class vtkRenderWindowInteractor;
 
 class vtkF3DInteractionHandler : public vtkObject
 {
 public:
+  static vtkF3DInteractionHandler* New();
   vtkTypeMacro(vtkF3DInteractionHandler, vtkObject);
 
-  static vtkF3DInteractionHandler* GetInstance()
-  {
-    if (!vtkF3DInteractionHandler::Instance)
-    {
-      vtkF3DInteractionHandler::Instance = vtkF3DInteractionHandler::New();
-    }
-    return vtkF3DInteractionHandler::Instance;
-  }
-
   void SetupInteractorStyles(vtkRenderWindowInteractor*, F3DAnimationManager*, F3DOptions*);
+
+  void SetDefaultStyle(vtkRenderer*);
 
   void OnDropFiles(vtkInteractorStyle*, vtkStringArray*);
 
@@ -45,13 +40,10 @@ public:
 protected:
   vtkF3DInteractionHandler() = default;
   ~vtkF3DInteractionHandler() override = default;
-  static vtkF3DInteractionHandler* New();
 
 private:
   vtkF3DInteractionHandler(const vtkF3DInteractionHandler&) = delete;
   void operator=(const vtkF3DInteractionHandler&) = delete;
-
-  static vtkF3DInteractionHandler* Instance;
 
   vtkRenderWindowInteractor* Interactor = nullptr;
   vtkNew<vtkF3DInteractorStyle2D> Style2D;

--- a/src/vtkF3DInteractionHandler.h
+++ b/src/vtkF3DInteractionHandler.h
@@ -1,0 +1,64 @@
+/**
+ * @class   vtkF3DInteractionHandler
+ * @brief   The key handler utility class
+ *
+ */
+
+#ifndef vtkF3DInteractionHandler_h
+#define vtkF3DInteractionHandler_h
+
+#include <vtkNew.h>
+#include <vtkObject.h>
+
+#include "vtkF3DInteractorStyle2D.h"
+#include "vtkF3DInteractorStyle3D.h"
+
+class F3DAnimationManager;
+class vtkInteractorStyle;
+class vtkStringArray;
+class vtkRenderWindowInteractor;
+
+class vtkF3DInteractionHandler : public vtkObject
+{
+public:
+  vtkTypeMacro(vtkF3DInteractionHandler, vtkObject);
+
+  static vtkF3DInteractionHandler* GetInstance()
+  {
+    if (!vtkF3DInteractionHandler::Instance)
+    {
+      vtkF3DInteractionHandler::Instance = vtkF3DInteractionHandler::New();
+    }
+    return vtkF3DInteractionHandler::Instance;
+  }
+
+  void SetupInteractorStyles(vtkRenderWindowInteractor*, F3DAnimationManager*, F3DOptions*);
+
+  void OnDropFiles(vtkInteractorStyle*, vtkStringArray*);
+
+  /**
+   * Handle the key press events.
+   * Returns true if key has been handled, false otherwise.
+   */
+  bool HandleKeyPress(vtkInteractorStyle*);
+
+protected:
+  vtkF3DInteractionHandler() = default;
+  ~vtkF3DInteractionHandler() override = default;
+  static vtkF3DInteractionHandler* New();
+
+private:
+  vtkF3DInteractionHandler(const vtkF3DInteractionHandler&) = delete;
+  void operator=(const vtkF3DInteractionHandler&) = delete;
+
+  static vtkF3DInteractionHandler* Instance;
+
+  vtkRenderWindowInteractor* Interactor = nullptr;
+  vtkNew<vtkF3DInteractorStyle2D> Style2D;
+  vtkNew<vtkF3DInteractorStyle3D> Style3D;
+
+  int WindowSize[2] = { -1, -1 };
+  int WindowPos[2] = { 0, 0 };
+};
+
+#endif

--- a/src/vtkF3DInteractorStyle2D.cxx
+++ b/src/vtkF3DInteractorStyle2D.cxx
@@ -14,13 +14,13 @@ vtkStandardNewMacro(vtkF3DInteractorStyle2D);
 //----------------------------------------------------------------------------
 void vtkF3DInteractorStyle2D::OnDropFiles(vtkStringArray* files)
 {
-  vtkF3DInteractionHandler::GetInstance()->OnDropFiles(this, files);
+  this->InteractionHandler->OnDropFiles(this, files);
 }
 
 //----------------------------------------------------------------------------
 void vtkF3DInteractorStyle2D::OnKeyPress()
 {
-  vtkF3DInteractionHandler::GetInstance()->HandleKeyPress(this);
+  this->InteractionHandler->HandleKeyPress(this);
 }
 
 //------------------------------------------------------------------------------

--- a/src/vtkF3DInteractorStyle2D.cxx
+++ b/src/vtkF3DInteractorStyle2D.cxx
@@ -1,0 +1,81 @@
+#include "vtkF3DInteractorStyle2D.h"
+
+#include "F3DAnimationManager.h"
+#include "F3DIncludes.h"
+#include "F3DLoader.h"
+#include "F3DLog.h"
+#include "vtkF3DInteractionHandler.h"
+#include "vtkF3DRendererWithColoring.h"
+
+#include <vtkObjectFactory.h>
+
+vtkStandardNewMacro(vtkF3DInteractorStyle2D);
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle2D::OnDropFiles(vtkStringArray* files)
+{
+  vtkF3DInteractionHandler::GetInstance()->OnDropFiles(this, files);
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle2D::OnKeyPress()
+{
+  vtkF3DInteractionHandler::GetInstance()->HandleKeyPress(this);
+}
+
+//------------------------------------------------------------------------------
+void vtkF3DInteractorStyle2D::Rotate()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle2D::Spin()
+{
+  if (this->IsUserInteractionBlocked())
+  {
+    return;
+  }
+  this->Superclass::Spin();
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle2D::Pan()
+{
+  if (this->IsUserInteractionBlocked())
+  {
+    return;
+  }
+  this->Superclass::Pan();
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle2D::Dolly()
+{
+  if (this->IsUserInteractionBlocked())
+  {
+    return;
+  }
+  this->Superclass::Dolly();
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle2D::Dolly(double factor)
+{
+  if (this->IsUserInteractionBlocked())
+  {
+    return;
+  }
+  this->Superclass::Dolly(factor);
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle2D::EnvironmentRotate()
+{
+  this->Superclass::EnvironmentRotate();
+}
+
+//----------------------------------------------------------------------------
+bool vtkF3DInteractorStyle2D::IsUserInteractionBlocked()
+{
+  return this->AnimationManager->IsPlaying() && this->Options->CameraIndex >= 0;
+}

--- a/src/vtkF3DInteractorStyle2D.h
+++ b/src/vtkF3DInteractorStyle2D.h
@@ -8,6 +8,7 @@
 
 #include <vtkInteractorStyleImage.h>
 
+class vtkF3DInteractionHandler;
 class F3DAnimationManager;
 struct F3DOptions;
 
@@ -59,12 +60,17 @@ public:
   /**
    * Set animation manager
    */
-  void SetAnimationManager(const F3DAnimationManager& mgr) { this->AnimationManager = &mgr; };
+  void SetAnimationManager(const F3DAnimationManager& mgr) { this->AnimationManager = &mgr; }
+
+  /**
+   * Set interaction handler
+   */
+  void SetInteractionHandler(vtkF3DInteractionHandler* handler) { this->InteractionHandler = handler; }
 
   /**
    * Set options
    */
-  void SetOptions(const F3DOptions& options) { this->Options = &options; };
+  void SetOptions(const F3DOptions& options) { this->Options = &options; }
 
 protected:
   /**
@@ -76,6 +82,7 @@ protected:
 
   const F3DAnimationManager* AnimationManager = nullptr;
   const F3DOptions* Options = nullptr;
+  vtkF3DInteractionHandler* InteractionHandler = nullptr;
 };
 
 #endif

--- a/src/vtkF3DInteractorStyle2D.h
+++ b/src/vtkF3DInteractorStyle2D.h
@@ -1,21 +1,21 @@
 /**
- * @class   vtkF3DInteractorStyle
- * @brief   custom interactor style based on default trackball camera
+ * @class   vtkF3DInteractorStyle2D
+ * @brief   custom interactor style based on default style image
  */
 
 #ifndef vtkF3DInteractorStyle_h
 #define vtkF3DInteractorStyle_h
 
-#include <vtkInteractorStyleTrackballCamera.h>
+#include <vtkInteractorStyleImage.h>
 
 class F3DAnimationManager;
 struct F3DOptions;
 
-class vtkF3DInteractorStyle : public vtkInteractorStyleTrackballCamera
+class vtkF3DInteractorStyle2D : public vtkInteractorStyleImage
 {
 public:
-  static vtkF3DInteractorStyle* New();
-  vtkTypeMacro(vtkF3DInteractorStyle, vtkInteractorStyleTrackballCamera);
+  static vtkF3DInteractorStyle2D* New();
+  vtkTypeMacro(vtkF3DInteractorStyle2D, vtkInteractorStyleImage);
 
   /**
    * Handle key presses
@@ -76,9 +76,6 @@ protected:
 
   const F3DAnimationManager* AnimationManager = nullptr;
   const F3DOptions* Options = nullptr;
-
-  int WindowSize[2] = { -1, -1 };
-  int WindowPos[2] = { 0, 0 };
 };
 
 #endif

--- a/src/vtkF3DInteractorStyle3D.cxx
+++ b/src/vtkF3DInteractorStyle3D.cxx
@@ -1,0 +1,169 @@
+#include "vtkF3DInteractorStyle3D.h"
+
+#include "F3DAnimationManager.h"
+#include "F3DIncludes.h"
+#include "F3DLoader.h"
+#include "F3DLog.h"
+#include "vtkF3DInteractionHandler.h"
+#include "vtkF3DRendererWithColoring.h"
+
+#include <vtkCallbackCommand.h>
+#include <vtkCamera.h>
+#include <vtkMath.h>
+#include <vtkMatrix3x3.h>
+#include <vtkObjectFactory.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+
+
+vtkStandardNewMacro(vtkF3DInteractorStyle3D);
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle3D::OnDropFiles(vtkStringArray* files)
+{
+  vtkF3DInteractionHandler::GetInstance()->OnDropFiles(this, files);
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle3D::OnKeyPress()
+{
+  vtkF3DInteractionHandler::GetInstance()->HandleKeyPress(this);
+}
+
+//------------------------------------------------------------------------------
+void vtkF3DInteractorStyle3D::Rotate()
+{
+  if (this->IsUserInteractionBlocked())
+  {
+    return;
+  }
+
+  vtkF3DRenderer* ren = vtkF3DRenderer::SafeDownCast(this->CurrentRenderer);
+
+  if (ren == nullptr)
+  {
+    return;
+  }
+
+  vtkRenderWindowInteractor* rwi = this->Interactor;
+
+  int dx = rwi->GetEventPosition()[0] - rwi->GetLastEventPosition()[0];
+  int dy = rwi->GetEventPosition()[1] - rwi->GetLastEventPosition()[1];
+
+  const int* size = ren->GetRenderWindow()->GetSize();
+
+  double delta_elevation = -20.0 / size[1];
+  double delta_azimuth = -20.0 / size[0];
+
+  double rxf = dx * delta_azimuth * this->MotionFactor;
+  double ryf = dy * delta_elevation * this->MotionFactor;
+
+  vtkCamera* camera = ren->GetActiveCamera();
+  double dir[3];
+  camera->GetDirectionOfProjection(dir);
+  double* up = ren->GetUpVector();
+
+  double dot = vtkMath::Dot(dir, up);
+
+  bool canElevate = ren->UsingTrackball() || std::abs(dot) < 0.99 || !std::signbit(dot * ryf);
+
+  camera->Azimuth(rxf);
+
+  if (canElevate)
+  {
+    camera->Elevation(ryf);
+  }
+
+  if (!ren->UsingTrackball())
+  {
+    // orthogonalize up vector based on focal direction
+    vtkMath::MultiplyScalar(dir, dot);
+    vtkMath::Subtract(up, dir, dir);
+    vtkMath::Normalize(dir);
+    camera->SetViewUp(dir);
+  }
+  else
+  {
+    camera->OrthogonalizeViewUp();
+  }
+
+  if (this->AutoAdjustCameraClippingRange)
+  {
+    this->CurrentRenderer->ResetCameraClippingRange();
+  }
+
+  if (rwi->GetLightFollowCamera())
+  {
+    this->CurrentRenderer->UpdateLightsGeometryToFollowCamera();
+  }
+
+  rwi->Render();
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle3D::Spin()
+{
+  if (this->IsUserInteractionBlocked())
+  {
+    return;
+  }
+  this->Superclass::Spin();
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle3D::Pan()
+{
+  if (this->IsUserInteractionBlocked())
+  {
+    return;
+  }
+  this->Superclass::Pan();
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle3D::Dolly()
+{
+  if (this->IsUserInteractionBlocked())
+  {
+    return;
+  }
+  this->Superclass::Dolly();
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle3D::Dolly(double factor)
+{
+  if (this->IsUserInteractionBlocked())
+  {
+    return;
+  }
+  this->Superclass::Dolly(factor);
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DInteractorStyle3D::EnvironmentRotate()
+{
+  this->Superclass::EnvironmentRotate();
+
+  vtkF3DRenderer* ren = vtkF3DRenderer::SafeDownCast(this->CurrentRenderer);
+  if (ren)
+  {
+    // update skybox orientation
+    double* up = ren->GetEnvironmentUp();
+    double* right = ren->GetEnvironmentRight();
+
+    double front[3];
+    vtkMath::Cross(right, up, front);
+
+    ren->GetSkybox()->SetFloorPlane(up[0], up[1], up[2], 0.0);
+    ren->GetSkybox()->SetFloorRight(front[0], front[1], front[2]);
+
+    this->Interactor->Render();
+  }
+}
+
+//----------------------------------------------------------------------------
+bool vtkF3DInteractorStyle3D::IsUserInteractionBlocked()
+{
+  return this->AnimationManager->IsPlaying() && this->Options->CameraIndex >= 0;
+}

--- a/src/vtkF3DInteractorStyle3D.cxx
+++ b/src/vtkF3DInteractorStyle3D.cxx
@@ -21,13 +21,13 @@ vtkStandardNewMacro(vtkF3DInteractorStyle3D);
 //----------------------------------------------------------------------------
 void vtkF3DInteractorStyle3D::OnDropFiles(vtkStringArray* files)
 {
-  vtkF3DInteractionHandler::GetInstance()->OnDropFiles(this, files);
+  this->InteractionHandler->OnDropFiles(this, files);
 }
 
 //----------------------------------------------------------------------------
 void vtkF3DInteractorStyle3D::OnKeyPress()
 {
-  vtkF3DInteractionHandler::GetInstance()->HandleKeyPress(this);
+  this->InteractionHandler->HandleKeyPress(this);
 }
 
 //------------------------------------------------------------------------------

--- a/src/vtkF3DInteractorStyle3D.h
+++ b/src/vtkF3DInteractorStyle3D.h
@@ -1,0 +1,81 @@
+/**
+ * @class   vtkF3DInteractorStyle3D
+ * @brief   custom interactor style based on default trackball camera
+ */
+
+#ifndef vtkF3DInteractorStyle3D_h
+#define vtkF3DInteractorStyle3D_h
+
+#include <vtkInteractorStyleTrackballCamera.h>
+
+class F3DAnimationManager;
+struct F3DOptions;
+
+class vtkF3DInteractorStyle3D : public vtkInteractorStyleTrackballCamera
+{
+public:
+  static vtkF3DInteractorStyle3D* New();
+  vtkTypeMacro(vtkF3DInteractorStyle3D, vtkInteractorStyleTrackballCamera);
+
+  /**
+   * Handle key presses
+   */
+  void OnKeyPress() override;
+
+  /**
+   * Disable base class features
+   */
+  void OnChar() override {}
+
+  /**
+   * Disable base class features
+   */
+  void OnTimer() override {}
+
+  /**
+   * Handle drop files
+   */
+  void OnDropFiles(vtkStringArray* files) override;
+
+  /**
+   * Overriden for turntable mode
+   */
+  void Rotate() override;
+
+  //@{
+  /**
+   * Overriden to disable during animation
+   */
+  void Spin() override;
+  void Pan() override;
+  void Dolly() override;
+  //@}
+
+  /**
+   * Overriden to rotate the skybox as well
+   */
+  void EnvironmentRotate() override;
+
+  /**
+   * Set animation manager
+   */
+  void SetAnimationManager(const F3DAnimationManager& mgr) { this->AnimationManager = &mgr; };
+
+  /**
+   * Set options
+   */
+  void SetOptions(const F3DOptions& options) { this->Options = &options; };
+
+protected:
+  /**
+   * Overriden to disable during animation
+   */
+  void Dolly(double factor) override;
+
+  virtual bool IsUserInteractionBlocked();
+
+  const F3DAnimationManager* AnimationManager = nullptr;
+  const F3DOptions* Options = nullptr;
+};
+
+#endif

--- a/src/vtkF3DInteractorStyle3D.h
+++ b/src/vtkF3DInteractorStyle3D.h
@@ -8,6 +8,7 @@
 
 #include <vtkInteractorStyleTrackballCamera.h>
 
+class vtkF3DInteractionHandler;
 class F3DAnimationManager;
 struct F3DOptions;
 
@@ -59,12 +60,17 @@ public:
   /**
    * Set animation manager
    */
-  void SetAnimationManager(const F3DAnimationManager& mgr) { this->AnimationManager = &mgr; };
+  void SetAnimationManager(const F3DAnimationManager& mgr) { this->AnimationManager = &mgr; }
+
+  /**
+   * Set interaction handler
+   */
+  void SetInteractionHandler(vtkF3DInteractionHandler* handler) { this->InteractionHandler = handler; }
 
   /**
    * Set options
    */
-  void SetOptions(const F3DOptions& options) { this->Options = &options; };
+  void SetOptions(const F3DOptions& options) { this->Options = &options; }
 
 protected:
   /**
@@ -76,6 +82,7 @@ protected:
 
   const F3DAnimationManager* AnimationManager = nullptr;
   const F3DOptions* Options = nullptr;
+  vtkF3DInteractionHandler* InteractionHandler = nullptr;
 };
 
 #endif

--- a/src/vtkF3DMetaReader.cxx
+++ b/src/vtkF3DMetaReader.cxx
@@ -97,10 +97,10 @@ void vtkF3DMetaReader::SetFileName(const std::string& fileName)
     return;
   }
 
-  F3DReader* reader = F3DReaderFactory::GetReader(fileName);
-  if (reader)
+  this->Reader = F3DReaderFactory::GetReader(fileName);
+  if (this->Reader)
   {
-    this->InternalReader = reader->CreateGeometryReader(fileName);
+    this->InternalReader = this->Reader->CreateGeometryReader(fileName);
   }
 
   if (this->InternalReader)

--- a/src/vtkF3DMetaReader.h
+++ b/src/vtkF3DMetaReader.h
@@ -10,6 +10,8 @@
 #include <vtkDataObjectAlgorithm.h>
 #include <vtkSmartPointer.h>
 
+class F3DReader;
+
 class vtkF3DMetaReader : public vtkDataObjectAlgorithm
 {
 public:
@@ -40,6 +42,11 @@ public:
    */
   vtkInformation* GetOutputInformation(int port);
 
+  /**
+   * Get the F3D reader (set once filename has been provided).
+   */
+  F3DReader* GetReader() { return this->Reader; }
+
 protected:
   vtkF3DMetaReader();
   ~vtkF3DMetaReader() override;
@@ -59,6 +66,7 @@ private:
   void operator=(const vtkF3DMetaReader&) = delete;
 
   vtkSmartPointer<vtkAlgorithm> InternalReader;
+  F3DReader* Reader = nullptr;
   char* FileName = nullptr;
 };
 

--- a/src/vtkF3DRendererWithColoring.cxx
+++ b/src/vtkF3DRendererWithColoring.cxx
@@ -320,7 +320,7 @@ void vtkF3DRendererWithColoring::FillCheatSheetHotkeys(std::stringstream& cheatS
                                                   this->ArrayForColoring->GetName(), 19)
                                               : "OFF")
                    << "]\n";
-    cheatSheetText << " Y: Coloring compponent ["
+    cheatSheetText << " Y: Coloring component ["
                    << vtkF3DRendererWithColoring::ComponentToString(this->ComponentForColoring)
                    << "]\n";
     cheatSheetText << " B: Scalar bar " << (this->ScalarBarVisible ? "[ON]" : "[OFF]") << "\n";


### PR DESCRIPTION
Fixes #49 

- [x] Add 2D interactor
- [x] Allow to switch between 2D and 3D interactors with `2` and `3` keys
- [x] Set the 2D interactor automatically for 2D data
- [x] Disable lighthing for 2D image data
- [ ] Set image scalars visibility by default for 2D image data
- [ ] Tests
