### PR TITLE
Log Assimp error description when Importer fails

### DIFF
--- a/library/VTKExtensions/Readers/Testing/CMakeLists.txt
+++ b/library/VTKExtensions/Readers/Testing/CMakeLists.txt
@@ -9,7 +9,9 @@ if(F3D_MODULE_ALEMBIC)
 endif()
 
 if(F3D_MODULE_ASSIMP)
-  list(APPEND VTKExtensionsReaderTests_list TestF3DAssimpImporter.cxx)
+  list(APPEND VTKExtensionsReaderTests_list
+      TestF3DAssimpImporter.cxx
+      TestF3DAssimpImportError.cxx)
 endif()
 
 if(F3D_MODULE_OCCT)

--- a/library/VTKExtensions/Readers/Testing/TestF3DAssimpImportError.cxx
+++ b/library/VTKExtensions/Readers/Testing/TestF3DAssimpImportError.cxx
@@ -1,0 +1,64 @@
+#include <vtkNew.h>
+#include <vtkTestUtilities.h>
+
+#include "vtkCommand.h"
+#include "vtkF3DAssimpImporter.h"
+
+#include <iostream>
+#include <vector>
+
+class WarningEventCallback : public vtkCommand
+{
+public:
+  static WarningEventCallback* New() { return new WarningEventCallback; }
+
+  void Execute(vtkObject* caller, unsigned long evId, void* data) override
+  {
+    auto importer = reinterpret_cast<vtkF3DAssimpImporter*>(caller);
+    char* message = static_cast<char*>(data);
+    if (importer && message)
+    {
+      this->Messages.push_back(message);
+    }
+  }
+
+  const std::vector<std::string>& GetRecordedWarningMessages() const { return this->Messages; }
+
+private:
+  std::vector<std::string> Messages;
+};
+
+int TestF3DAssimpImportError(int argc, char* argv[])
+{
+  vtkObject::GlobalWarningDisplayOn();
+  vtkNew<vtkF3DAssimpImporter> importer;
+
+  vtkNew<WarningEventCallback> warningEventCallback;
+  importer->AddObserver(vtkCommand::WarningEvent, warningEventCallback);
+
+  importer->SetFileName("dummy.dae");
+  importer->Update();
+
+  auto warningMessages = warningEventCallback->GetRecordedWarningMessages();
+  if (warningMessages.empty())
+  {
+    std::cerr << "No warning triggered." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  auto lastMessage = warningMessages.back();
+  if (lastMessage.find("Assimp error") == std::string::npos)
+  {
+    std::cerr << "No Assimp error triggered!" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (importer->GetNumberOfAnimations() != 0)
+  {
+    std::cerr << "Importer has " << importer->GetNumberOfAnimations()
+              << " animations, expected 0 animation." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/library/VTKExtensions/Readers/vtkF3DAssimpImporter.cxx
+++ b/library/VTKExtensions/Readers/vtkF3DAssimpImporter.cxx
@@ -582,6 +582,9 @@ public:
     else
     {
       vtkWarningWithObjectMacro(this->Parent, "Assimp failed to load: " << filePath);
+
+      auto errorDescription = this->Importer.GetErrorString();
+      vtkWarningWithObjectMacro(this->Parent, "Assimp error: " << errorDescription);
     }
   }
 


### PR DESCRIPTION
This pull request uses the error description mechanism of Assimp to ease debugging when the importer fails to load a file.

As a side note, Assimp also provides an advanced system to add dynamic stream loggers for the host application as explained [in the documentation](https://assimp.sourceforge.net/lib_html/usage.html#logging), but I would understand it's complex over-engineering for normal usage.
For your information, I've used it to investigate the following issue in Assimp which was detected by F3D Debian package testing :wink: : 
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1023212

As always, feel free to comment and modify.

Thanks!