### PR TITLE
add --light-intensity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Options|Default|Description
 -n, \-\-filename||Display the *name of the file*.
 -m, \-\-metadata||Display the *metadata*.<br>This only makes sense when using the default scene.
 -u, \-\-blur-background||Blur background.<br>This only makes sense when using a HDRI.
+\-\-light-intensity|1.0|*Adjust the intensity* of every light in the scene.
 
 ## Scientific visualization options
 

--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -246,6 +246,7 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
     this->DeclareOption(grp3, "filename", "n", "Display filename", options.getAsBoolRef("ui.filename"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp3, "metadata", "m", "Display file metadata", options.getAsBoolRef("ui.metadata"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp3, "blur-background", "u", "Blur background", options.getAsBoolRef("render.background.blur"), HasDefault::YES, MayHaveConfig::YES);
+    this->DeclareOption(grp3, "light-intensity", "", "Light intensity", options.getAsDoubleRef("render.light.intensity"), HasDefault::YES, MayHaveConfig::YES, "<intensity>");
 
     auto grp4 = cxxOptions.add_options("Scientific visualization");
     this->DeclareOption(grp4, "scalars", "s", "Color by scalars", options.getAsStringRef("model.scivis.array-name"), HasDefault::YES, MayHaveConfig::YES, "<array_name>", HasImplicitValue::YES, "");

--- a/application/F3DOptionsParser.h
+++ b/application/F3DOptionsParser.h
@@ -40,6 +40,7 @@ struct F3DAppOptions
   std::vector<double> CameraPosition = { 0 };
   std::vector<double> CameraViewUp = { 0 };
   double CameraViewAngle = 0.0;
+  double LightIntensity = 0.0;
 };
 
 class F3DOptionsParser

--- a/application/F3DOptionsParser.h
+++ b/application/F3DOptionsParser.h
@@ -40,7 +40,6 @@ struct F3DAppOptions
   std::vector<double> CameraPosition = { 0 };
   std::vector<double> CameraViewUp = { 0 };
   double CameraViewAngle = 0.0;
-  double LightIntensity = 0.0;
 };
 
 class F3DOptionsParser

--- a/documentation/content/docs/index.md
+++ b/documentation/content/docs/index.md
@@ -154,6 +154,7 @@ Options|Default|Description
 -m, \-\-metadata||Display the *metadata*.<br>This only makes sense when using the default scene.
 -f, \-\-fullscreen||Display in fullscreen.
 -u, \-\-blur-background||Blur background.<br>This only makes sense when using a HDRI.
