### PR TITLE
fix image data python bindings

### DIFF
--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -32,8 +32,23 @@ PYBIND11_MODULE(f3d, module)
     .def("setResolution", &f3d::image::setResolution)
     .def("getChannelCount", &f3d::image::getChannelCount)
     .def("setChannelCount", &f3d::image::setChannelCount)
-    .def("setData", &f3d::image::setData)
-    .def("getData", &f3d::image::getData)
+    .def("setData",
+      [](f3d::image& img, const py::bytes& data)
+      {
+        const py::buffer_info info(py::buffer(data).request());
+        if (info.itemsize != 1 ||
+          info.size != img.getChannelCount() * img.getWidth() * img.getHeight())
+        {
+          throw py::value_error();
+        }
+        img.setData((unsigned char*)info.ptr);
+      })
+    .def("getData",
+      [](const f3d::image& img)
+      {
+        return py::bytes(
+          (char*)img.getData(), img.getChannelCount() * img.getWidth() * img.getHeight());
+      })
     .def("compare", &f3d::image::compare)
     .def("save", &f3d::image::save);
 

--- a/python/testing/CMakeLists.txt
+++ b/python/testing/CMakeLists.txt
@@ -1,6 +1,7 @@
 list(APPEND pyf3dTests_list
      TestPythonOptions.py
      TestPythonCamera.py
+     TestPythonImageData.py
     )
 
 # Test image comparison only with VTK > 9.0.1

--- a/python/testing/TestPythonImageData.py
+++ b/python/testing/TestPythonImageData.py
@@ -1,0 +1,50 @@
+import f3d
+
+engine = f3d.engine(f3d.window.NATIVE_OFFSCREEN)
+window = engine.getWindow()
+window.setSize(300, 200)
+
+
+'''with background -> RGB image'''
+
+img = window.renderToImage()
+width = img.getWidth()
+height = img.getHeight()
+depth = img.getChannelCount()
+data = img.getData()
+
+assert width == window.getWidth()
+assert height == window.getHeight()
+assert depth == 3
+assert isinstance(data, (bytes, bytearray))
+assert len(data) == depth * width * height
+
+
+'''without background -> RGBA image'''
+
+img = window.renderToImage(True)
+width = img.getWidth()
+height = img.getHeight()
+depth = img.getChannelCount()
+data = img.getData()
+
+assert width == window.getWidth()
+assert height == window.getHeight()
+assert depth == 4
+assert isinstance(data, (bytes, bytearray))
+assert len(data) == depth * width * height
+
+
+'''set data back'''
+
+img.setData(data)
+assert img.getData() == data
+
+
+'''attempt to set partial data back'''
+
+try:
+    img.setData(data[:-1])
+    assert False, 'expected exception'
+except ValueError:
+    assert True


### PR DESCRIPTION
`pybind` doesn't automagically bind C-style arrays ([which makes sense](https://github.com/pybind/pybind11/issues/1460)) so there needs to be some explicit conversion to properly expose `char*` image data in python as `bytes`/`bytearray` type.