### PR TITLE
Add Java bindings

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt update && apt install -y \
     ca-certificates \
     clang-10 \
     curl \
+    default-jdk \
     freeglut3 \
     freeglut3-dev \
     g++-8 \

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -62,6 +62,7 @@ jobs:
         -DCMAKE_INSTALL_PREFIX:PATH=../install
         -DF3D_STRICT_BUILD=ON
         -DF3D_MODULE_EXODUS=OFF
+        -DF3D_JAVA_BINDINGS=ON
         -DCMAKE_BUILD_TYPE=Release
         -DVTK_DIR:PATH=$(pwd)/../dependencies/vtk_build/CMakeExternals/Install/vtk-android/lib/cmake/vtk-9.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
         fetch-depth: 0
         lfs: 'false'
 
+    - name: Setup JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
     - name: Set LFS env var
       working-directory: ${{github.workspace}}/source
       shell: bash
@@ -104,6 +110,7 @@ jobs:
         -DF3D_MODULE_ASSIMP=ON
         -DF3D_MODULE_ALEMBIC=ON
         -DF3D_PYTHON_BINDINGS=ON
+        -DF3D_JAVA_BINDINGS=ON
         -DCMAKE_BUILD_TYPE=Release
         -DVTK_DIR:PATH=$(pwd)/../dependencies/vtk_install/lib/cmake/vtk
         -Dassimp_DIR:PATH=$(pwd)/../dependencies/assimp_install/lib/cmake/assimp-5.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,12 @@ if(F3D_PYTHON_BINDINGS)
   add_subdirectory(python)
 endif()
 
+# JNI bindings
+option(F3D_JAVA_BINDINGS "Create Java bindings" OFF)
+if(F3D_JAVA_BINDINGS)
+  add_subdirectory(java)
+endif()
+
 # Installation
 option(F3D_INSTALL_DEFAULT_CONFIGURATION_FILE "Install a default configuration file" OFF)
 mark_as_advanced(F3D_INSTALL_DEFAULT_CONFIGURATION_FILE)

--- a/README_libf3d.md
+++ b/README_libf3d.md
@@ -3,7 +3,7 @@
 By Michael Migliore and Mathieu Westphal.
 
 libf3d is a BSD-licensed C++ library to open and render 3D meshes. It is of course used by F3D.
-libf3d API is simple and easy to learn. Python bindings are provided through pybind11.
+libf3d API is simple and easy to learn. Python bindings are provided through pybind11. Java bindings are also available.
 
 # Getting Started
 
@@ -186,7 +186,9 @@ Options|Default|Type|Description|F3D option|Trigger
 ------|------|------|------|------|------
 window.fullscreen|false|bool|Display in fullscreen.|--fullscreen|render
 
-# Python Bindings
+# Bindings
+
+## Python Bindings
 
 If the python bindings are generated, the libf3d can be used directly from python.
 Make sure to set `PYTHONPATH` to path where the python module is built.
@@ -204,6 +206,31 @@ eng.getOptions()
 
 eng.getLoader().addFile("f3d/testing/data/dragon.vtu").loadFile()
 eng.getInteractor().start()