+\-\-light-intensity|1.0|*Adjust the intensity* of every light in the scene.
 
 # Rendering precedence
 

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -97,7 +97,7 @@ void vtkF3DRenderer::Initialize(const std::string& fileInfo, const std::string& 
 {
   this->RemoveAllViewProps();
   this->RemoveAllLights();
-  this->originalLightIntensities.clear();
+  this->OriginalLightIntensities.clear();
 
   this->AddActor(this->FilenameActor);
   this->AddActor(this->GridActor);
@@ -525,14 +525,15 @@ void vtkF3DRenderer::SetLightIntensity(const double intensityFactor)
   vtkCollectionSimpleIterator it;
   for (lc->InitTraversal(it); (light = lc->GetNextLight(it));)
   {
-    double originalIntensity = light->GetIntensity();
-    if (this->originalLightIntensities.count(light))
+    double originalIntensity;
+    if (this->OriginalLightIntensities.count(light))
     {
-      originalIntensity = this->originalLightIntensities[light];
+      originalIntensity = this->OriginalLightIntensities[light];
     }
     else
     {
-      this->originalLightIntensities[light] = originalIntensity;
+      originalIntensity = light->GetIntensity();
+      this->OriginalLightIntensities[light] = originalIntensity;
     }
 
     light->SetIntensity(originalIntensity * intensityFactor);

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -515,6 +515,29 @@ void vtkF3DRenderer::SetBackground(const double* color)
 }
 
 //----------------------------------------------------------------------------
+void vtkF3DRenderer::SetLightIntensity(const double intensity)
+{
+  if (intensity > 0)
+  {
+    if (intensity != LightKit->GetKeyLightIntensity() || !this->LightKitAdded)
+    {
+      LightKit->SetKeyLightIntensity(intensity);
+      LightKit->SetKeyLightWarmth(.5);
+      if (!this->LightKitAdded)
+      {
+        LightKit->AddLightsToRenderer(this);
+        this->LightKitAdded = true;
+      }
+    }
+  }
+  else if (this->LightKitAdded)
+  {
+    LightKit->RemoveLightsFromRenderer(this);
+    this->LightKitAdded = false;
+  }
+}
+
+//----------------------------------------------------------------------------
 void vtkF3DRenderer::SetUseDepthPeelingPass(bool use)
 {
   if (this->UseDepthPeelingPass != use)

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.h
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.h
@@ -12,6 +12,7 @@
 #define vtkF3DRenderer_h
 
 #include <vtkOpenGLRenderer.h>
+#include <vtkLightKit.h>
 
 class vtkCornerAnnotation;
 class vtkOrientationMarkerWidget;
@@ -47,6 +48,7 @@ public:
   void SetFontFile(const std::string& fontFile);
   void SetHDRIFile(const std::string& hdriFile);
   void SetBackground(const double* backgroundColor) override;
+  void SetLightIntensity(const double intensity);
   //@}
 
   //@{
@@ -174,6 +176,9 @@ protected:
   bool HasHDRI = false;
   std::string HDRIFile;
   std::string FontFile;
+
+  vtkNew<vtkLightKit> LightKit;
+  bool LightKitAdded = false;
 
   std::string CurrentGridInfo;
   std::string GridInfo;

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.h
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.h
@@ -11,9 +11,10 @@
 #ifndef vtkF3DRenderer_h
 #define vtkF3DRenderer_h
 
-#include <map>
 #include <vtkLight.h>
 #include <vtkOpenGLRenderer.h>
+
+#include <map>
 
 class vtkCornerAnnotation;
 class vtkOrientationMarkerWidget;

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.h
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.h
@@ -11,6 +11,7 @@
 #ifndef vtkF3DRenderer_h
 #define vtkF3DRenderer_h
 
+#include <map>
 #include <vtkLightKit.h>
 #include <vtkOpenGLRenderer.h>
 
@@ -177,8 +178,7 @@ protected:
   std::string HDRIFile;
   std::string FontFile;
 
-  vtkNew<vtkLightKit> LightKit;
-  bool LightKitAdded = false;
+  std::map<vtkLight*, double> originalLightIntensities;
 
   std::string CurrentGridInfo;
   std::string GridInfo;

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.h
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.h
@@ -11,8 +11,8 @@
 #ifndef vtkF3DRenderer_h
 #define vtkF3DRenderer_h
 
-#include <vtkOpenGLRenderer.h>
 #include <vtkLightKit.h>
+#include <vtkOpenGLRenderer.h>
 
 class vtkCornerAnnotation;
 class vtkOrientationMarkerWidget;

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.h
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.h
@@ -12,7 +12,7 @@
 #define vtkF3DRenderer_h
 
 #include <map>
-#include <vtkLightKit.h>
+#include <vtkLight.h>
 #include <vtkOpenGLRenderer.h>
 
 class vtkCornerAnnotation;
@@ -178,7 +178,7 @@ protected:
   std::string HDRIFile;
   std::string FontFile;
 
-  std::map<vtkLight*, double> originalLightIntensities;
+  std::map<vtkLight*, double> OriginalLightIntensities;
 
   std::string CurrentGridInfo;
   std::string GridInfo;

--- a/library/src/options.cxx
+++ b/library/src/options.cxx
@@ -131,7 +131,7 @@ options::options()
   this->Internals->init(
     "render.background.hdri", std::string()); // XXX This overrides background.color
   this->Internals->init("render.background.blur", false);
-  this->Internals->init("render.light.intensity", 0.);
+  this->Internals->init("render.light.intensity", 1.);
 
   // UI
   this->Internals->init("ui.bar", false);

--- a/library/src/options.cxx
+++ b/library/src/options.cxx
@@ -131,6 +131,7 @@ options::options()
   this->Internals->init(
     "render.background.hdri", std::string()); // XXX This overrides background.color
   this->Internals->init("render.background.blur", false);
+  this->Internals->init("render.light.intensity", 0.);
 
   // UI
   this->Internals->init("ui.bar", false);

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -277,6 +277,9 @@ void window_impl::UpdateDynamicOptions()
     this->Internals->Options.getAsBool("render.background.blur"));
   this->Internals->Renderer->SetHDRIFile(
     this->Internals->Options.getAsString("render.background.hdri"));
+  this->Internals->Renderer->SetLightIntensity(
+    this->Internals->Options.getAsDouble("render.light.intensity"));
+
 
   this->Internals->Renderer->SetFontFile(this->Internals->Options.getAsString("ui.font-file"));
 

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -280,7 +280,6 @@ void window_impl::UpdateDynamicOptions()
   this->Internals->Renderer->SetLightIntensity(
     this->Internals->Options.getAsDouble("render.light.intensity"));
 
-
   this->Internals->Renderer->SetFontFile(this->Internals->Options.getAsString("ui.font-file"));
 
   vtkF3DRendererWithColoring* renWithColor =

--- a/library/testing/CMakeLists.txt
+++ b/library/testing/CMakeLists.txt
@@ -17,6 +17,7 @@ if(VTK_VERSION VERSION_GREATER 9.0.1)
     TestSDKWindowNative.cxx
     TestSDKDynamicBackgroundColor.cxx
     TestSDKDynamicFontFile.cxx
+    TestSDKDynamicLightIntensity.cxx
     )
 endif()
 

--- a/library/testing/TestSDKDynamicLightIntensity.cxx
+++ b/library/testing/TestSDKDynamicLightIntensity.cxx
@@ -1,0 +1,47 @@
+#include <engine.h>
+#include <loader.h>
+#include <options.h>
+#include <window.h>
+
+#include "TestSDKHelpers.h"
+
+int TestSDKDynamicLightIntensity(int argc, char* argv[])
+{
+  f3d::engine eng(f3d::window::Type::NATIVE_OFFSCREEN);
+  f3d::loader& load = eng.getLoader();
+  f3d::window& win = eng.getWindow();
+  f3d::options& opt = eng.getOptions();
+  win.setSize(300, 300);
+
+  load.addFile(std::string(argv[1]) + "/data/cow.vtp").loadFile();
+
+  win.render();
+
+  // Check render with default light intensity
+  if (!TestSDKHelpers::RenderTest(eng.getWindow(), std::string(argv[1]) + "baselines/",
+        std::string(argv[2]), "TestSDKDynamicLightIntensity-default", 50))
+  {
+    std::cerr << "failed for default light intensity" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // set light-intensity to 5x brighter
+  opt.set("render.light.intensity", 5.);
+  if (!TestSDKHelpers::RenderTest(eng.getWindow(), std::string(argv[1]) + "baselines/",
+        std::string(argv[2]), "TestSDKDynamicLightIntensity-5x-brighter", 50))
+  {
+    std::cerr << "failed for light intensity = 5" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // set light-intensity to 5x darker
+  opt.set("render.light.intensity", .2);
+  if (!TestSDKHelpers::RenderTest(eng.getWindow(), std::string(argv[1]) + "baselines/",
+        std::string(argv[2]), "TestSDKDynamicLightIntensity-5x-darker", 50))
+  {
+    std::cerr << "failed for light intensity = .2" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/testing/baselines/TestSDKDynamicLightIntensity-5x-brighter.png
+++ b/testing/baselines/TestSDKDynamicLightIntensity-5x-brighter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e4216c483df9ab0ff4c5c2360495b266426db5b429069a0a6ca2622b8aff3de
+size 10549

--- a/testing/baselines/TestSDKDynamicLightIntensity-5x-darker.png
+++ b/testing/baselines/TestSDKDynamicLightIntensity-5x-darker.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7420dc7b0d085638256fa460856775537a7cd6d0613a3610384cddff60e66a56
+size 14147

--- a/testing/baselines/TestSDKDynamicLightIntensity-default.png
+++ b/testing/baselines/TestSDKDynamicLightIntensity-default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f2fba6832f298e6872af830ca607f02baba77d6433c1e0a894bbe9b52dd73e
+size 17521


### PR DESCRIPTION
This PR adds a `--light-intensity` option to address problem described in #352.

It is implemented by simply adding a [`vtkLightKit`](https://vtk.org/doc/release/4.0/html/classvtkLightKit.html) to the renderer.

Here are some samples using the same model as in previous issue:

```bash
f3d 'ROKN Chung Mu.glb' --camera-position 37.3,20.4,61.6 --camera-focal-point -5.5,1.4,6.7 --camera-view-up -0.2,1.0,-0.2 --camera-view-angle 30 --ssao --fxaa --tone-mapping
```
![light-intensity-no](https://user-images.githubusercontent.com/489715/198180241-da2c44f2-5e68-4ef1-9f40-fd06ae452aca.png)

```bash
f3d 'ROKN Chung Mu.glb' --light-intensity=1 --camera-position 37.3,20.4,61.6 --camera-focal-point -5.5,1.4,6.7 --camera-view-up -0.2,1.0,-0.2 --camera-view-angle 30 --ssao --fxaa --tone-mapping --light-intensity=1
```
![light-intensity-1](https://user-images.githubusercontent.com/489715/198180311-4e4cb154-13a9-4c29-a773-f72f3b27109b.png)

```bash
f3d 'ROKN Chung Mu.glb' --light-intensity=2 --camera-position 37.3,20.4,61.6 --camera-focal-point -5.5,1.4,6.7 --camera-view-up -0.2,1.0,-0.2 --camera-view-angle 30 --ssao --fxaa --tone-mapping --light-intensity=2
```
![light-intensity-2](https://user-images.githubusercontent.com/489715/198180344-722dab0d-ef06-4efb-8cf1-8bb637aa7fff.png)

```bash
f3d 'ROKN Chung Mu.glb' --light-intensity=4 --camera-position 37.3,20.4,61.6 --camera-focal-point -5.5,1.4,6.7 --camera-view-up -0.2,1.0,-0.2 --camera-view-angle 30 --ssao --fxaa --tone-mapping --light-intensity=4
```
![light-intensity-4](https://user-images.githubusercontent.com/489715/198180362-10cc56d8-6ac2-43a0-9c12-4354c5f85a63.png)


