### PR TITLE
Fixing some issues with F3D website

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,15 +1,8 @@
----
-layout: default
-title: License
-parent: Licenses
-nav_order: 0
----
-
 BSD 3-Clause License
 
-```
-Copyright 2019-2021 Kitware SAS
-Copyright 2021-2022 Michael Migliore, Mathieu Westphal
+* Copyright 2019-2021 Kitware SAS
+* Copyright 2021-2022 Michael Migliore, Mathieu Westphal
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,4 +29,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ permalink: /
 # F3D - Fast and minimalist 3D viewer
 By Michael Migliore and Mathieu Westphal.
 
-<img src="https://user-images.githubusercontent.com/3129530/195972584-11ebb000-4939-47f4-9719-9d55e18867b0.png" align="left" width="20px"/>
+<img src="resources/logo.svg" align="left" width="20px"/>
 F3D (pronounced `/fɛd/`) is a fast and minimalist 3D viewer. It supports many file formats, from digital content to scientific datasets (including glTF, STL, STEP, PLY, OBJ, FBX, Alembic), can show animations and support lot of rendering and texturing options including real time physically based rendering and raytracing.
 <br clear="left"/>
 

--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ F3D was initially created by [Kitware SAS](https://www.kitware.eu/) and is relyi
 
 # License
 
-F3D can be used and distributed under the 3-Clause BSD License, see the [license](LICENSE.md).
+F3D can be used and distributed under the 3-Clause BSD License, see the [license](_license.md).
 F3D rely on other libraries and tools, all under permissive licenses, see the [third party licenses](doc/THIRD_PARTY_LICENSES.md).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+---
+layout: default
+title: Home
+nav_order: 0
+description: "F3D - Fast and minimalist 3D viewer"
+permalink: /
+---
+
 [![CI](https://github.com/f3d-app/f3d/actions/workflows/ci.yml/badge.svg)](https://github.com/f3d-app/f3d/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/f3d-app/f3d/branch/master/graph/badge.svg?token=siwG82IXK7)](https://codecov.io/gh/f3d-app/f3d) [![Downloads](https://img.shields.io/github/downloads/f3d-app/f3d/total.svg)](https://github.com/f3d-app/f3d/releases)
 
 # F3D - Fast and minimalist 3D viewer
@@ -48,7 +56,7 @@ man f3d # Linux only
 
 # Documentation
 
-- To get started, please take a look at the [user documentation](doc/README.md).
+- To get started, please take a look at the [user documentation](doc/user/README.md).
 - If you need any help, are looking for a feature or found a bug, please open an [issue](https://github.com/f3d-app/f3d/issues).
 - If you want to use the libf3d, please take a look at its [documentation](doc/libf3d/README.md).
 - If you want to build F3D and contribute to it, please take a look at the [developper documentation](doc/dev/README.md).
@@ -63,5 +71,5 @@ F3D was initially created by [Kitware SAS](https://www.kitware.eu/) and is relyi
 
 # License
 
-F3D can be used and distributed under the 3-Clause BSD License, see the [license](_license.md).
+F3D can be used and distributed under the 3-Clause BSD License, see the [license](LICENSE.md).
 F3D rely on other libraries and tools, all under permissive licenses, see the [third party licenses](doc/THIRD_PARTY_LICENSES.md).

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ relative_links:
   enabled: true
   collections: true
 include:
-  - README.md
+  - _home.md
   - LICENSE.md
   - _licenses.md
   - _license.md

--- a/_config.yml
+++ b/_config.yml
@@ -2,12 +2,15 @@ remote_theme: just-the-docs/just-the-docs
 plugins:
   - jekyll-remote-theme
   - jekyll-relative-links
+  - jekyll-optional-front-matter
 relative_links:
   enabled: true
   collections: true
 include:
-  - _readme.md
+  - README.md
+  - LICENSE.md
   - _licenses.md
+  - _license.md
 exclude:
   - testing/data/DATA_LICENSES.md
 title: F3D

--- a/_home.md
+++ b/_home.md
@@ -1,5 +1,13 @@
+---
+layout: default
+title: Home
+nav_order: 0
+description: "F3D - Fast and minimalist 3D viewer"
+permalink: /
+---
+
 <!---
-This file is very similar to _home.md, any changes made here should be reflected there too.
+This file is very similar to README.md, any changes made here should be reflected there too.
 -->
 
 [![CI](https://github.com/f3d-app/f3d/actions/workflows/ci.yml/badge.svg)](https://github.com/f3d-app/f3d/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/f3d-app/f3d/branch/master/graph/badge.svg?token=siwG82IXK7)](https://codecov.io/gh/f3d-app/f3d) [![Downloads](https://img.shields.io/github/downloads/f3d-app/f3d/total.svg)](https://github.com/f3d-app/f3d/releases)
@@ -19,7 +27,7 @@ F3D also contains the libf3d, a simple library to render meshes, with C++, Pytho
 
 *A typical render by F3D*
 
-<img src="https://user-images.githubusercontent.com/3129530/194735261-dd6f1c1c-fa57-47b0-9d27-f735d18ccd5e.gif" width="640">
+<video src='https://user-images.githubusercontent.com/3129530/194734947-f34bc377-8ee4-472a-b130-30ce9e86facf.webm' autoplay="autoplay" loop="loop" width="640"></video>
 
 *Animation of a glTF file within F3D*
 

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" href="resources/logo.ico" type="image/x-icon">
+<link rel="shortcut icon" href="https://raw.githubusercontent.com/f3d-app/f3d/master/resources/logo.ico" type="image/x-icon">

--- a/_license.md
+++ b/_license.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: License
+parent: Licenses
+nav_order: 0
+---
+
+{% include_relative LICENSE.md %}

--- a/_readme.md
+++ b/_readme.md
@@ -1,9 +1,0 @@
----
-layout: default
-title: Home
-nav_order: 0
-description: "F3D - Fast and minimalist 3D viewer"
-permalink: /
----
-
-{% include_relative README.md %}

--- a/doc/dev/GENERATE.md
+++ b/doc/dev/GENERATE.md
@@ -25,7 +25,7 @@ Requires `clang` toolchain.
 # How to locally generate the jekyll based website
 
 1. Install `ruby` and make sure ruby binaries directory is added to your `PATH`
-2. Install jekyll and all dependencies: `gem install jekyll jekyll-remote-theme jekyll-relative-links jekyll-seo-tag`
+2. Install jekyll and all dependencies: `gem install jekyll jekyll-remote-theme jekyll-relative-links jekyll-seo-tag jekyll-optional-front-matter`
 3. Run jekyll locally: `jekyll server`
 
 Please note the favicon and search bar are not working locally, this is expected.


### PR DESCRIPTION
- Sadly using `include` breaks all jekyll links inside the included part, reverting to duplicating meain readme.
- Use local logo in readme as it works perfectly
- Use a cloud icon for favicon as the path is relative aand breaks in the doc tree
- Fix a wrong link
- Fix license detection by using a raw license file
- Last point means the link in the "summary" and the link in the readme are not the same, the best I could do.