+```
+
+## Java Bindings
+
+If the Java bindings are generated, the libf3d can be used directly from Java.
+You can import the `f3d.jar` package and use the provided Java classes directly.
+Make sure to set `java.library.path` to path where the JNI library is built.
+Here is an example showing how to use libf3d Java bindings:
+
+```java
+import io.github.f3d_app.f3d.*;
+
+public class F3DExample {
+  public static void main(String[] args) {
+
+    // Always use try-with-resources idiom to ensure the native engine is released
+    try (Engine engine = new Engine(Window.Type.NATIVE)) {
+      Loader loader = engine.getLoader();
+      loader.addFile("f3d/testing/data/dragon.vtu");
+      loader.loadFile(Loader.LoadFileEnum.LOAD_FIRST);
+
+      engine.getWindow().render();
+    }
+  }
+}
 ```
 
 # Building against the libf3d

--- a/cmake/installing.cmake
+++ b/cmake/installing.cmake
@@ -19,6 +19,13 @@ if (BUILD_WINDOWS_SHELL_THUMBNAILS_EXTENSION)
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT shellext)
 endif()
 
+# Java bindings
+if (F3D_JAVA_BINDINGS)
+  install(TARGETS javaf3d
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT java)
+  install_jar(f3d-jar DESTINATION "share/java" COMPONENT java)
+endif()
+
 # Python module
 if (F3D_PYTHON_BINDINGS)
   if(WIN32)

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -1,0 +1,39 @@
+# With Android NDK, JNI is automatically found
+if (NOT ANDROID)
+  find_package(JNI REQUIRED)
+endif()
+
+find_package(Java REQUIRED)
+include(UseJava)
+
+set(F3D_JAVA_SOURCES
+  Camera.java
+  Engine.java
+  Loader.java
+  Options.java
+  Window.java)
+
+# Generate JNI headers, and builds a JAR package
+set(CMAKE_JAVA_COMPILE_FLAGS -source 8 -target 8)
+add_jar(f3d-jar ${F3D_JAVA_SOURCES}
+  GENERATE_NATIVE_HEADERS f3d-jni-headers
+  OUTPUT_NAME f3d)
+
+add_library(javaf3d SHARED F3DJavaBindings.cxx)
+target_link_libraries(javaf3d PRIVATE f3d-jni-headers)
+
+target_include_directories(javaf3d PRIVATE ${JNI_INCLUDE_DIRS})
+target_link_libraries(javaf3d PRIVATE libf3d ${JNI_LIBRARIES})
+
+set_target_properties(javaf3d PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+  CXX_VISIBILITY_PRESET hidden
+  CXX_STANDARD 11
+  OUTPUT_NAME "f3d-java"
+  )
+
+# testing
+if(BUILD_TESTING)
+  add_subdirectory(testing)
+endif()

--- a/java/Camera.java
+++ b/java/Camera.java
@@ -1,0 +1,22 @@
+package io.github.f3d_app.f3d;
+
+public class Camera {
+
+    public Camera(long nativeAddress) {
+        mNativeAddress = nativeAddress;
+    }
+
+    public native void dolly(double val);
+    public native void roll(double angle);
+    public native void azimuth(double angle);
+    public native void yaw(double angle);
+    public native void elevation(double angle);
+    public native void pitch(double angle);
+
+    public native double[] getFocalPoint();
+    public native void setFocalPoint(double[] pt);
+    public native double[] getPosition();
+    public native void setPosition(double[] pt);
+
+    private long mNativeAddress;
+}

--- a/java/Engine.java
+++ b/java/Engine.java
@@ -1,0 +1,36 @@
+package io.github.f3d_app.f3d;
+
+public class Engine implements AutoCloseable {
+    // Used to load the 'f3d' library on application startup.
+    static {
+        System.loadLibrary("f3d-java");
+    }
+
+    public Engine(Window.Type type) {
+        mNativeAddress = construct(type); // instantiate the native engine
+        mLoader = new Loader(mNativeAddress);
+        mOptions = new Options(mNativeAddress);
+        mWindow = new Window(mNativeAddress);
+    }
+
+    // The engine class is automatically released using the Java
+    // try-with-resources idiom
+    // see https://www.baeldung.com/java-try-with-resources
+    @Override
+    public void close() {
+        destroy(mNativeAddress);
+    }
+
+    public Loader getLoader() { return mLoader; }
+    public Options getOptions() { return mOptions; }
+    public Window getWindow() { return mWindow; }
+
+    private native long construct(Window.Type type);
+    private native void destroy(long nativeAddress);
+
+    private Loader mLoader;
+    private Options mOptions;
+    private Window mWindow;
+
+    private long mNativeAddress;
+}

--- a/java/F3DJavaBindings.cxx
+++ b/java/F3DJavaBindings.cxx
@@ -1,0 +1,183 @@
+// Automatically generated headers
+#include <io_github_f3d_app_f3d_Camera.h>
+#include <io_github_f3d_app_f3d_Engine.h>
+#include <io_github_f3d_app_f3d_Loader.h>
+#include <io_github_f3d_app_f3d_Options.h>
+#include <io_github_f3d_app_f3d_Window.h>
+
+#include <engine.h>
+#include <log.h>
+
+#include <cassert>
+
+#define JAVA_BIND(Cls, Func) JNICALL Java_io_github_f3d_1app_f3d_##Cls##_##Func
+
+inline f3d::engine* GetEngine(JNIEnv* env, jobject self)
+{
+  jclass cls = env->GetObjectClass(self);
+  jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
+  jlong ptr = env->GetLongField(self, fid);
+
+  return reinterpret_cast<f3d::engine*>(ptr);
+}
+
+extern "C"
+{
+  // Engine
+  JNIEXPORT jlong JAVA_BIND(Engine, construct)(JNIEnv* env, jobject self, jobject windowType)
+  {
+    // read cursor
+    jmethodID method =
+      env->GetMethodID(env->FindClass("io/github/f3d_app/f3d/Window$Type"), "ordinal", "()I");
+    jint itype = env->CallIntMethod(windowType, method);
+
+    return reinterpret_cast<jlong>(new f3d::engine(static_cast<f3d::window::Type>(itype)));
+  }
+
+  JNIEXPORT void JAVA_BIND(Engine, destroy)(JNIEnv*, jobject, jlong ptr)
+  {
+    delete reinterpret_cast<f3d::engine*>(ptr);
+  }
+
+  // Loader
+  JNIEXPORT void JAVA_BIND(Loader, loadFile)(JNIEnv* env, jobject self, jobject cursor)
+  {
+    // read cursor
+    jmethodID method = env->GetMethodID(
+      env->FindClass("io/github/f3d_app/f3d/Loader$LoadFileEnum"), "ordinal", "()I");
+    jint icursor = env->CallIntMethod(cursor, method);
+
+    GetEngine(env, self)->getLoader().loadFile(static_cast<f3d::loader::LoadFileEnum>(icursor));
+  }
+
+  JNIEXPORT void JAVA_BIND(Loader, addFile)(JNIEnv* env, jobject self, jstring path)
+  {
+    const char* str = env->GetStringUTFChars(path, nullptr);
+    GetEngine(env, self)->getLoader().addFile(str);
+    env->ReleaseStringUTFChars(path, str);
+  }
+
+  // Window
+  JNIEXPORT void JAVA_BIND(Window, render)(JNIEnv* env, jobject self)
+  {
+    GetEngine(env, self)->getWindow().render();
+  }
+
+  JNIEXPORT void JAVA_BIND(Window, setSize)(JNIEnv* env, jobject self, jint w, jint h)
+  {
+    GetEngine(env, self)->getWindow().setSize(w, h);
+  }
+
+  JNIEXPORT jint JAVA_BIND(Window, getWidth)(JNIEnv* env, jobject self)
+  {
+    return GetEngine(env, self)->getWindow().getWidth();
+  }
+
+  JNIEXPORT jint JAVA_BIND(Window, getHeight)(JNIEnv* env, jobject self)
+  {
+    return GetEngine(env, self)->getWindow().getHeight();
+  }
+
+  JNIEXPORT jdoubleArray JAVA_BIND(Window, getDisplayFromWorld)(JNIEnv* env, jobject self, jdoubleArray pt)
+  {
+    double* arr = env->GetDoubleArrayElements(pt, nullptr);
+    f3d::point3_t newPt =
+      GetEngine(env, self)->getWindow().getDisplayFromWorld({ arr[0], arr[1], arr[2] });
+    env->ReleaseDoubleArrayElements(pt, arr, 0);
+
+    jdoubleArray ret = env->NewDoubleArray(3);
+    env->SetDoubleArrayRegion(ret, 0, 3, newPt.data());
+
+    return ret;
+  }
+
+  JNIEXPORT jdoubleArray JAVA_BIND(Window, getWorldFromDisplay)(JNIEnv* env, jobject self, jdoubleArray pt)
+  {
+    double* arr = env->GetDoubleArrayElements(pt, nullptr);
+    f3d::point3_t newPt =
+      GetEngine(env, self)->getWindow().getWorldFromDisplay({ arr[0], arr[1], arr[2] });
+    env->ReleaseDoubleArrayElements(pt, arr, 0);
+
+    jdoubleArray ret = env->NewDoubleArray(3);
+    env->SetDoubleArrayRegion(ret, 0, 3, newPt.data());
+
+    return ret;
+  }
+
+  // Options
+  JNIEXPORT void JAVA_BIND(Options, toggle)(JNIEnv* env, jobject self, jstring name)
+  {
+    const char* str = env->GetStringUTFChars(name, nullptr);
+    GetEngine(env, self)->getOptions().toggle(str);
+    env->ReleaseStringUTFChars(name, str);
+  }
+
+  // Camera
+  JNIEXPORT void JAVA_BIND(Camera, dolly)(JNIEnv* env, jobject self, jdouble factor)
+  {
+    GetEngine(env, self)->getWindow().getCamera().dolly(factor);
+  }
+
+  JNIEXPORT void JAVA_BIND(Camera, roll)(JNIEnv* env, jobject self, jdouble angle)
+  {
+    GetEngine(env, self)->getWindow().getCamera().roll(angle);
+  }
+
+  JNIEXPORT void JAVA_BIND(Camera, azimuth)(JNIEnv* env, jobject self, jdouble angle)
+  {
+    GetEngine(env, self)->getWindow().getCamera().azimuth(angle);
+  }
+
+  JNIEXPORT void JAVA_BIND(Camera, yaw)(JNIEnv* env, jobject self, jdouble angle)
+  {
+    GetEngine(env, self)->getWindow().getCamera().yaw(angle);
+  }
+
+  JNIEXPORT void JAVA_BIND(Camera, elevation)(JNIEnv* env, jobject self, jdouble angle)
+  {
+    GetEngine(env, self)->getWindow().getCamera().elevation(angle);
+  }
+
+  JNIEXPORT void JAVA_BIND(Camera, pitch)(JNIEnv* env, jobject self, jdouble angle)
+  {
+    GetEngine(env, self)->getWindow().getCamera().pitch(angle);
+  }
+
+  JNIEXPORT jdoubleArray JAVA_BIND(Camera, getFocalPoint)(JNIEnv* env, jobject self)
+  {
+    f3d::point3_t pt = GetEngine(env, self)->getWindow().getCamera().getFocalPoint();
+
+    jdoubleArray ret = env->NewDoubleArray(3);
+    env->SetDoubleArrayRegion(ret, 0, 3, pt.data());
+
+    return ret;
+  }
+
+  JNIEXPORT void JAVA_BIND(Camera, setFocalPoint)(JNIEnv* env, jobject self, jdoubleArray pt)
+  {
+    assert(env->GetArrayLength(pt) == 3);
+
+    double* arr = env->GetDoubleArrayElements(pt, nullptr);
+    GetEngine(env, self)->getWindow().getCamera().setFocalPoint({ arr[0], arr[1], arr[2] });
+    env->ReleaseDoubleArrayElements(pt, arr, 0);
+  }
+
+  JNIEXPORT jdoubleArray JAVA_BIND(Camera, getPosition)(JNIEnv* env, jobject self)
+  {
+    f3d::point3_t pt = GetEngine(env, self)->getWindow().getCamera().getPosition();
+
+    jdoubleArray ret = env->NewDoubleArray(3);
+    env->SetDoubleArrayRegion(ret, 0, 3, pt.data());
+
+    return ret;
+  }
+
+  JNIEXPORT void JAVA_BIND(Camera, setPosition)(JNIEnv* env, jobject self, jdoubleArray pt)
+  {
+    assert(env->GetArrayLength(pt) == 3);
+
+    double* arr = env->GetDoubleArrayElements(pt, nullptr);
+    GetEngine(env, self)->getWindow().getCamera().setPosition({ arr[0], arr[1], arr[2] });
+    env->ReleaseDoubleArrayElements(pt, arr, 0);
+  }
+}

--- a/java/Loader.java
+++ b/java/Loader.java
@@ -1,0 +1,15 @@
+package io.github.f3d_app.f3d;
+
+public class Loader {
+
+    public enum LoadFileEnum { LOAD_FIRST, LOAD_PREVIOUS, LOAD_CURRENT, LOAD_NEXT, LOAD_LAST }
+
+    public Loader(long nativeAddress) {
+        mNativeAddress = nativeAddress;
+    }
+
+    public native void loadFile(LoadFileEnum cursor);
+    public native void addFile(String file);
+
+    private long mNativeAddress;
+}

--- a/java/Options.java
+++ b/java/Options.java
@@ -1,0 +1,12 @@
+package io.github.f3d_app.f3d;
+
+public class Options {
+
+    public Options(long nativeAddress) {
+        mNativeAddress = nativeAddress;
+    }
+
+    public native void toggle(String name);
+
+    private long mNativeAddress;
+}

--- a/java/Window.java
+++ b/java/Window.java
@@ -1,0 +1,26 @@
+package io.github.f3d_app.f3d;
+
+public class Window {
+
+    public enum Type { NONE, NATIVE, NATIVE_OFFSCREEN, EXTERNAL }
+
+    public Window(long nativeAddress) {
+        mNativeAddress = nativeAddress;
+        mCamera = new Camera(nativeAddress);
+    }
+
+    public Camera getCamera() { return mCamera; }
+
+    public native void render();
+    public native void setSize(int width, int height);
+
+    public native int getWidth();
+    public native int getHeight();
+
+    public native double[] getDisplayFromWorld(double[] pt);
+    public native double[] getWorldFromDisplay(double[] pt);
+
+    private long mNativeAddress;
+
+    private Camera mCamera;
+}

--- a/java/testing/CMakeLists.txt
+++ b/java/testing/CMakeLists.txt
@@ -1,0 +1,35 @@
+list(APPEND javaf3dTests_list
+     ${CMAKE_CURRENT_SOURCE_DIR}/TestJavaBindings.java
+    )
+
+set(java_test_args "-ea") # enable assertions
+if(APPLE)
+  # On macOS, this argument is mandatory in order to create native window
+  list(APPEND java_test_args "-XstartOnFirstThread")
+endif()
+
+# On macOS, VTK 9.1 is crashing in modifyDPIForBackingScaleFactorOfWindow, see:
+# https://gitlab.kitware.com/vtk/vtk/-/merge_requests/6845 (introduces the crash)
+# https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9372 (fixes the crash)
+# Disabling the tests if we are between these two commits
+set(java_test_disabled OFF)
+if(APPLE AND VTK_VERSION VERSION_GREATER 9.0.0 AND VTK_VERSION VERSION_LESS_EQUAL 9.1.20220617)
+  set(java_test_disabled ON)
+endif()
+
+# Add all the ADD_TEST for each test
+foreach(test_file ${javaf3dTests_list})
+  get_filename_component (TName ${test_file} NAME_WE)
+
+  add_test(NAME javaf3d::${TName}
+    WORKING_DIRECTORY "$<SHELL_PATH:$<TARGET_FILE_DIR:javaf3d>>" # path to the JNI library
+    COMMAND ${Java_JAVA_EXECUTABLE}
+      -Djava.library.path=$<SHELL_PATH:$<TARGET_FILE_DIR:javaf3d>> # path to the JNI library
+      ${java_test_args}
+      -cp $<SHELL_PATH:$<TARGET_PROPERTY:f3d-jar,JAR_FILE>> # path to the JAR file
+      $<SHELL_PATH:${test_file}>
+    )
+
+    set_tests_properties(javaf3d::${TName} PROPERTIES DISABLED ${java_test_disabled})
+endforeach()
+

--- a/java/testing/CMakeLists.txt
+++ b/java/testing/CMakeLists.txt
@@ -32,4 +32,3 @@ foreach(test_file ${javaf3dTests_list})
 
     set_tests_properties(javaf3d::${TName} PROPERTIES DISABLED ${java_test_disabled})
 endforeach()
-

--- a/java/testing/TestJavaBindings.java
+++ b/java/testing/TestJavaBindings.java
@@ -1,0 +1,30 @@
+import io.github.f3d_app.f3d.*;
+
+public class TestJavaBindings {
+
+  static {
+    if (System.getProperty("os.name").startsWith("Windows"))
+    {
+      // On Windows, preload the OpenGL library
+      // This ensures the OpenGL used is the one in the working directory if any.
+      // In practice, it is used in F3D CI to run the test using Mesa, it's not required for production.
+      System.loadLibrary("opengl32");
+    }
+  }
+
+  public static void main(String[] args) {
+
+    // Always use try-with-resources idiom to ensure the native engine is released
+    try (Engine engine = new Engine(Window.Type.NATIVE_OFFSCREEN)) {
+
+      Camera camera = engine.getWindow().getCamera();
+
+      camera.setPosition(new double[] { 0, 1, 2 });
+      double[] pos = camera.getPosition();
+
+      assert pos[0] == 0.0 : "Position X is not valid";
+      assert pos[1] == 1.0 : "Position Y is not valid";
+      assert pos[2] == 2.0 : "Position Z is not valid";
+    }
+  }
+}


### PR DESCRIPTION
Add Java bindings architecture with a working test.  
All the APIs are not bound yet, but it will be fixed with #426  
A few notes:
- We need JDK 8+ to run the test without compiling it first
- Windows works fine, but on a headless server, we need to load Mesa `opengl32.dll` manually first
- On MacOS, we need to run java with the option `-XstartOnFirstThread` otherwise an exception is raised
- VTK 9.1 is crashing on MacOS for some reason (it's fixed on master)

When `F3D_JAVA_BINDINGS` is enabled, a native shared library called `f3d-java` is built containing the JNI symbols. A `f3d.jar` package is also generated containing the Java classes.  
So, in order to use the Java classes, you need to import the JAR file, and put the native `f3d-java` library somewhere in your `java.library.path`