### PR TITLE
Added DEB to cPack generator

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -74,7 +74,7 @@ if(WIN32 AND NOT UNIX)
 
 else()
   if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set(CPACK_GENERATOR TGZ TXZ)
+    set(CPACK_GENERATOR TGZ TXZ DEB)
   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(CPACK_GENERATOR DragNDrop)
     set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/resources/logo.icns")

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -74,6 +74,7 @@ if(WIN32 AND NOT UNIX)
 
 else()
   if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(CPACK_PACKAGE_CONTACT "Whisley <whisley.santos@gmail.com>")
     set(CPACK_GENERATOR TGZ TXZ DEB)
   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(CPACK_GENERATOR DragNDrop)


### PR DESCRIPTION
DEB was added to cmake. That should generate a working DEB package to be installed in any DEB system like Debian, Mint, Ubuntu, etc.