### PR TITLE
Support config filename/filestem only

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ Options|Description
 \-\-up|Define the Up direction (default: +Y)
 \-\-animation-index|Select the animation to show.<br>Any negative value means all animations.<br>The default scene always has at most one animation.<br>If the option is not specified, the first animation is enabled.
 \-\-geometry-only|For certain **full scene** file formats (gltf/glb and obj),<br>reads *only the geometry* from the file and use default scene construction instead.
-\-\-dry-run|Do not read the configuration file but consider only the command line options
-\-\-config|Read a provided configuration file instead of default one
+\-\-dry-run|Do not read any configuration file but consider only the command line options
+\-\-config|Specify the configuration file to use. Supports absolute/relative path but also filename/filestem to search for in configuration file locations.
 \-\-font-file|Use the provided FreeType compatible font file to display text.<br>Can be useful to display non-ASCII filenames.
 
 ## Material options
@@ -399,8 +399,11 @@ They are considered in the below order and only the first found will be used.
  * Windows: `%APPDATA%\f3d\config.json`, `[install_dir]\config.json`
  * macOS: `${XDG_CONFIG_HOME}/.config/f3d/config.json`, `~/.config/f3d/config.json`, `/usr/local/etc/f3d/config.json`, `f3d.app/Contents/Resources/config.json`
 
-If you are using the binary releases, a default configuration file is provided when installing F3D.
-On Linux, it will be installed in `[install_dir]/etc/f3d/`, on Windows, it will be installed in the install directory, on macOS, it will be installed in the bundle.
+When installing F3D default configuration files can be installed, one for generic usage (`config.json`) and one for thumbnails (`thumbnail.json`).
+When installing the binary release, On Linux, they will be installed in `[install_dir]/share/f3d/`, on Windows, it will be installed in the install directory, on macOS, it will be installed in the bundle.
+
+Please note there is a command line option to control the configuration file to read. Using it, one can specify an absolute/relative path for the configuration path, but also
+only the filename or filestem (`.json` will be added) to look for in the locations listed above, instead of looking for `config.json`.
 
 # libf3d
 

--- a/application/F3DConfigFileTools.cxx
+++ b/application/F3DConfigFileTools.cxx
@@ -72,7 +72,7 @@ std::string F3DConfigFileTools::GetBinaryConfigFileDirectory()
     char buffer[size];
     if (_NSGetExecutablePath(buffer, &size) != 0)
     {
-      f3d::log::error("Executable is too long to recover path to config file");
+      f3d::log::error("Executable is too long to recover path to configuration file");
       return std::string();
     }
     execPath = buffer;
@@ -96,7 +96,7 @@ std::string F3DConfigFileTools::GetBinaryConfigFileDirectory()
   }
   catch (const std::filesystem::filesystem_error&)
   {
-    f3d::log::debug("Cannot recover binary config file directory: ", dirPath.string());
+    f3d::log::debug("Cannot recover binary configuration file directory: ", dirPath.string());
     return std::string();
   }
 
@@ -104,9 +104,8 @@ std::string F3DConfigFileTools::GetBinaryConfigFileDirectory()
 }
 
 //----------------------------------------------------------------------------
-std::string F3DConfigFileTools::GetConfigFilePath()
+std::string F3DConfigFileTools::GetConfigFilePath(const std::string& filename)
 {
-  std::string fileName = "config.json";
   std::filesystem::path filePath;
   std::vector<std::string> dirsToCheck;
   try
@@ -125,20 +124,19 @@ std::string F3DConfigFileTools::GetConfigFilePath()
     {
       if (!dir.empty())
       {
-        filePath = std::filesystem::path(dir) / fileName;
+        filePath = std::filesystem::path(dir) / filename;
         if (std::filesystem::exists(filePath))
         {
-          f3d::log::debug("Config file found in: ", filePath.string());
           return filePath.string();
         }
       }
     }
-    f3d::log::debug("No config file found");
+    f3d::log::debug("No configuration file (\"", filename, "\") found");
     return std::string();
   }
   catch (const std::filesystem::filesystem_error&)
   {
-    f3d::log::error("Error recovering config file path: ", filePath.string());
+    f3d::log::error("Error recovering configuration file path: ", filePath.string());
     return std::string();
   }
 }

--- a/application/F3DConfigFileTools.h
+++ b/application/F3DConfigFileTools.h
@@ -14,7 +14,7 @@ namespace F3DConfigFileTools
 std::string GetUserConfigFileDirectory();
 std::string GetBinaryConfigFileDirectory();
 std::string GetSystemConfigFileDirectory();
