### PR TITLE
Remove unneeded dependency to a missing VTK module: vtkTestingRendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,11 @@ jobs:
       run: ctest -C Release -j 2 --output-on-failure || ctest -C Release -j 1 --rerun-failed -VV
 
     - name: Upload Tests Artifact
-      if: success() || failure()
+      if: failure()
       uses: actions/upload-artifact@v2
       with:
         path: ./build/Testing/Temporary
-        name: f3d-tests-artifact
+        name: f3d-tests-artifact-${{matrix.os}}-${{matrix.vtk_version}}
 
     - name: Install
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,11 @@ jobs:
       run: ctest -C Release -j 2 --output-on-failure || ctest -C Release -j 1 --rerun-failed -VV
 
    - name: Archive Test Results
-     if: always()
-     uses: actions/upload-artifact@v1
+     if: success() || failure()
+     uses: actions/upload-artifact@v2
      with:
-       name: test-results
        path: ./build/Testing/Temporary/*
+       name: test-results
 
     - name: Install
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,13 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest -C Release -j 2 --output-on-failure || ctest -C Release -j 1 --rerun-failed -VV
 
+   - name: Archive Test Results
+     if: always()
+     uses: actions/upload-artifact@v1
+     with:
+       name: test-results
+       path: ./build/Testing/Temporary/*
+
     - name: Install
       working-directory: ${{github.workspace}}/build
       run: cmake --install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,12 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest -C Release -j 2 --output-on-failure || ctest -C Release -j 1 --rerun-failed -VV
 
+    - name: Upload Tests Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        path: ./build/Testing/Temporary
+        name: f3d-tests-artifact
+
     - name: Install
       working-directory: ${{github.workspace}}/build
       run: cmake --install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,12 +130,6 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest -C Release -j 2 --output-on-failure || ctest -C Release -j 1 --rerun-failed -VV
 
-   - name: Archive Test Results
-     uses: actions/upload-artifact@v2
-     with:
-       path: ./build/Testing/Temporary/*
-       name: test-results
-
     - name: Install
       working-directory: ${{github.workspace}}/build
       run: cmake --install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
       run: ctest -C Release -j 2 --output-on-failure || ctest -C Release -j 1 --rerun-failed -VV
 
     - name: Upload Tests Artifact
+      if: success() || failure()
       uses: actions/upload-artifact@v2
       with:
         path: ./build/Testing/Temporary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,6 @@ jobs:
       run: ctest -C Release -j 2 --output-on-failure || ctest -C Release -j 1 --rerun-failed -VV
 
    - name: Archive Test Results
-     if: success() || failure()
      uses: actions/upload-artifact@v2
      with:
        path: ./build/Testing/Temporary/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ option(F3D_MODULE_ALEMBIC "Alembic module (ABC files)" OFF)
 # VTK dependency
 find_package(VTK 9.0 REQUIRED
   COMPONENTS
+    CommonCore
+    CommonDataModel
+    CommonExecutionModel
     FiltersGeneral
     FiltersGeometry
     ImagingCore

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 cmake_dependent_option(F3D_MACOS_BUNDLE "Build a macOS bundle application" ON "APPLE" OFF)
 cmake_dependent_option(F3D_WINDOWS_GUI "Build a non-console Win32 application" ON "WIN32" OFF)
 

--- a/src/library/VTKExtensions/Rendering/Testing/TestF3DRenderer.cxx
+++ b/src/library/VTKExtensions/Rendering/Testing/TestF3DRenderer.cxx
@@ -3,7 +3,6 @@
 #include <vtkNew.h>
 #include <vtkPolyData.h>
 #include <vtkPolyDataMapper.h>
-#include <vtkRegressionTestImage.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkXMLPolyDataReader.h>

--- a/src/library/VTKExtensions/Rendering/vtk.module
+++ b/src/library/VTKExtensions/Rendering/vtk.module
@@ -16,7 +16,6 @@ OPTIONAL_DEPENDS
   VTK::RenderingRayTracing
 TEST_DEPENDS
   VTK::TestingCore
-  VTK::TestingRendering
   VTK::IOXML
   VTK::InteractionWidgets
   f3d::VTKExtensionsCore


### PR DESCRIPTION
vtkTestingRendering was incorrectly required by Rendering module for testing, actually disabling tests for this module in the CI.