### PR TITLE
Max size option

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -209,6 +209,7 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
     this->DeclareOption(grp0, "config", "", "Specify the configuration file to use. absolute/relative path or filename/filestem to search in configuration file locations.", appOptions.UserConfigFile,  LocalHasDefaultNo, MayHaveConfig::NO , "<filePath/filename/fileStem>");
     this->DeclareOption(grp0, "dry-run", "", "Do not read the configuration file", appOptions.DryRun,  HasDefault::YES, MayHaveConfig::NO );
     this->DeclareOption(grp0, "no-render", "", "Verbose mode without any rendering, only for the first file", appOptions.NoRender,  HasDefault::YES, MayHaveConfig::YES );
+    this->DeclareOption(grp0, "max-size", "", "Maximum size in Mib of a file to load, -1 means unlimited", appOptions.MaxSize,  HasDefault::YES, MayHaveConfig::YES, "<size in Mib>");
 
     auto grp1 = cxxOptions.add_options("General");
     this->DeclareOption(grp1, "verbose", "", "Enable verbose mode, providing more information about the loaded data in the console output", appOptions.Verbose,  HasDefault::YES, MayHaveConfig::YES );

--- a/application/F3DOptionsParser.h
+++ b/application/F3DOptionsParser.h
@@ -28,6 +28,8 @@ struct F3DAppOptions
   bool NoBackground = false;
   bool NoRender = false;
   double RefThreshold = 50;
+  int MaxSize = -1;
+
   std::vector<int> Resolution{ 1000, 600 };
   bool Quiet = false;
   bool Verbose = false;

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -325,13 +325,21 @@ void F3DStarter::LoadFile(f3d::loader::LoadFileEnum load)
   this->Internals->UpdateWithCommandLineParsing = false; // this is done only once
   this->Internals->Engine->setOptions(this->Internals->FileOptions);
 
-  // Load the file
-  this->Internals->LoadedFile = this->Internals->Engine->getLoader().loadFile(load);
-
-  if (!this->Internals->AppOptions.NoRender)
+  // Check the size of the file before loading it
+  if (fileAppOptions.MaxSize >= 0 && std::filesystem::file_size(std::filesystem::path(filePath)) > static_cast<std::uintmax_t>(fileAppOptions.MaxSize) * 1048576)
   {
-    // Setup the camera according to options
-    this->Internals->SetupCamera(fileAppOptions);
+    f3d::log::info("No file loaded, file is bigger than max size");
+  }
+  else
+  {
+    // Load the file
+    this->Internals->LoadedFile = this->Internals->Engine->getLoader().loadFile(load);
+
+    if (!this->Internals->AppOptions.NoRender)
+    {
+      // Setup the camera according to options
+      this->Internals->SetupCamera(fileAppOptions);
+    }
   }
 }
 

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -326,7 +326,10 @@ void F3DStarter::LoadFile(f3d::loader::LoadFileEnum load)
   this->Internals->Engine->setOptions(this->Internals->FileOptions);
 
   // Check the size of the file before loading it
-  if (fileAppOptions.MaxSize >= 0 && std::filesystem::file_size(std::filesystem::path(filePath)) > static_cast<std::uintmax_t>(fileAppOptions.MaxSize) * 1048576)
+  static constexpr int BYTES_IN_MIB = 1048576;
+  if (fileAppOptions.MaxSize >= 0 &&
+    std::filesystem::file_size(std::filesystem::path(filePath)) >
+      static_cast<std::uintmax_t>(fileAppOptions.MaxSize) * BYTES_IN_MIB)
   {
     f3d::log::info("No file loaded, file is bigger than max size");
   }

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -158,7 +158,7 @@ f3d_test(NAME TestUTF8 DATA "(ノಠ益ಠ )ノ.vtp" DEFAULT_LIGHTS)
 f3d_test(NAME TestFont DATA suzanne.ply ARGS -n --font-file=${CMAKE_SOURCE_DIR}/testing/data/AttackGraffiti-3zRBM.ttf DEFAULT_LIGHTS)
 f3d_test(NAME TestAnimationIndex DATA InterpolationTest.glb ARGS --animation-index=7 DEFAULT_LIGHTS)
 f3d_test(NAME TestMaxSizeBelow DATA suzanne.stl ARGS --max-size=1 DEFAULT_LIGHTS)
-f3d_test(NAME TestMaxSizeAbove DATA WaterBottle.glb ARGS --max-size=1 REGEXP "No file loaded, no rendering performed" NO_BASELINE)
+f3d_test(NAME TestMaxSizeAbove DATA WaterBottle.glb ARGS --max-size=1 REGEXP "No file loaded, file is bigger than max size" NO_BASELINE)
 f3d_test(NAME TestNonExistentFile DATA nonExistentFile.vtp ARGS --filename WILL_FAIL)
 f3d_test(NAME TestUnsupportedFile DATA unsupportedFile.dummy ARGS --filename WILL_FAIL)
 

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -157,6 +157,8 @@ f3d_test(NAME TestTIFF DATA logo.tif ARGS -sy --up=-Y DEFAULT_LIGHTS)
 f3d_test(NAME TestUTF8 DATA "(ノಠ益ಠ )ノ.vtp" DEFAULT_LIGHTS)
 f3d_test(NAME TestFont DATA suzanne.ply ARGS -n --font-file=${CMAKE_SOURCE_DIR}/testing/data/AttackGraffiti-3zRBM.ttf DEFAULT_LIGHTS)
 f3d_test(NAME TestAnimationIndex DATA InterpolationTest.glb ARGS --animation-index=7 DEFAULT_LIGHTS)
+f3d_test(NAME TestMaxSizeBelow DATA suzanne.stl ARGS --max-size=1 DEFAULT_LIGHTS)
+f3d_test(NAME TestMaxSizeAbove DATA WaterBottle.glb ARGS --max-size=1 REGEXP "No file loaded, no rendering performed" NO_BASELINE)
 f3d_test(NAME TestNonExistentFile DATA nonExistentFile.vtp ARGS --filename WILL_FAIL)
 f3d_test(NAME TestUnsupportedFile DATA unsupportedFile.dummy ARGS --filename WILL_FAIL)
 

--- a/resources/thumbnail.json
+++ b/resources/thumbnail.json
@@ -4,7 +4,8 @@
     "scalars": "",
     "fxaa": true,
     "tone-mapping": true,
-    "no-background": true
+    "no-background": true,
+    "max-size":100
   },
   ".*(dcm|nrrd|mhd|mha|vti)":
   {

--- a/testing/baselines/TestMaxSizeBelow.png
+++ b/testing/baselines/TestMaxSizeBelow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a36d1885eaef13ae1d8d70dc413ccae495186907112ccc0587d60b58baaa263
+size 21277


### PR DESCRIPTION
Adds a --max-size option, that will just not load a file if it is bigger than provided max size, -1 being infinite.

Very useful tor thumbnails.