-std::string GetConfigFilePath();
+std::string GetConfigFilePath(const std::string& filename);
 }
 
 #endif

--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -200,19 +200,19 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
 
     // clang-format off
     auto grp0 = cxxOptions.add_options("Applicative");
-    this->DeclareOption(grp0, "input", "", "Input file", inputs, LocalHasDefaultNo, MayHaveConfig::NO , "<files>");
-    this->DeclareOption(grp0, "output", "", "Render to file", appOptions.Output, LocalHasDefaultNo, MayHaveConfig::NO, "<png file>");
+    this->DeclareOption(grp0, "input", "", "Input file", inputs, LocalHasDefaultNo, MayHaveConfig::YES , "<files>");
+    this->DeclareOption(grp0, "output", "", "Render to file", appOptions.Output, LocalHasDefaultNo, MayHaveConfig::YES, "<png file>");
     this->DeclareOption(grp0, "no-background", "", "No background when render to file", appOptions.NoBackground, HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp0, "help", "h", "Print help");
     this->DeclareOption(grp0, "version", "", "Print version details");
     this->DeclareOption(grp0, "readers-list", "", "Print the list of file types");
-    this->DeclareOption(grp0, "config", "", "Read a provided configuration file instead of default one", appOptions.UserConfigFile,  LocalHasDefaultNo, MayHaveConfig::NO , "<file path>");
+    this->DeclareOption(grp0, "config", "", "Specify the configuration file to use. absolute/relative path or filename/filestem to search in configuration file locations.", appOptions.UserConfigFile,  LocalHasDefaultNo, MayHaveConfig::NO , "<filePath/filename/fileStem>");
     this->DeclareOption(grp0, "dry-run", "", "Do not read the configuration file", appOptions.DryRun,  HasDefault::YES, MayHaveConfig::NO );
-    this->DeclareOption(grp0, "no-render", "", "Verbose mode without any rendering, only for the first file", appOptions.NoRender,  HasDefault::YES, MayHaveConfig::NO );
+    this->DeclareOption(grp0, "no-render", "", "Verbose mode without any rendering, only for the first file", appOptions.NoRender,  HasDefault::YES, MayHaveConfig::YES );
 
     auto grp1 = cxxOptions.add_options("General");
