### PR TITLE
Strict build rework

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,15 @@ cmake_dependent_option(F3D_WINDOWS_GUI "Build a non-console Win32 application" O
 # Force static library when creating a macOS bundle
 cmake_dependent_option(BUILD_SHARED_LIBS "Build f3d with shared libraries" ON "NOT F3D_MACOS_BUNDLE" OFF)
 
+# F3D_STRICT_BUILD
 set(F3D_STRICT_BUILD OFF CACHE BOOL "Use strict warnings and errors flags for building F3D")
 mark_as_advanced(F3D_STRICT_BUILD)
+if(MSVC)
+  # Warning C4275 is essentially noise, disabling it to silent an issue with jsoncpp library
+  set(f3d_strict_build_compile_options /W4 /WX /wd4275)
+else()
+  set(f3d_strict_build_compile_options -Wall -Wextra -Wshadow -Woverloaded-virtual -Wno-deprecated -Wno-strict-overflow -Wno-array-bounds -Wunreachable-code -Wsuggest-override -Wno-missing-field-initializers -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -Wpointer-arith -Werror)
+endif()
 
 # libf3d target
 add_subdirectory(library)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,10 @@ if(MSVC)
   # Warning C4275 is essentially noise, disabling it to silent an issue with jsoncpp library
   set(f3d_strict_build_compile_options /W4 /WX /wd4275)
 else()
-  set(f3d_strict_build_compile_options -Wall -Wextra -Wshadow -Woverloaded-virtual -Wno-deprecated -Wno-strict-overflow -Wno-array-bounds -Wunreachable-code -Wsuggest-override -Wno-missing-field-initializers -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -Wpointer-arith -Werror)
+  set(f3d_strict_build_compile_options -Wall -Wextra -Wshadow -Woverloaded-virtual -Wno-deprecated -Wno-strict-overflow -Wno-array-bounds -Wunreachable-code -Wno-missing-field-initializers -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -Wpointer-arith -Werror)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    list(APPEND f3d_strict_build_compile_options -Wsuggest-override)
+  endif()
 endif()
 
 # libf3d target

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -43,12 +43,11 @@ target_include_directories(f3d
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   )
 
+# F3D_STRICT_BUILD
 if(F3D_STRICT_BUILD)
+  list(APPEND libf3d_compile_options_private ${f3d_strict_build_compile_options})
   if(MSVC)
-    target_compile_options(f3d PRIVATE /W4 /WX)
     target_compile_definitions(f3d PRIVATE _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS _CRT_SECURE_NO_WARNINGS)
-  else()
-    target_compile_options(f3d PRIVATE -Wall -Wextra -Wshadow -Werror)
   endif()
 endif()
 

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -77,13 +77,9 @@ set(libf3d_compile_options_public)
 set(libf3d_compile_options_private)
 set(libf3d_link_options_public)
 
+# F3D_STRICT_BUILD
 if(F3D_STRICT_BUILD)
-  if(MSVC)
-    # Warning C4275 is essentially noise, disabling it to silent an issue with jsoncpp library
-    list(APPEND libf3d_compile_options_private /W4 /WX /wd4275)
-  else()
-    list(APPEND libf3d_compile_options_private -Wall -Wextra -Wshadow -Werror)
-  endif()
+  list(APPEND libf3d_compile_options_private ${f3d_strict_build_compile_options})
 endif()
 
 # coverage

--- a/src/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.h
+++ b/src/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.h
@@ -41,6 +41,7 @@ public:
   vtkGetMacro(UpIndex, int);
   //@}
 
+  using vtkOpenGLPolyDataMapper::GetBounds;
   double* GetBounds() override;
 
 protected:

--- a/src/library/VTKExtensions/Rendering/vtkF3DRenderer.h
+++ b/src/library/VTKExtensions/Rendering/vtkF3DRenderer.h
@@ -44,6 +44,7 @@ public:
   bool IsCheatSheetVisible();
   //@}
 
+  using vtkOpenGLRenderer::SetBackground;
   //@{
   /**
    * Set different actors parameters
@@ -103,6 +104,7 @@ public:
    */
   void InitializeCamera();
 
+  using vtkOpenGLRenderer::ResetCamera;
   /**
    * Reset the camera to its initial parameters
    */

--- a/src/library/f3d_engine.cxx
+++ b/src/library/f3d_engine.cxx
@@ -83,7 +83,7 @@ window& engine::getWindow()
   if (!this->Internals->Window ||
     dynamic_cast<window_impl_noRender*>(this->Internals->Window.get()))
   {
-    throw window_exception();
+    throw f3d::engine::exception("Cannot create window with this engine");
   }
   return *this->Internals->Window;
 }
@@ -99,7 +99,7 @@ interactor& engine::getInteractor()
 {
   if (!this->Internals->Interactor)
   {
-    throw interactor_exception();
+    throw f3d::engine::exception("Cannot create interactor with this engine");
   }
   return *this->Internals->Interactor;
 }

--- a/src/library/f3d_engine.h
+++ b/src/library/f3d_engine.h
@@ -22,14 +22,13 @@ class interactor;
 class F3D_EXPORT engine
 {
 public:
-
   class exception : public std::runtime_error
   {
   public:
-    exception(const std::string& what = "") 
+    exception(const std::string& what = "")
       : std::runtime_error(what)
-    {   
-    }   
+    {
+    }
   };
 
   //======== Engine Flags =============

--- a/src/library/f3d_engine.h
+++ b/src/library/f3d_engine.h
@@ -10,6 +10,7 @@
 
 #include "f3d_export.h"
 
+#include <stdexcept>
 #include <string>
 
 namespace f3d
@@ -21,13 +22,14 @@ class interactor;
 class F3D_EXPORT engine
 {
 public:
-  struct window_exception : public std::exception
+
+  class exception : public std::runtime_error
   {
-    const char* what() const throw() { return "Cannot create window with this engine"; }
-  };
-  struct interactor_exception : public std::exception
-  {
-    const char* what() const throw() { return "Cannot create interactor with this engine"; }
+  public:
+    exception(const std::string& what = "") 
+      : std::runtime_error(what)
+    {   
+    }   
   };
 
   //======== Engine Flags =============

--- a/src/library/testing/TestSDKEngineExceptions.cxx
+++ b/src/library/testing/TestSDKEngineExceptions.cxx
@@ -13,7 +13,7 @@ int TestSDKEngineExceptions(int argc, char* argv[])
   {
     f3d::window& win = eng.getWindow();
   }
-  catch (const f3d::engine::window_exception& ex)
+  catch (const f3d::engine::exception& ex)
   {
     std::cerr << ex.what() << std::endl;
   }
@@ -22,7 +22,7 @@ int TestSDKEngineExceptions(int argc, char* argv[])
   {
     f3d::interactor& inter = eng.getInteractor();
   }
-  catch (const f3d::engine::interactor_exception& ex)
+  catch (const f3d::engine::exception& ex)
   {
     std::cerr << ex.what() << std::endl;
     exit(EXIT_SUCCESS);


### PR DESCRIPTION
- Rework strict build to share it between app and lib
- Add more flags to warn on
- Fix some warnings
- use f3d::engine::exception instead of dedicated exception