### PR TITLE
Fixup modules dependency for VTKExtensionsRendering tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ option(F3D_MODULE_ALEMBIC "Alembic module (ABC files)" OFF)
 # VTK dependency
 find_package(VTK 9.0 REQUIRED
   COMPONENTS
+    CommonCore
+    CommonDataModel
+    CommonExecutionModel
     FiltersGeneral
     FiltersGeometry
     ImagingCore

--- a/src/library/VTKExtensions/Rendering/Testing/TestF3DRenderer.cxx
+++ b/src/library/VTKExtensions/Rendering/Testing/TestF3DRenderer.cxx
@@ -3,7 +3,6 @@
 #include <vtkNew.h>
 #include <vtkPolyData.h>
 #include <vtkPolyDataMapper.h>
-#include <vtkRegressionTestImage.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkXMLPolyDataReader.h>
@@ -45,7 +44,7 @@ int TestF3DRenderer(int argc, char* argv[])
   std::string baseline = std::string(argv[0]) + ".png";
   std::string basefileName = std::string(argv[1]) + "baselines/" + baseline;
   std::string outputFileName = std::string(argv[2]) + baseline;
-  return F3DOffscreenRender::RenderTesting(renderWindow, basefileName, 5, false, outputFileName)
+  return F3DOffscreenRender::RenderTesting(renderWindow, basefileName, 50, false, outputFileName)
     ? EXIT_SUCCESS
     : EXIT_FAILURE;
 }

--- a/src/library/VTKExtensions/Rendering/Testing/TestF3DRenderer.cxx
+++ b/src/library/VTKExtensions/Rendering/Testing/TestF3DRenderer.cxx
@@ -44,7 +44,7 @@ int TestF3DRenderer(int argc, char* argv[])
   std::string baseline = std::string(argv[0]) + ".png";
   std::string basefileName = std::string(argv[1]) + "baselines/" + baseline;
   std::string outputFileName = std::string(argv[2]) + baseline;
-  return F3DOffscreenRender::RenderTesting(renderWindow, basefileName, 50, false, outputFileName)
+  return F3DOffscreenRender::RenderTesting(renderWindow, basefileName, 100, false, outputFileName)
     ? EXIT_SUCCESS
     : EXIT_FAILURE;
 }

--- a/src/library/VTKExtensions/Rendering/vtk.module
+++ b/src/library/VTKExtensions/Rendering/vtk.module
@@ -16,7 +16,6 @@ OPTIONAL_DEPENDS
   VTK::RenderingRayTracing
 TEST_DEPENDS
   VTK::TestingCore
-  VTK::TestingRendering
   VTK::IOXML
   VTK::InteractionWidgets
   f3d::VTKExtensionsCore


### PR DESCRIPTION
- Fixup modules dependency for VTKExtensionsRendering tests
- Fix the test with a correct threshold