### PR TITLE
Improve --quiet option to rely on OutputWindow

### DIFF
--- a/src/F3DLoader.cxx
+++ b/src/F3DLoader.cxx
@@ -16,6 +16,7 @@
 #include <vtkCamera.h>
 #include <vtkDoubleArray.h>
 #include <vtkImageData.h>
+#include <vtkLogger.h>
 #include <vtkNew.h>
 #include <vtkPointGaussianMapper.h>
 #include <vtkPolyDataMapper.h>
@@ -41,6 +42,10 @@ typedef struct ProgressDataStruct {
 //----------------------------------------------------------------------------
 F3DLoader::F3DLoader()
 {
+  // Disable vtkLogger in case VTK was built with log support
+  vtkLogger::SetStderrVerbosity(vtkLogger::VERBOSITY_OFF);
+  vtkLogger::SetInternalVerbosityLevel(vtkLogger::VERBOSITY_OFF);
+
   // instanciate our own polydata mapper and output windows
   vtkNew<vtkF3DObjectFactory> factory;
   vtkObjectFactory::RegisterFactory(factory);

--- a/src/F3DLog.cxx
+++ b/src/F3DLog.cxx
@@ -3,16 +3,9 @@
 #include "Config.h"
 #include "vtkF3DConsoleOutputWindow.h"
 
-bool F3DLog::Quiet = false;
-
 //----------------------------------------------------------------------------
 void F3DLog::PrintInternal(Severity sev, const std::string& str)
 {
-  if (F3DLog::Quiet)
-  {
-    return;
-  }
-
   vtkOutputWindow* win = vtkOutputWindow::GetInstance();
   switch (sev)
   {
@@ -43,5 +36,6 @@ void F3DLog::SetUseColoring(bool use)
 //----------------------------------------------------------------------------
 void F3DLog::SetQuiet(bool quiet)
 {
-  F3DLog::Quiet = quiet;
+  vtkOutputWindow* win = vtkOutputWindow::GetInstance();
+  win->SetDisplayMode(quiet ? vtkOutputWindow::NEVER : vtkOutputWindow::ALWAYS);
 }


### PR DESCRIPTION
* Improve --quiet option so that even vtk warnings and errors are impacted.
* Disable vtkLogger completely