### PR TITLE
Fix ZSH completions

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -213,7 +213,7 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
     this->DeclareOption(grp1, "quiet", "", "Enable quiet mode, which superseed any verbose options and prevent any console output to be generated at all", appOptions.Quiet,  HasDefault::YES, MayHaveConfig::YES );
     this->DeclareOption(grp1, "progress", "", "Show progress bar", options.getAsBoolRef("ui.loader-progress"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp1, "geometry-only", "", "Do not read materials, cameras and lights from file", options.getAsBoolRef("scene.geometry-only"), HasDefault::YES, MayHaveConfig::YES);
-    this->DeclareOption(grp1, "up", "", "Up direction", options.getAsStringRef("scene.up-direction"), HasDefault::YES, MayHaveConfig::YES, "[-X|+X|-Y|+Y|-Z|+Z]");
+    this->DeclareOption(grp1, "up", "", "Up direction", options.getAsStringRef("scene.up-direction"), HasDefault::YES, MayHaveConfig::YES, "{-X, +X, -Y, +Y, -Z, +Z}");
     this->DeclareOption(grp1, "axis", "x", "Show axes", options.getAsBoolRef("interactor.axis"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp1, "grid", "g", "Show grid", options.getAsBoolRef("render.grid"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp1, "edges", "e", "Show cell edges", options.getAsBoolRef("render.show-edges"), HasDefault::YES, MayHaveConfig::YES);

--- a/resources/completion.zsh
+++ b/resources/completion.zsh
@@ -13,4 +13,4 @@ longopts=$(echo $f3dhelp | grep "[-]-" | sed 's/=.*>//g' | sed 's/-.,//g' | sed 
 arguments=("${(f)shortopts}")
 arguments+=("${(f)longopts}")
 
-_arguments "$arguments[@]"
+_arguments "$arguments[@]" "*:file:_files"

--- a/resources/completion.zsh
+++ b/resources/completion.zsh
@@ -5,9 +5,9 @@ local shortopts
 local arguments
 local f3dhelp
 
-f3dhelp=$(f3d --help 2>&1 | sed '1,/Examples/!d')
+f3dhelp=$(f3d --help 2>&1 | sed '1,/Examples/!d' | sed 's/\[.*\] *//')
 
-shortopts=$(echo $f3dhelp | grep "[-].," | sed "s/^ *\(-.\), *--[^ ]* *\(.*\)$/\1[\2]/")
+shortopts=$(echo $f3dhelp | grep "^\s*[-].," | sed "s/^ *\(-.\), *--[^ ]* *\(.*\)$/\1[\2]/")
 longopts=$(echo $f3dhelp | grep "[-]-" | sed 's/=.*>//g' | sed 's/-.,//g' | sed "s/^ *\([^ ]*\) *\(.*\)$/\1[\2]/g")
 
 arguments=("${(f)shortopts}")


### PR DESCRIPTION
Characters `[]` may not appear in the explanation text of ZSH completions, so change ` to not include those characters.

- Format choices as `{A, B, C}` instead of `[A|B|C]` [(the same syntax as Python `argparse`](https://docs.python.org/3/library/argparse.html#choices))

- Format implicit values as `<arg>(=value)` instead of `[=<arg>(=value)]` (don't know an existing alternate syntax, so just stripped `[]`).

The `completions.zsh` regex should also skip short-options that occur in option explanations (text `-y` occurs in the explanation for `--comp`).

Add a trailing `*:file:_files` optspec so that filenames may autocomplete.
