### PR TITLE
Fix useless whatis entry in man page.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -262,7 +262,7 @@ if(F3D_GENERATE_MAN)
     set(MAN_OUTPUT_FILE ${CMAKE_BINARY_DIR}/f3d.1)
     add_custom_command(
       OUTPUT ${MAN_OUTPUT_FILE}
-      COMMAND ${HELP2MAN} $<TARGET_FILE:f3d> -N > ${MAN_OUTPUT_FILE}
+      COMMAND ${HELP2MAN} $<TARGET_FILE:f3d> -N -n "F3D - Fast and minimalist 3D viewer" > ${MAN_OUTPUT_FILE}
       COMMAND ${GZIP} -f ${MAN_OUTPUT_FILE}
       DEPENDS f3d)
     add_custom_target(man ALL DEPENDS ${MAN_OUTPUT_FILE})


### PR DESCRIPTION
Help2Man generates a useless whatis entry in the man page: `f3d - manual page for f3d 1.2.0`

This merge request adds the `-n` option in order to to provide a more meaningful description: `F3D - Fast and minimalist 3D viewer`

More information here:
https://lintian.debian.org/tags/useless-whatis-entry
