### PR TITLE
Remove CMAKE_SYSTEM_PROCESSOR to fix reproducibility.

### DIFF
--- a/library/src/config.cxx.in
+++ b/library/src/config.cxx.in
@@ -5,7 +5,7 @@
 namespace f3d::detail
 {
 const std::string LibVersion = "@PROJECT_VERSION@"; // Version is synchronized with F3D
-const std::string LibBuildSystem = "@CMAKE_SYSTEM_NAME@ @CMAKE_SYSTEM_PROCESSOR@";
+const std::string LibBuildSystem = "@CMAKE_SYSTEM_NAME@";
 const std::string LibBuildDate = "@F3D_BUILD_DATE@";
 const std::string LibCompiler = "@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
 }


### PR DESCRIPTION
Hello,

the `CMAKE_SYSTEM_PROCESSOR` variable triggered a reproducibility error when cross compiling. See for example [this diffoscope report](https://tests.reproducible-builds.org/debian/rb-pkg/bookworm/i386/diffoscope-results/f3d.html) which contains the string `Linux·x86_64` when cross-compiling from amd64 to i386, instead of `Linux i686`. The string origin is in `config.cxx.in` and easily visible with `f3d --help` command.

The current fix works for the Debian package, but I'm not sure that this is the correct one as it may be a cross-compiling tool-chain misconfiguration, hence not related to F3D itself.

Feel free to edit this PR.

Best,
François
