### PR TITLE
FIX: fix potential Windows Explorer crash when trying to generate thumbnails for broken files

### DIFF
--- a/src/winshellext/CMakeLists.txt
+++ b/src/winshellext/CMakeLists.txt
@@ -1,4 +1,12 @@
+set(F3D_WINDOWS_THUMBNAIL_TIMEOUT 8000 CACHE STRING "Windows thumbnail creation timeout in milliseconds")
+
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/F3DThumbnailConfig.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/F3DThumbnailConfig.h"
+  @ONLY)
+
 add_library(F3DShellExtension SHARED
+  "${CMAKE_CURRENT_BINARY_DIR}/F3DThumbnailConfig.h"
   F3DShellExtension.cxx
   F3DShellExtensionClassFactory.h
   F3DThumbnailProvider.h
@@ -8,9 +16,9 @@ add_library(F3DShellExtension SHARED
 
 target_compile_definitions(F3DShellExtension PUBLIC UNICODE)
 
-target_include_directories(F3DShellExtension PUBLIC ${CMAKE_BINARY_DIR})
+target_include_directories(F3DShellExtension PUBLIC ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(F3DShellExtension PUBLIC libf3d PRIVATE pathcch shlwapi)
+target_link_libraries(F3DShellExtension PUBLIC libf3d PRIVATE pathcch shlwapi windowscodecs)
 
 set_target_properties(F3DShellExtension PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")

--- a/src/winshellext/F3DThumbnailConfig.h.in
+++ b/src/winshellext/F3DThumbnailConfig.h.in
@@ -1,0 +1,6 @@
+#ifndef F3DThumbnailConfig_h
+#define F3DThumbnailConfig_h
+
+#cmakedefine F3D_WINDOWS_THUMBNAIL_TIMEOUT @F3D_WINDOWS_THUMBNAIL_TIMEOUT@
+
+#endif

--- a/src/winshellext/F3DThumbnailProvider.h
+++ b/src/winshellext/F3DThumbnailProvider.h
@@ -42,5 +42,6 @@ protected:
 
 private:
   long m_cRef;
+  wchar_t m_f3dPath[MAX_PATH];  // The path to f3d executable that will be used to produce the thumbnail
   wchar_t m_filePath[MAX_PATH]; // The path to the file for which we will have to produce the thumbnail
 };


### PR DESCRIPTION
Instead of using f3d as a library and thumbnail image fetched in a buffer,
the F3D executable is ran in a separate process so if it crashes it does
not crash Explorer.
Note that this way of processing is way slower as:
 - a new process must created, and the VTK libraries must be loaded
   for each file/thumbnail;
 - the thumbnail image is created into a temporary PNG file by F3D,
   then the file is read back by the handler in order to pass the
   image buffer to the Explorer thumbnail manager;
 - the temporary file is deleted.