-    this->DeclareOption(grp1, "verbose", "", "Enable verbose mode, providing more information about the loaded data in the console output", appOptions.Verbose,  HasDefault::YES, MayHaveConfig::NO );
-    this->DeclareOption(grp1, "quiet", "", "Enable quiet mode, which superseed any verbose options and prevent any console output to be generated at all", appOptions.Quiet,  HasDefault::YES, MayHaveConfig::NO );
+    this->DeclareOption(grp1, "verbose", "", "Enable verbose mode, providing more information about the loaded data in the console output", appOptions.Verbose,  HasDefault::YES, MayHaveConfig::YES );
+    this->DeclareOption(grp1, "quiet", "", "Enable quiet mode, which superseed any verbose options and prevent any console output to be generated at all", appOptions.Quiet,  HasDefault::YES, MayHaveConfig::YES );
     this->DeclareOption(grp1, "progress", "", "Show progress bar", options.getAsBoolRef("ui.loader-progress"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp1, "geometry-only", "", "Do not read materials, cameras and lights from file", options.getAsBoolRef("scene.geometry-only"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp1, "up", "", "Up direction", options.getAsStringRef("scene.up-direction"), HasDefault::YES, MayHaveConfig::YES, "[-X|+X|-Y|+Y|-Z|+Z]");
@@ -242,7 +242,7 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
 
     auto grp3 = cxxOptions.add_options("Window");
     this->DeclareOption(grp3, "bg-color", "", "Background color", options.getAsDoubleVectorRef("render.background.color"), HasDefault::YES, MayHaveConfig::YES, "<R,G,B>");
-    this->DeclareOption(grp3, "resolution", "", "Window resolution", appOptions.Resolution, HasDefault::YES, MayHaveConfig::NO, "<width,height>");
+    this->DeclareOption(grp3, "resolution", "", "Window resolution", appOptions.Resolution, HasDefault::YES, MayHaveConfig::YES, "<width,height>");
     this->DeclareOption(grp3, "fps", "z", "Display frame per second", options.getAsBoolRef("ui.fps"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp3, "filename", "n", "Display filename", options.getAsBoolRef("ui.filename"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp3, "metadata", "m", "Display file metadata", options.getAsBoolRef("ui.metadata"), HasDefault::YES, MayHaveConfig::YES);
@@ -281,10 +281,10 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
     this->DeclareOption(grp6, "tone-mapping", "t", "Enable Tone Mapping", options.getAsBoolRef("render.effect.tone-mapping"), HasDefault::YES, MayHaveConfig::YES);
 
     auto grp7 = cxxOptions.add_options("Testing");
-    this->DeclareOption(grp7, "ref", "", "Reference", appOptions.Reference, LocalHasDefaultNo, MayHaveConfig::NO, "<png file>");
-    this->DeclareOption(grp7, "ref-threshold", "", "Testing threshold", appOptions.RefThreshold, HasDefault::YES, MayHaveConfig::NO, "<threshold>");
-    this->DeclareOption(grp7, "interaction-test-record", "", "Path to an interaction log file to record interactions events to", appOptions.InteractionTestRecordFile, LocalHasDefaultNo, MayHaveConfig::NO, "<file_path>");
-    this->DeclareOption(grp7, "interaction-test-play", "", "Path to an interaction log file to play interaction events from when loading a file", appOptions.InteractionTestPlayFile, LocalHasDefaultNo, MayHaveConfig::NO,"<file_path>");
+    this->DeclareOption(grp7, "ref", "", "Reference", appOptions.Reference, LocalHasDefaultNo, MayHaveConfig::YES, "<png file>");
+    this->DeclareOption(grp7, "ref-threshold", "", "Testing threshold", appOptions.RefThreshold, HasDefault::YES, MayHaveConfig::YES, "<threshold>");
+    this->DeclareOption(grp7, "interaction-test-record", "", "Path to an interaction log file to record interactions events to", appOptions.InteractionTestRecordFile, LocalHasDefaultNo, MayHaveConfig::YES, "<file_path>");
+    this->DeclareOption(grp7, "interaction-test-play", "", "Path to an interaction log file to play interaction events from when loading a file", appOptions.InteractionTestPlayFile, LocalHasDefaultNo, MayHaveConfig::YES,"<file_path>");
     // clang-format on
 
     cxxOptions.parse_positional({ "input" });

--- a/application/F3DOptionsParser.h
+++ b/application/F3DOptionsParser.h
@@ -46,10 +46,14 @@ public:
 
   /**
    * Find and parse a config file, if any, into the config file dictionnary.
-   * If a non-empty userConfigFile is provided, it will be considered instead
-   * of standard settings config file
+   * If a non-empty configNameis provided, it will be considered instead
+   * of standard settings config file.
+   * supported config are:
+   *  - relative/absolute path to a config file
+   *  - name of file to look for in standard locations
+   *  - name of file without extension to look for in standard locations, .json will be added.
    */
-  void InitializeDictionaryFromConfigFile(const std::string& userConfigFile);
+  void InitializeDictionaryFromConfigFile(const std::string& config);
 
   /**
    * Parse the command line and return the options passed

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -81,6 +81,16 @@ int F3DStarter::Start(int argc, char** argv)
   this->Internals->Parser.GetOptions(
     this->Internals->AppOptions, this->Internals->DynamicOptions, files);
 
+  // Set verbosity level early from command line
+  if (this->Internals->AppOptions.Quiet)
+  {
+    f3d::log::setVerboseLevel(f3d::log::VerboseLevel::QUIET);
+  }
+  else if (this->Internals->AppOptions.Verbose || this->Internals->AppOptions.NoRender)
+  {
+    f3d::log::setVerboseLevel(f3d::log::VerboseLevel::DEBUG);
+  }
+
   // Read config file if needed
   if (!this->Internals->AppOptions.DryRun)
   {
@@ -91,16 +101,16 @@ int F3DStarter::Start(int argc, char** argv)
     // Parse command line options with config file, global section only
     this->Internals->Parser.GetOptions(
       this->Internals->AppOptions, this->Internals->DynamicOptions, files);
-  }
 
-  // Set verbosity level
-  if (this->Internals->AppOptions.Quiet)
-  {
-    f3d::log::setVerboseLevel(f3d::log::VerboseLevel::QUIET);
-  }
-  else if (this->Internals->AppOptions.Verbose || this->Internals->AppOptions.NoRender)
-  {
-    f3d::log::setVerboseLevel(f3d::log::VerboseLevel::DEBUG);
+    // Set verbosity level again if it was defined in the configuration file global block
+    if (this->Internals->AppOptions.Quiet)
+    {
+      f3d::log::setVerboseLevel(f3d::log::VerboseLevel::QUIET);
+    }
+    else if (this->Internals->AppOptions.Verbose || this->Internals->AppOptions.NoRender)
+    {
+      f3d::log::setVerboseLevel(f3d::log::VerboseLevel::DEBUG);
+    }
   }
 
 #if __APPLE__

--- a/cmake/installing.cmake
+++ b/cmake/installing.cmake
@@ -47,17 +47,22 @@ endif()
 install(FILES LICENSE THIRD_PARTY_LICENSES.md README.md
   DESTINATION ${F3D_DOC_DIR} COMPONENT documentation)
 
+list(APPEND config_files
+     "${CMAKE_SOURCE_DIR}/resources/config.json"
+     "${CMAKE_SOURCE_DIR}/resources/thumbnail.json"
+    )
+
 # Default config file
 if (UNIX AND NOT APPLE)
   if (F3D_INSTALL_DEFAULT_CONFIGURATION_FILE)
     if (F3D_INSTALL_DEFAULT_CONFIGURATION_FILE_IN_PREFIX)
-      install(FILES "${CMAKE_SOURCE_DIR}/resources/config.json"
+      install(FILES ${config_files}
         DESTINATION "share/f3d" COMPONENT configuration)
     else()
       message(STATUS "Enabling F3D_INSTALL_DEFAULT_CONFIGURATION_FILE, while not enabling "
               "F3D_INSTALL_DEFAULT_CONFIGURATION_FILE_IN_PREFIX implies that installation of the config file rely on
               CMAKE_INSTALL_FULL_SYSCONFDIR and that the config file will not be packaged by cpack.")
-      install(FILES "${CMAKE_SOURCE_DIR}/resources/config.json"
+      install(FILES ${config_files}
         DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/f3d" COMPONENT configuration)
     endif()
   endif()
@@ -135,12 +140,12 @@ elseif(WIN32 AND NOT UNIX)
   install(FILES "${CMAKE_SOURCE_DIR}/resources/logo.ico"
     DESTINATION "." COMPONENT assets)
   if (F3D_INSTALL_DEFAULT_CONFIGURATION_FILE)
-    install(FILES "${CMAKE_SOURCE_DIR}/resources/config.json"
+    install(FILES ${config_files}
       DESTINATION "." COMPONENT configuration)
   endif()
 elseif(APPLE AND NOT F3D_MACOS_BUNDLE)
   if (F3D_INSTALL_DEFAULT_CONFIGURATION_FILE)
-    install(FILES "${CMAKE_SOURCE_DIR}/resources/config.json"
+    install(FILES ${config_files}
       DESTINATION "." COMPONENT configuration)
   endif()
 endif()

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -208,6 +208,9 @@ endif()
 # no-background test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8501
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)
   f3d_test(NAME TestNoBackground DATA cow.vtp ARGS --no-background)
+  f3d_test(NAME TestThumbnailConfigFile DATA dragon.vtu CONFIG ${CMAKE_SOURCE_DIR}/resources/thumbnail.json DEFAULT_LIGHTS)
+  f3d_test(NAME TestThumbnailConfigFileAnotherBlock DATA vase_4comp.vti CONFIG ${CMAKE_SOURCE_DIR}/resources/thumbnail.json DEFAULT_LIGHTS)
+  f3d_test(NAME TestThumbnailConfigFileUp DATA suzanne.stl CONFIG ${CMAKE_SOURCE_DIR}/resources/thumbnail.json DEFAULT_LIGHTS)
 endif()
 
 # HDRI test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8825
@@ -397,11 +400,20 @@ f3d_test(NAME TestInvalidHDRI DATA cow.vtp ARGS --hdri=${CMAKE_SOURCE_DIR}/testi
 # Test invalid options, do not add a --dummy option
 f3d_test(NAME TestInvalidOption ARGS --dummy REGEXP "Error parsing options:")
 
-# Test non-existent config file, do not add a dummy.json
-f3d_test(NAME TestNonExistentConfigFile DATA cow.vtp CONFIG "${CMAKE_SOURCE_DIR}/testing/configs/dummy.json" REGEXP "Configuration file does not exist" NO_BASELINE)
+# Test non-existent config filepath, do not add a dummy.json
+f3d_test(NAME TestNonExistentConfigFilePath DATA cow.vtp CONFIG "${CMAKE_SOURCE_DIR}/testing/configs/dummy.json" REGEXP "Configuration file does not exist" NO_BASELINE)
+
+# Test non-existent config filename, do not add a dummy.json
+f3d_test(NAME TestNonExistentConfigFilename DATA cow.vtp CONFIG "dummy.json" REGEXP "Configuration file for \"dummy.json\" could not been found" NO_BASELINE)
+
+# Test non-existent config filename, do not add a dummy.json
+f3d_test(NAME TestNonExistentConfigFileStem DATA cow.vtp CONFIG "dummy" REGEXP "Configuration file for \"dummy\" could not been found" NO_BASELINE)
 
 # Test invalid config file
 f3d_test(NAME TestInvalidConfigFile DATA cow.vtp CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/invalid.json REGEXP "Unable to parse the configuration file" NO_BASELINE)
+
+# Test quiet in config file
+f3d_test(NAME TestConfigFileQuiet DATA nonExistentFile.vtp CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/quiet.json REGEXP_FAIL "File .*/testing/data/nonExistentFile.vtp does not exist" NO_RENDER)
 
 # Test help display
 f3d_test(NAME TestHelp ARGS --help REGEXP "Usage:")

--- a/resources/f3d.thumbnailer.in
+++ b/resources/f3d.thumbnailer.in
@@ -2,5 +2,5 @@
 Type=X-Thumbnailer
 Name=f3d Thumbnailer
 TryExec=f3d
-Exec=f3d --dry-run -sta --no-background --output=%o --resolution=%s,%s %i
+Exec=f3d --config=thumbnail --quiet --output=%o --resolution=%s,%s %i
 MimeType=${F3D_SUPPORTED_MIME_TYPES}

--- a/resources/thumbnail.json
+++ b/resources/thumbnail.json
@@ -1,0 +1,33 @@
+{
+  "global":
+  {
+    "scalars": "",
+    "fxaa": true,
+    "tone-mapping": true,
+    "no-background": true
+  },
+  ".*(dcm|nrrd|mhd|mha|vti)":
+  {
+    "volume": true
+  },
+  ".*(3ds|stl|off)":
+  {
+    "up": "+Z"
+  },
+  ".*(dxf)":
+  {
+    "up": "-Z"
+  },
+  ".*(step|stp|iges|igs)":
+  {
+    "up": "+Z",
+    "ssao": true,
+    "comp": "-2",
+    "cells": true
+  },
+  ".*(tif|tiff)":
+  {
+    "up": "-Y",
+    "comp": "-2"
+  }
+}

--- a/testing/baselines/TestThumbnailConfigFile.png
+++ b/testing/baselines/TestThumbnailConfigFile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da0f43488d8dc1c56af4623522b3cfc94589b3cfc97fd393f44073288710fdd4
+size 31320

--- a/testing/baselines/TestThumbnailConfigFileAnotherBlock.png
+++ b/testing/baselines/TestThumbnailConfigFileAnotherBlock.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96a23016ad10fe4f022e5d4671de471ff4739ac2a3d4aaf4d6282d89b1220f26
+size 17706

--- a/testing/baselines/TestThumbnailConfigFileUp.png
+++ b/testing/baselines/TestThumbnailConfigFileUp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6034733dadc8a309ffd8ccaeee486050f9ca4cd7324cef6ba5088fd0091c54a
+size 16581

--- a/testing/configs/quiet.json
+++ b/testing/configs/quiet.json
@@ -1,0 +1,6 @@
+{
+  "global":
+  {
+    "quiet": true
+  }
+}

--- a/winshellext/F3DThumbnailProvider.cxx
+++ b/winshellext/F3DThumbnailProvider.cxx
@@ -166,7 +166,7 @@ IFACEMETHODIMP F3DThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
   // Create command to run
   wchar_t command[MAX_PATH * 3 + 20];
   swprintf_s(command, MAX_PATH * 3 + 20,
-    L"\"%s\" --input \"%s\" --output \"%s\" --dry-run -sta --no-background --quiet --resolution "
+    L"\"%s\" --input \"%s\" --output \"%s\" --config=thumbnail --quiet --resolution "
     L"%d,%d\"",
     m_f3dPath, m_filePath, image_filename, cx, cx);
 


### PR DESCRIPTION
--config now support filename/fileStem , which is great and lets us specify a config file for thumbnails.

- Add support for filename/fileStem in --config
- Update/Improve doc
- Fix an issue with options not read from config file, introduced in #396 
- Add a thumbnail.json and use it in thumbnailers
- Add tests