### PR TITLE
WIP: Add python packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .vscode
+_skbuild
+_version.py
+dist
+*.egg-info
+__pycache__

--- a/cmake/installing.cmake
+++ b/cmake/installing.cmake
@@ -1,4 +1,14 @@
 # F3D Installation
+
+# Are we building a python wheel?
+if (DEFINED SKBUILD)
+  # If so, we only need the f3d binary and the python library
+  set_target_properties(pyf3d PROPERTIES PREFIX "_")
+  install(TARGETS pyf3d LIBRARY DESTINATION .)
+  install(TARGETS f3d RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  return() # early exit
+endif()
+
 install(TARGETS f3d
   EXPORT f3dTargets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT application

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "setuptools_scm>=6.2",
+    "scikit-build",
+    "cmake>=3.18",
+    "ninja; platform_system!='Windows'"
+]
+build-backend="setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "python/packaging/_version.py"
+fallback_version = "1.2.2"
+
+[tool.pytest.ini_options]
+python_files = "python/testing/*.py"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -12,6 +12,11 @@ set_target_properties(pyf3d PROPERTIES
   OUTPUT_NAME "f3d"
   )
 
+if (DEFINED SKBUILD)
+  # If we are building a python wheel, we import _f3d.* in __init__.py
+  target_compile_definitions(pyf3d PRIVATE F3D_PYTHONLIB_NAME=_f3d)
+endif()
+
 if(WIN32)
   # On Windows, the python module needs to be in the same folder than f3d.dll
   # Usage of PATH to find the DLL is not possible, see https://stackoverflow.com/a/64303856/2609654

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -11,7 +11,11 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(f3d, module)
+#ifndef F3D_PYTHONLIB_NAME
+#define F3D_PYTHONLIB_NAME f3d
+#endif
+
+PYBIND11_MODULE(F3D_PYTHONLIB_NAME, module)
 {
   module.doc() = "f3d library bindings";
 

--- a/python/packaging/__init__.py
+++ b/python/packaging/__init__.py
@@ -1,0 +1,3 @@
+from ._f3d import *
+from ._version import version as __version__
+from ._version import version_tuple

--- a/python/packaging/__main__.py
+++ b/python/packaging/__main__.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+from pathlib import Path
+
+F3D_BIN_PATH = Path(__file__).parent / "bin" / "f3d"
+if sys.platform == "win32":
+    F3D_BIN_PATH = F3D_BIN_PATH.with_suffix(".exe")
+
+
+def run(args):
+    return subprocess.call([F3D_BIN_PATH] + args)
+
+
+def main():
+    return SystemExit(run(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/testing/TestPythonCompareWithFile.py
+++ b/python/testing/TestPythonCompareWithFile.py
@@ -1,25 +1,37 @@
 import f3d
 import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
-dataset = sys.argv[1] + "data/cow.vtp"
-reference = sys.argv[1] + "baselines/TestPythonCompareWithFile.png"
-output = sys.argv[2] + "TestPythonCompareWithFile.png"
-outputDiff = sys.argv[2] + "TestPythonCompareWithFile.diff.png"
+TESTS_DATA_DIR = Path(__file__).parent.parent.parent / "testing"
 
-engine = f3d.engine(f3d.window.NATIVE_OFFSCREEN)
-engine.getWindow().setSize(300, 300);
-engine.getLoader().addFile(dataset)
-engine.getLoader().loadFile(f3d.loader.LoadFileEnum.LOAD_CURRENT)
+def test_compare(in_dir = TESTS_DATA_DIR, out_dir = None):
+  if out_dir is None:
+    tmp_dir = TemporaryDirectory()
+    out_dir = Path(tmp_dir.name)
+    
+  dataset = str(in_dir / "data" / "cow.vtp")
+  reference = str(in_dir / "baselines" / "TestPythonCompareWithFile.png")
+  output = str(out_dir / "TestPythonCompareWithFile.png")
+  outputDiff = str(out_dir / "TestPythonCompareWithFile.diff.png")
 
-img = engine.getWindow().renderToImage()
-img.save(output)
+  engine = f3d.engine(f3d.window.NATIVE_OFFSCREEN)
+  engine.getWindow().setSize(300, 300);
+  engine.getLoader().addFile(dataset)
+  engine.getLoader().loadFile(f3d.loader.LoadFileEnum.LOAD_CURRENT)
 
-diff = f3d.image()
-error = 0.0
+  img = engine.getWindow().renderToImage()
+  img.save(output)
 
-ret = img.compare(f3d.image(reference), 50, diff, error)
+  diff = f3d.image()
+  error = 0.0
 
-if not ret:
-  diff.save(outputDiff)
-  
-assert ret is True
+  ret = img.compare(f3d.image(reference), 50, diff, error)
+
+  if not ret:
+    diff.save(outputDiff)
+    
+  assert ret is True
+
+if __name__ == '__main__':
+  test_compare(Path(sys.argv[1]), Path(sys.argv[2]))

--- a/python/testing/TestPythonOptions.py
+++ b/python/testing/TestPythonOptions.py
@@ -1,24 +1,28 @@
 import f3d
 
-engine = f3d.engine(f3d.window.NONE)
+def test_options():
+    engine = f3d.engine(f3d.window.NONE)
 
-assert engine.getOptions().getAsBool("axis") is False
-assert engine.getOptions().getAsDouble("roughness") == 0.3
-assert engine.getOptions().getAsInt("samples") == 5
-assert engine.getOptions().getAsDoubleVector("color") == [ 1., 1., 1.]
-assert engine.getOptions().getAsString("up") == "+Y"
+    assert engine.getOptions().getAsBool("axis") is False
+    assert engine.getOptions().getAsDouble("roughness") == 0.3
+    assert engine.getOptions().getAsInt("samples") == 5
+    assert engine.getOptions().getAsDoubleVector("color") == [ 1., 1., 1.]
+    assert engine.getOptions().getAsString("up") == "+Y"
 
-options = f3d.options()
-options.set("axis", True)
-options.set("roughness", 0.7)
-options.set("samples", 2)
-options.set("color", [ 0., 1., 1.])
-options.set("up", "-Z")
+    options = f3d.options()
+    options.set("axis", True)
+    options.set("roughness", 0.7)
+    options.set("samples", 2)
+    options.set("color", [ 0., 1., 1.])
+    options.set("up", "-Z")
 
-engine.setOptions(options)
+    engine.setOptions(options)
 
-assert engine.getOptions().getAsBool("axis") is True
-assert engine.getOptions().getAsDouble("roughness") == 0.7
-assert engine.getOptions().getAsInt("samples") == 2
-assert engine.getOptions().getAsDoubleVector("color") == [ 0., 1., 1.]
-assert engine.getOptions().getAsString("up") == "-Z"
+    assert engine.getOptions().getAsBool("axis") is True
+    assert engine.getOptions().getAsDouble("roughness") == 0.7
+    assert engine.getOptions().getAsInt("samples") == 2
+    assert engine.getOptions().getAsDoubleVector("color") == [ 0., 1., 1.]
+    assert engine.getOptions().getAsString("up") == "-Z"
+
+if __name__ == '__main__':
+    test_options()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,54 @@
+import pathlib
+
+from skbuild import setup
+
+
+def exclude_static_libraries(cmake_manifest):
+    return list(filter(lambda name: not (name.endswith(".a") and not name.endswith(".lib")), cmake_manifest))
+
+here = pathlib.Path(__file__).parent.resolve()
+long_description = (here / "README.md").read_text(encoding="utf-8")
+
+setup(
+    name="f3d",
+    description="F3D, a fast and minimalist 3D viewer",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://f3d-app.github.io/f3d/",
+    project_urls={
+        "Source Code": "https://github.com/f3d-app/f3d",
+        "Bug Tracker": "https://github.com/f3d-app/f3d/issues",
+        "Documentation": "https://f3d-app.github.io/f3d/docs/",
+    },
+    author="Michael Migliore and Mathieu Westphal",
+    author_email="",  # TODO
+    license="BSD 3-Clause",
+    license_files=["LICENSE", "THIRD-PARTY-LICENSES.md"],
+    classifiers=[  # TODO
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Operating System :: MacOS",
+        "Programming Language :: C++",
+        "Programming Language :: Python :: 3",
+    ],
+    keywords="",  # TODO
+    python_requires=">=3.7",
+    packages=["f3d"],
+    package_dir={
+        "f3d": "python/packaging",
+    },
+    install_requires=[],
+    entry_points={"console_scripts": ["f3d=f3d.__main__:main"]},
+    cmake_source_dir=".",
+    cmake_install_dir="python/packaging",
+    cmake_args=[  # TODO: enable/disable modules with env variables?
+        "-DF3D_PYTHON_BINDINGS:BOOL=ON",
+        "-DBUILD_SHARED_LIBS:BOOL=OFF",
+        "-DF3D_MODULE_OCCT:BOOL=ON",
+        "-DF3D_MODULE_ASSIMP:BOOL=ON",
+        "-DF3D_MODULE_ALEMBIC:BOOL=ON",
+    ],
+    cmake_process_manifest_hook=exclude_static_libraries,
+    zip_safe=False,
+)


### PR DESCRIPTION
Initial implementation of python packaging, looking for feedback if's something you want / would accept.

Goal would be to make f3d easily installable with `pip`. The python packages generated here include both the libf3d (#52) bindings, as well as the `f3d` executable. I advocate for including the `f3d` binary in the python distribution wheel, to me `pip` the fastest & easiest way to install software (especially if I only need it for a specific project).

`pip install .` installs the python package, `pip wheel .` builds a python distribution wheel. I've updated the python test files so that `pytest` is able to run.

I'll note that because pybind11 does [not support](https://github.com/pybind/pybind11/issues/1755) the stable cpython ABI we unfortunately would have to build a `.whl`for each python minor version & OS combination.

- [x] Make `pip install .` compile & install a python package for libf3d
- [x] Add `f3d` executable as a `console_script` (using a python wrapper)
- [ ] Don't use `BUILD_SHARED_LIBS=OFF`
- [ ] Add CI to build platform independent wheels for Linux / MacOS / Windows
- [ ] Complete metadata information in `setup.py`
- [ ] Add CI job to publish on PyPi on release
- [ ] Maintainers: Register https://pypi.org/project/f3d/