### PR TITLE
Rework description logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Note that some hotkeys can be available or not depending on the file being loade
 Other hotkeys are available:
 
 * `H`: key to toggle the display of a cheat sheet showing all these hotkeys and their statuses.
-* `?`: key to dump camera state to the terminal.
+* `?`: key to print scene description to the terminal.
 * `ESC`: close the window and quit F3D.
 * `ENTER`: reset the camera to its initial parameters.
 * `SPACE`: play the animation if any.

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -204,9 +204,26 @@ void vtkF3DRenderer::SetupRenderPasses()
 }
 
 //----------------------------------------------------------------------------
-std::string vtkF3DRenderer::GetRenderingDescription()
+std::string vtkF3DRenderer::GetSceneDescription()
 {
   std::string descr;
+
+  // Camera Info
+  vtkCamera* cam = this->GetActiveCamera();
+  double position[3];
+  double focal[3];
+  double up[3];
+  cam->GetPosition(position);
+  cam->GetFocalPoint(focal);
+  cam->GetViewUp(up);
+  std::stringstream stream;
+  stream << "Camera position: " << position[0] << "," << position[1] << "," << position[2] << "\n"
+         << "Camera focal point: " << focal[0] << "," << focal[1] << "," << focal[2] << "\n"
+         << "Camera view up: " << up[0] << "," << up[1] << "," << up[2] << "\n"
+         << "Camera view angle: " << cam->GetViewAngle() << "\n\n";
+  descr += stream.str();
+
+  // Grid Info
   if (this->GridVisible)
   {
     descr += this->GridInfo;
@@ -607,7 +624,7 @@ void vtkF3DRenderer::UpdateCheatSheet()
     cheatSheetText << "\n";
     this->FillCheatSheetHotkeys(cheatSheetText);
     cheatSheetText << "\n   H  : Cheat sheet \n";
-    cheatSheetText << "   ?  : Dump camera state to the terminal\n";
+    cheatSheetText << "   ?  : Print scene descr to terminal\n";
     cheatSheetText << "  ESC : Quit \n";
     cheatSheetText << " ENTER: Reset camera to initial parameters\n";
     cheatSheetText << " SPACE: Play animation if any\n";
@@ -742,21 +759,4 @@ bool vtkF3DRenderer::IsBackgroundDark()
   double luminance =
     0.299 * this->Background[0] + 0.587 * this->Background[1] + 0.114 * this->Background[2];
   return this->HasHDRI ? true : luminance < 0.5;
-}
-
-//----------------------------------------------------------------------------
-std::string vtkF3DRenderer::GetSceneDescription()
-{
-  vtkCamera* cam = this->GetActiveCamera();
-  double position[3];
-  double focal[3];
-  double up[3];
-  cam->GetPosition(position);
-  cam->GetFocalPoint(focal);
-  cam->GetViewUp(up);
-  std::stringstream stream;
-  stream << "Camera position: " << position[0] << "," << position[1] << "," << position[2] << "\n"
-         << "Camera focal point: " << focal[0] << "," << focal[1] << "," << focal[2] << "\n"
-         << "Camera view up: " << up[0] << "," << up[1] << "," << up[2] << "\n";
-  return stream.str();
 }

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.h
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.h
@@ -103,15 +103,10 @@ public:
   void ResetCamera() override;
 
   /**
-   * Get useful scene state description. Currently contains only camera state.
+   * Return description about the current rendering status
+   * Currently contains information about the camera and the grid if any
    */
   virtual std::string GetSceneDescription();
-
-  /**
-   * Return description about the current rendering status
-   * Currently contains only information about the grid size if any
-   */
-  virtual std::string GetRenderingDescription();
 
   /**
    * Get up vector

--- a/library/VTKExtensions/Rendering/vtkF3DRendererWithColoring.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRendererWithColoring.cxx
@@ -333,10 +333,9 @@ void vtkF3DRendererWithColoring::UpdateColoringActors()
 }
 
 //----------------------------------------------------------------------------
-std::string vtkF3DRendererWithColoring::GetRenderingDescription()
+std::string vtkF3DRendererWithColoring::GetColoringDescription()
 {
   std::stringstream stream;
-  stream << this->Superclass::GetRenderingDescription();
   if (this->ArrayForColoring)
   {
     stream << "Coloring using "

--- a/library/VTKExtensions/Rendering/vtkF3DRendererWithColoring.h
+++ b/library/VTKExtensions/Rendering/vtkF3DRendererWithColoring.h
@@ -174,10 +174,9 @@ public:
   void UpdateColoringActors();
 
   /**
-   * Get information about the current rendering
-   * Use the superclass then append coloring information on it
+   * Get information about the current coloring
    */
-  std::string GetRenderingDescription() override;
+  virtual std::string GetColoringDescription();
 
 protected:
   vtkF3DRendererWithColoring() = default;

--- a/library/private/window_impl.h
+++ b/library/private/window_impl.h
@@ -10,6 +10,7 @@
 #ifndef f3d_window_impl_h
 #define f3d_window_impl_h
 
+#include "log.h"
 #include "window.h"
 
 #include <memory>
@@ -76,6 +77,16 @@ public:
    * Should be called after UpdateDynamicOptions to get correct positioning
    */
   virtual void InitializeCamera();
+
+  /**
+   * Print scene description to log using provided verbose level
+   */
+  void PrintSceneDescription(log::VerboseLevel level);
+
+  /**
+   * Print coloring description to log using provided verbose level if available
+   */
+  void PrintColoringDescription(log::VerboseLevel level);
 
   /**
    * Implementation only API.

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -87,6 +87,7 @@ public:
         if (renWithColor)
         {
           renWithColor->CycleScalars(vtkF3DRendererWithColoring::F3D_FIELD_CYCLE);
+          self->Window.PrintColoringDescription(log::VerboseLevel::DEBUG);
           checkColoring = true;
           render = true;
         }
@@ -95,6 +96,7 @@ public:
         if (renWithColor)
         {
           renWithColor->CycleScalars(vtkF3DRendererWithColoring::F3D_ARRAY_CYCLE);
+          self->Window.PrintColoringDescription(log::VerboseLevel::DEBUG);
           checkColoring = true;
           render = true;
         }
@@ -103,6 +105,7 @@ public:
         if (renWithColor)
         {
           renWithColor->CycleScalars(vtkF3DRendererWithColoring::F3D_COMPONENT_CYCLE);
+          self->Window.PrintColoringDescription(log::VerboseLevel::DEBUG);
           checkColoring = true;
           render = true;
         }
@@ -187,11 +190,9 @@ public:
         render = true;
         break;
       case '?':
-      {
-        std::string output = ren->GetSceneDescription();
-        log::info(output);
-      }
-      break;
+        self->Window.PrintColoringDescription(log::VerboseLevel::INFO);
+        self->Window.PrintSceneDescription(log::VerboseLevel::INFO);
+        break;
       default:
         if (keySym == "Left")
         {

--- a/library/src/loader_impl.cxx
+++ b/library/src/loader_impl.cxx
@@ -391,6 +391,10 @@ bool loader_impl::loadFile(loader::LoadFileEnum load)
   this->Internals->Window.UpdateDynamicOptions();
   this->Internals->Window.InitializeCamera();
 
+  // Print info about scene and coloring
+  this->Internals->Window.PrintColoringDescription(log::VerboseLevel::DEBUG);
+  this->Internals->Window.PrintSceneDescription(log::VerboseLevel::DEBUG);
+
   this->Internals->LoadedFile = true;
   return this->Internals->LoadedFile;
 }

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -33,18 +33,6 @@ public:
   {
   }
 
-  static void DisplayCameraInformation(vtkCamera* cam)
-  {
-    double* position = cam->GetPosition();
-    log::debug("Camera position is: ", position[0], ", ", position[1], ", ", position[2], ".");
-    double* focalPoint = cam->GetFocalPoint();
-    log::debug(
-      "Camera focal point is: ", focalPoint[0], ", ", focalPoint[1], ", ", focalPoint[2], ".");
-    double* viewUp = cam->GetViewUp();
-    log::debug("Camera view up is: ", viewUp[0], ", ", viewUp[1], ", ", viewUp[2], ".");
-    log::debug("Camera view angle is: ", cam->GetViewAngle(), ".\n");
-  }
-
   vtkSmartPointer<vtkRenderWindow> RenWin;
   vtkSmartPointer<vtkF3DRenderer> Renderer;
   Type WindowType;
@@ -209,9 +197,6 @@ void window_impl::UpdateDynamicOptions()
 
   // Show grid last as it needs to know the bounding box to be able to compute its size
   this->Internals->Renderer->ShowGrid(this->Internals->Options.getAsBool("grid"));
-
-  // Print rendering description when available
-  log::debug(this->Internals->Renderer->GetRenderingDescription());
 }
 
 //----------------------------------------------------------------------------
@@ -256,11 +241,26 @@ void window_impl::InitializeCamera()
     cam->Azimuth(this->Internals->Options.getAsDouble("camera-azimuth-angle"));
     cam->Elevation(this->Internals->Options.getAsDouble("camera-elevation-angle"));
     cam->OrthogonalizeViewUp();
-
-    window_impl::internals::DisplayCameraInformation(cam);
   }
 
   this->Internals->Renderer->InitializeCamera();
+}
+
+//----------------------------------------------------------------------------
+void window_impl::PrintSceneDescription(log::VerboseLevel level)
+{
+  log::print(level, this->Internals->Renderer->GetSceneDescription());
+}
+
+//----------------------------------------------------------------------------
+void window_impl::PrintColoringDescription(log::VerboseLevel level)
+{
+  vtkF3DRendererWithColoring* renWithColor =
+    vtkF3DRendererWithColoring::SafeDownCast(this->Internals->Renderer);
+  if (renWithColor)
+  {
+    log::print(level, renWithColor->GetColoringDescription());
+  }
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Previously, rendering information was outputted on each hitkey stroke. This rework the logic to output only when needed, which means:

Coloring information when changing colouring (debug)
Scene and coloring when pressing ? (Info)
Scene and coloring and loading file (debug)