### PR TITLE
Fix DLL export warning on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,6 @@ mark_as_advanced(F3D_STRICT_BUILD)
 set(f3d_strict_build_compile_options "")
 if(F3D_STRICT_BUILD)
   if(MSVC)
-    # Warning C4275 is essentially noise, disabling it to silent an issue with jsoncpp library
     set(f3d_strict_build_compile_options /W4 /WX)
   else()
     set(f3d_strict_build_compile_options -Wall -Wextra -Wshadow -Woverloaded-virtual -Wno-deprecated -Wno-strict-overflow -Wno-array-bounds -Wunreachable-code -Wno-missing-field-initializers -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -Wpointer-arith -Werror)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ set(f3d_strict_build_compile_options "")
 if(F3D_STRICT_BUILD)
   if(MSVC)
     # Warning C4275 is essentially noise, disabling it to silent an issue with jsoncpp library
-    set(f3d_strict_build_compile_options /W4 /WX /wd4275)
+    set(f3d_strict_build_compile_options /W4 /WX)
   else()
     set(f3d_strict_build_compile_options -Wall -Wextra -Wshadow -Woverloaded-virtual -Wno-deprecated -Wno-strict-overflow -Wno-array-bounds -Wunreachable-code -Wno-missing-field-initializers -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -Wpointer-arith -Werror)
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/library/public/exception.h
+++ b/library/public/exception.h
@@ -9,14 +9,12 @@
 #ifndef f3d_exception_h
 #define f3d_exception_h
 
-#include "export.h"
-
 #include <stdexcept>
 #include <string>
 
 namespace f3d
 {
-struct F3D_EXPORT exception : public std::runtime_error
+struct exception : public std::runtime_error
 {
   exception(const std::string& what = "")
     : std::runtime_error(what)


### PR DESCRIPTION
`f3d::exception` derives from `std::runtime_error` resulting in a warning in Windows because the exported symbol rely on the STL.  
We don't need to export the class since it's header only.

Fix #428 