### PR TITLE
Renderer rework

### DIFF
--- a/src/library/F3DOptions.cxx
+++ b/src/library/F3DOptions.cxx
@@ -764,17 +764,15 @@ void F3DOptionsParser::ConvertToNewAPI(const F3DOptions& oldOptions, f3d::option
 
   // Loading but should not
   newOptions->set("cells", oldOptions.Cells);
-  newOptions->set("scalars", oldOptions.Scalars);
   newOptions->set("component", oldOptions.Component);
   newOptions->set("fullscreen", oldOptions.FullScreen);
   newOptions->set("resolution", oldOptions.Resolution);
-  newOptions->set("hdri", oldOptions.HDRIFile);
-  newOptions->set("background-color", oldOptions.BackgroundColor);
+  newOptions->set("scalars", oldOptions.Scalars);
   newOptions->set("up", oldOptions.Up);
-  newOptions->set("font-file", oldOptions.FontFile);
 
   // Rendering/Dynamic
   newOptions->set("axis", oldOptions.Axis);
+  newOptions->set("background-color", oldOptions.BackgroundColor);
   newOptions->set("bar", oldOptions.Bar);
   newOptions->set("blur-background", oldOptions.BlurBackground);
   newOptions->set("camera-azimuth-angle", oldOptions.CameraAzimuthAngle);
@@ -788,9 +786,11 @@ void F3DOptionsParser::ConvertToNewAPI(const F3DOptions& oldOptions, f3d::option
   newOptions->set("depth-peeling", oldOptions.DepthPeeling);
   newOptions->set("edges", oldOptions.Edges);
   newOptions->set("filename", oldOptions.Filename);
+  newOptions->set("font-file", oldOptions.FontFile);
   newOptions->set("fps", oldOptions.FPS);
   newOptions->set("fxaa", oldOptions.FXAA);
   newOptions->set("grid", oldOptions.Grid);
+  newOptions->set("hdri", oldOptions.HDRIFile);
   newOptions->set("inverse", oldOptions.InverseOpacityFunction);
   newOptions->set("metadata", oldOptions.MetaData);
   newOptions->set("point-sprites", oldOptions.PointSprites);

--- a/src/library/vtkF3DRenderer.h
+++ b/src/library/vtkF3DRenderer.h
@@ -15,10 +15,6 @@
 #include <vtkOrientationMarkerWidget.h>
 #include <vtkSkybox.h>
 
-namespace f3d
-{
-class options;
-}
 class vtkCornerAnnotation;
 class vtkTextActor;
 
@@ -50,7 +46,16 @@ public:
 
   //@{
   /**
-   * Set/Get usages of different render passes
+   * Set different actors parameters
+   */
+  void SetFontFile(const std::string& fontFile);
+  void SetHDRIFile(const std::string& hdriFile);
+  void SetBackground(const double* backgroundColor) override;
+  //@}
+
+  //@{
+  /**
+   * Set/Get usages and configurations of different render passes
    */
   void SetUseRaytracing(bool use);
   void SetUseRaytracingDenoiser(bool use);
@@ -60,6 +65,7 @@ public:
   void SetUseToneMappingPass(bool use);
   void SetUseBlurBackground(bool use);
   void SetUseTrackball(bool use);
+  void SetRaytracingSamples(int samples);
   bool UsingRaytracing();
   bool UsingRaytracingDenoiser();
   bool UsingDepthPeelingPass();
@@ -76,23 +82,10 @@ public:
   void Render() override;
 
   /**
-   * Update internal options using provided options
-   */
-  virtual void UpdateOptions(const f3d::options& options);
-
-  /**
-   * Initialize the renderer to be used with provided options and file.
+   * Initialize the renderer actors and flags.
    * Should be called after being added to a vtkRenderWindow.
    */
-  virtual void Initialize(const f3d::options& options, const std::string& fileInfo);
-
-  //@{
-  /**
-   * Set/Get the axis widget
-   */
-  vtkGetSmartPointerMacro(AxisWidget, vtkOrientationMarkerWidget);
-  vtkSetSmartPointerMacro(AxisWidget, vtkOrientationMarkerWidget);
-  //@}
+  virtual void Initialize(const std::string& fileInfo, const std::string& up);
 
   /**
    * Get the OpenGL skybox
@@ -100,21 +93,13 @@ public:
   vtkGetObjectMacro(Skybox, vtkSkybox);
 
   /**
-   * Set the visibility of the different actors
-   * as they were set by the options during the initialization.
-   * Also call UpdateInternalActors
-   */
-  void ShowOptions();
-
-  /**
    * Setup the different render passes
-   * as they were set by the options during the initialization.
    */
   void SetupRenderPasses();
 
   /**
    * Initialize the camera position, focal point,
-   * view up and view angle according to the options if any
+   * view up and view angle.
    */
   void InitializeCamera();
 
@@ -134,27 +119,15 @@ public:
    */
   virtual std::string GetRenderingDescription();
 
-  //@{
   /**
-   * Set/Get up vector
+   * Get up vector
    */
   vtkGetVector3Macro(UpVector, double);
-  vtkSetVector3Macro(UpVector, double);
-  //@}
 
-  //@{
   /**
    * Set/Get right vector
    */
   vtkGetVector3Macro(RightVector, double);
-  vtkSetVector3Macro(RightVector, double);
-  //@}
-
-  /**
-   * Override to update internal actors that display data
-   * in a specific way
-   */
-  virtual void UpdateInternalActors(){};
 
 protected:
   vtkF3DRenderer();
@@ -198,7 +171,7 @@ protected:
 
   bool GridVisible = false;
   bool AxisVisible = false;
-  bool EdgesVisible = false;
+  bool EdgeVisible = false;
   bool TimerVisible = false;
   bool FilenameVisible = false;
   bool MetaDataVisible = false;
@@ -217,7 +190,10 @@ protected:
   double UpVector[3] = { 0.0, 1.0, 0.0 };
   double RightVector[3] = { 1.0, 0.0, 0.0 };
 
+  bool HasHDRI = false;
   std::string HDRIFile;
+  std::string FontFile;
+
   std::string GridInfo;
 };
 

--- a/src/library/vtkF3DRendererWithColoring.cxx
+++ b/src/library/vtkF3DRendererWithColoring.cxx
@@ -166,7 +166,7 @@ bool vtkF3DRendererWithColoring::UsingInverseOpacityFunction()
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRendererWithColoring::SetScalarBarRange(std::vector<double> range, bool update)
+void vtkF3DRendererWithColoring::SetScalarBarRange(const std::vector<double>& range, bool update)
 {
   if (this->UserScalarBarRange != range)
   {
@@ -179,7 +179,7 @@ void vtkF3DRendererWithColoring::SetScalarBarRange(std::vector<double> range, bo
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRendererWithColoring::SetColormap(std::vector<double> colormap, bool update)
+void vtkF3DRendererWithColoring::SetColormap(const std::vector<double>& colormap, bool update)
 {
   if (this->Colormap != colormap)
   {

--- a/src/library/vtkF3DRendererWithColoring.cxx
+++ b/src/library/vtkF3DRendererWithColoring.cxx
@@ -1,7 +1,6 @@
 #include "vtkF3DRendererWithColoring.h"
 
 #include "F3DLog.h"
-#include "f3d_options.h"
 
 #include <vtkColorTransferFunction.h>
 #include <vtkDataSetAttributes.h>
@@ -16,10 +15,9 @@
 vtkStandardNewMacro(vtkF3DRendererWithColoring);
 
 //----------------------------------------------------------------------------
-void vtkF3DRendererWithColoring::Initialize(
-  const f3d::options& options, const std::string& fileInfo)
+void vtkF3DRendererWithColoring::Initialize(const std::string& fileInfo, const std::string& up)
 {
-  this->Superclass::Initialize(options, fileInfo);
+  this->Superclass::Initialize(fileInfo, up);
 
   this->SetScalarBarActor(nullptr);
   this->SetGeometryActor(nullptr);
@@ -28,14 +26,6 @@ void vtkF3DRendererWithColoring::Initialize(
   this->SetPolyDataMapper(nullptr);
   this->SetPointGaussianMapper(nullptr);
   this->SetVolumeMapper(nullptr);
-
-  options.get("point-sprites", this->UsePointSprites);
-  options.get("volume", this->UseVolume);
-  options.get("inverse", this->UseInverseOpacityFunction);
-  options.get("bar", this->ScalarBarVisible);
-
-  options.get("range", this->SpecifiedRange);
-  options.get("colormap", this->Colormap);
 
   this->PointDataForColoring = nullptr;
   this->CellDataForColoring = nullptr;
@@ -102,12 +92,17 @@ std::string vtkF3DRendererWithColoring::GenerateMetaDataDescription()
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRendererWithColoring::SetUsePointSprites(bool use)
+void vtkF3DRendererWithColoring::SetUsePointSprites(bool use, bool update)
 {
-  this->UsePointSprites = use;
-  this->UpdateInternalActors();
-  this->SetupRenderPasses();
-  this->CheatSheetNeedUpdate = true;
+  if (this->UsePointSprites != use)
+  {
+    this->UsePointSprites = use;
+    this->CheatSheetNeedUpdate = true;
+    if (update)
+    {
+      this->UpdateColoringActors();
+    }
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -117,12 +112,17 @@ bool vtkF3DRendererWithColoring::UsingPointSprites()
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRendererWithColoring::SetUseVolume(bool use)
+void vtkF3DRendererWithColoring::SetUseVolume(bool use, bool update)
 {
-  this->UseVolume = use;
-  this->UpdateInternalActors();
-  this->SetupRenderPasses();
-  this->CheatSheetNeedUpdate = true;
+  if (this->UseVolume != use)
+  {
+    this->UseVolume = use;
+    this->CheatSheetNeedUpdate = true;
+    if (update)
+    {
+      this->UpdateColoringActors();
+    }
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -132,30 +132,63 @@ bool vtkF3DRendererWithColoring::UsingVolume()
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRendererWithColoring::SetUseInverseOpacityFunction(bool use)
+void vtkF3DRendererWithColoring::SetUseInverseOpacityFunction(bool use, bool update)
 {
-  this->UseInverseOpacityFunction = use;
-  if (this->VolumeProp)
+  if (this->UseInverseOpacityFunction != use)
   {
-    vtkPiecewiseFunction* pwf = this->VolumeProp->GetProperty()->GetScalarOpacity();
-    if (pwf->GetSize() == 2)
+    this->UseInverseOpacityFunction = use;
+    if (this->VolumeProp)
     {
-      double range[2];
-      pwf->GetRange(range);
+      vtkPiecewiseFunction* pwf = this->VolumeProp->GetProperty()->GetScalarOpacity();
+      if (pwf->GetSize() == 2)
+      {
+        double range[2];
+        pwf->GetRange(range);
 
-      pwf->RemoveAllPoints();
-      pwf->AddPoint(range[0], this->UseInverseOpacityFunction ? 1.0 : 0.0);
-      pwf->AddPoint(range[1], this->UseInverseOpacityFunction ? 0.0 : 1.0);
+        pwf->RemoveAllPoints();
+        pwf->AddPoint(range[0], this->UseInverseOpacityFunction ? 1.0 : 0.0);
+        pwf->AddPoint(range[1], this->UseInverseOpacityFunction ? 0.0 : 1.0);
+      }
+      this->CheatSheetNeedUpdate = true;
+      if (update)
+      {
+        this->SetupRenderPasses();
+      }
     }
-    this->SetupRenderPasses();
+    this->CheatSheetNeedUpdate = true;
   }
-  this->CheatSheetNeedUpdate = true;
 }
 
 //----------------------------------------------------------------------------
 bool vtkF3DRendererWithColoring::UsingInverseOpacityFunction()
 {
   return this->UseInverseOpacityFunction;
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DRendererWithColoring::SetScalarBarRange(std::vector<double> range, bool update)
+{
+  if (this->UserScalarBarRange != range)
+  {
+    this->UserScalarBarRange = range;
+    if (update)
+    {
+      this->UpdateColoringActors();
+    }
+  }
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DRendererWithColoring::SetColormap(std::vector<double> colormap, bool update)
+{
+  if (this->Colormap != colormap)
+  {
+    this->Colormap = colormap;
+    if (update)
+    {
+      this->UpdateColoringActors();
+    }
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -298,18 +331,22 @@ void vtkF3DRendererWithColoring::CycleScalars(int cycleType)
   this->VolumeConfigured = false;
   this->ScalarBarActorConfigured = false;
 
-  this->UpdateInternalActors();
-  this->SetupRenderPasses();
+  this->UpdateColoringActors();
   this->CheatSheetNeedUpdate = true;
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRendererWithColoring::ShowScalarBar(bool show)
+void vtkF3DRendererWithColoring::ShowScalarBar(bool show, bool update)
 {
-  this->ScalarBarVisible = show;
-  this->UpdateScalarBarVisibility();
-  this->SetupRenderPasses();
-  this->CheatSheetNeedUpdate = true;
+  if (this->ScalarBarVisible != show)
+  {
+    this->ScalarBarVisible = show;
+    this->CheatSheetNeedUpdate = true;
+    if (update)
+    {
+      this->UpdateColoringActors();
+    }
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -351,7 +388,7 @@ void vtkF3DRendererWithColoring::FillCheatSheetHotkeys(std::stringstream& cheatS
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRendererWithColoring::UpdateInternalActors()
+void vtkF3DRendererWithColoring::UpdateColoringActors()
 {
   // Make sure ArrayForColoring is pointing to the right array
   if (this->DataForColoring)
@@ -447,6 +484,7 @@ void vtkF3DRendererWithColoring::UpdateInternalActors()
     this->VolumeProp->SetVisibility(volumeVisibility);
   }
   this->UpdateScalarBarVisibility();
+  this->SetupRenderPasses();
 }
 
 //----------------------------------------------------------------------------
@@ -588,14 +626,14 @@ void vtkF3DRendererWithColoring::ConfigureRangeAndCTFForColoring(vtkDataArray* a
   }
 
   // Get range
-  if (this->SpecifiedRange.size() == 2)
+  if (this->UserScalarBarRange.size() == 2)
   {
-    this->ColorRange[0] = this->SpecifiedRange[0];
-    this->ColorRange[1] = this->SpecifiedRange[1];
+    this->ColorRange[0] = this->UserScalarBarRange[0];
+    this->ColorRange[1] = this->UserScalarBarRange[1];
   }
   else
   {
-    if (this->SpecifiedRange.size() > 0)
+    if (this->UserScalarBarRange.size() > 0)
     {
       F3DLog::Print(F3DLog::Severity::Warning,
         "The range specified does not have exactly 2 values, using automatic range.");

--- a/src/library/vtkF3DRendererWithColoring.h
+++ b/src/library/vtkF3DRendererWithColoring.h
@@ -25,7 +25,10 @@ public:
   static vtkF3DRendererWithColoring* New();
   vtkTypeMacro(vtkF3DRendererWithColoring, vtkF3DRenderer);
 
-  void Initialize(const f3d::options& options, const std::string& fileInfo) override;
+  /**
+   * Initialize all actors and flags
+   */
+  void Initialize(const std::string& fileInfo, const std::string& up) override;
 
   //@{
   /**
@@ -33,7 +36,7 @@ public:
    * It will only be shown when coloring and not
    * using direct scalars rendering.
    */
-  void ShowScalarBar(bool show);
+  void ShowScalarBar(bool show, bool update = true);
   bool IsScalarBarVisible();
   //@}
 
@@ -42,7 +45,7 @@ public:
    * Set/Get the visibility of the point sprites actor.
    * It will inly be shown if raytracing and volume are not enabled
    */
-  void SetUsePointSprites(bool use);
+  void SetUsePointSprites(bool use, bool update = true);
   bool UsingPointSprites();
   //@}
 
@@ -52,7 +55,7 @@ public:
    * It will inly be shown if the data is compatible with volume rendering
    * and raytracing is not enabled
    */
-  void SetUseVolume(bool use);
+  void SetUseVolume(bool use, bool update = true);
   bool UsingVolume();
   //@}
 
@@ -62,8 +65,20 @@ public:
    * for volume rendering..
    */
   bool UsingInverseOpacityFunction();
-  void SetUseInverseOpacityFunction(bool use);
+  void SetUseInverseOpacityFunction(bool use, bool update = true);
   //@}
+
+  /**
+   * Set the range of the scalar bar
+   * Setting an empty vector will use automatic range
+   */
+  void SetScalarBarRange(std::vector<double> range, bool update = true);
+
+  /**
+   * Set the colormap to use
+   * Setting an empty vector will use defaut color map
+   */
+  void SetColormap(std::vector<double> colormap, bool update = true);
 
   enum CycleTypeEnum
   {
@@ -142,7 +157,7 @@ public:
   /**
    * Update the visibility and coloring of internal actors as well as the scalar bar actors
    */
-  void UpdateInternalActors() override;
+  void UpdateColoringActors();
 
   /**
    * Get information about the current rendering
@@ -248,7 +263,7 @@ protected:
   bool UseVolume = false;
   bool UseInverseOpacityFunction = false;
 
-  std::vector<double> SpecifiedRange;
+  std::vector<double> UserScalarBarRange;
   std::vector<double> Colormap;
 };
 

--- a/src/library/vtkF3DRendererWithColoring.h
+++ b/src/library/vtkF3DRendererWithColoring.h
@@ -72,13 +72,13 @@ public:
    * Set the range of the scalar bar
    * Setting an empty vector will use automatic range
    */
-  void SetScalarBarRange(std::vector<double> range, bool update = true);
+  void SetScalarBarRange(const std::vector<double>& range, bool update = true);
 
   /**
    * Set the colormap to use
    * Setting an empty vector will use defaut color map
    */
-  void SetColormap(std::vector<double> colormap, bool update = true);
+  void SetColormap(const std::vector<double>& colormap, bool update = true);
 
   enum CycleTypeEnum
   {


### PR DESCRIPTION
- Rework of the importer
- All vtkF3DRenderer options are controllable with a setter now
- All setters take care of updating what is needed or position flags as needed
- All setters check if the value is actually being changed
- In WithColoring, a UpdateColoringActors method still exists
- In WithColoring, setter update can be disabled, which means the UpdateColoringActors then needs to be called manually
- f3d::options is not used at all in the vtk* stack anymore
- some members have been renamed for better consistency