### PR TITLE
On UNIX, fix the RPATH for the application installation

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -41,7 +41,7 @@ set_target_properties(f3d PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DI
 if (APPLE)
   set_target_properties(f3d PROPERTIES INSTALL_RPATH @loader_path/../lib)
 elseif (UNIX)
-  set_target_properties(f3d PROPERTIES INSTALL_RPATH $ORIGIN/../lib)
+  set_target_properties(f3d PROPERTIES INSTALL_RPATH $ORIGIN/../${CMAKE_INSTALL_LIBDIR})
 endif ()
 
 target_compile_features(f3d PRIVATE cxx_std_17)


### PR DESCRIPTION
The name of the **lib** directory is really distro dependent. This MR improve the install part of the f3d application to respect the distro ecosystem.

NB. I did not change the apple one because I do not know if `GNUInstallDir` handle this system correctly. The same change may be meaningful there too.