### PR TITLE
Fix reproducible build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(f3d
   DESCRIPTION "F3D - A fast and minimalist 3D viewer"
   LANGUAGES C CXX)
 
-string(TIMESTAMP F3D_BUILD_DATE "%Y-%m-%d %H:%M:%S")
+string(TIMESTAMP F3D_BUILD_DATE "%Y-%m-%d %H:%M:%S" UTC)
 
 # CMake variables
 option(BUILD_TESTING "Build the tests" OFF)

--- a/src/library/Config.cxx.in
+++ b/src/library/Config.cxx.in
@@ -5,7 +5,7 @@ namespace f3d
   const std::string AppName = "@PROJECT_NAME@";
   const std::string AppTitle = "@PROJECT_DESCRIPTION@";
   const std::string AppVersion = "@PROJECT_VERSION@";
-  const std::string AppBuildSystem = "@CMAKE_SYSTEM@ @CMAKE_SYSTEM_PROCESSOR@";
+  const std::string AppBuildSystem = "@CMAKE_SYSTEM_NAME@ @CMAKE_SYSTEM_PROCESSOR@";
   const std::string AppBuildDate = "@F3D_BUILD_DATE@";
   const std::string AppCompiler = "@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
   const std::string F3DReservedString = "f3d_reserved";


### PR DESCRIPTION
This pull request fixes reproducible build issues, see [reproducible build website](https://reproducible-builds.org/) for the motivations.

 - Recorded timestamp through CMake should not depend on time zone (more info [here](https://reproducible-builds.org/docs/source-date-epoch/))
 - Platform version (for example kernel version on Linux platform) usually does not affect the generated binaries and should not be recorded (more info [here](https://reproducible-builds.org/docs/recording/))

The issues were detected by the Debian reprotest tool. You can look at [diffoscope_result.zip](https://github.com/f3d-app/f3d/files/7834236/diffoscope_result.zip) for the diff between two build environments that should produce the same binaries.

