### PR TITLE
Fix shell completion

### DIFF
--- a/resources/completion.fish
+++ b/resources/completion.fish
@@ -1,3 +1,3 @@
-set -l compl_cmds (f3d --help 2>&1 | grep "\-\-" | sed 's/-\(.\),/-s \1/g' | sed 's/=.*>//g' | sed 's/--\([^ ]*\) *\(.*\)/-l \1 -d \'\2\'/g' | sed 's/^ */complete -c f3d /')
+set -l compl_cmds (f3d --help 2>&1 | sed '1,/Examples/!d' | grep "\-\-" | sed 's/-\(.\),/-s \1/g' | sed 's/=.*>//g' | sed 's/--\([^ ]*\) *\(.*\)/-l \1 -d \'\2\'/g' | sed 's/^ */complete -c f3d /')
 
 for current_cmd in $compl_cmds; eval $current_cmd; end

--- a/resources/completion.zsh
+++ b/resources/completion.zsh
@@ -5,7 +5,7 @@ local shortopts
 local arguments
 local f3dhelp
 
-f3dhelp=$(f3d --help 2>&1)
+f3dhelp=$(f3d --help 2>&1 | sed '1,/Examples/!d')
 
 shortopts=$(echo $f3dhelp | grep "\-.," | sed "s/^ *\(-.\), *--[^ ]* *\(.*\)$/\1[\2]/")
 longopts=$(echo $f3dhelp | grep "\-\-" | sed 's/=.*>//g' | sed 's/-.,//g' | sed "s/^ *\([^ ]*\) *\(.*\)$/\1[\2]/g")


### PR DESCRIPTION
Since we have added the examples section in the help, it makes shell completion script failing.  
Just remove the examples from the help parsing.