### PR TITLE
add filename to window title

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 include(CMakeDependentOption)
 
-project(f3d
+project(F3D
   VERSION "1.3.1"
   DESCRIPTION "F3D - A fast and minimalist 3D viewer"
   LANGUAGES C CXX)

--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -28,6 +28,7 @@ public:
     : Argc(argc)
     , Argv(argv)
   {
+    this->ExecutableName = argc > 0 && argv[0][0] ? argv[0] : "f3d";
   }
 
   void GetOptions(F3DAppOptions& appOptions, f3d::options& options,
@@ -179,6 +180,7 @@ private:
   using Dictionary = std::map<std::string, DictionaryEntry>;
   DictionaryEntry GlobalConfigDicEntry;
   Dictionary ConfigDic;
+  std::string ExecutableName;
 };
 
 //----------------------------------------------------------------------------
@@ -211,7 +213,7 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
 
   try
   {
-    cxxopts::Options cxxOptions(F3D::AppName, F3D::AppTitle);
+    cxxopts::Options cxxOptions(this->ExecutableName, F3D::AppTitle);
     cxxOptions.positional_help("file1 file2 ...");
 
     // clang-format off
@@ -357,12 +359,13 @@ void ConfigurationOptions::PrintHelpPair(
 void ConfigurationOptions::PrintHelp(cxxopts::Options& cxxOptions)
 {
   // clang-format off
+  const std::string f3d = this->ExecutableName;
   const std::vector<std::pair<std::string, std::string> > examples =
   {
-    { "f3d file.vtu -xtgans", "View a unstructured mesh in a typical nice looking sciviz style" },
-    { "f3d file.glb -tuqap --hdri=file.hdr", "View a gltf file in a realistic environment" },
-    { "f3d file.ply -so --point-size=0 --comp=-2", "View a point cloud file with direct scalars rendering" },
-    { "f3d folder", "View all files in folder" },
+    { f3d+" file.vtu -xtgans", "View a unstructured mesh in a typical nice looking sciviz style" },
+    { f3d+" file.glb -tuqap --hdri=file.hdr", "View a gltf file in a realistic environment" },
+    { f3d+" file.ply -so --point-size=0 --comp=-2", "View a point cloud file with direct scalars rendering" },
+    { f3d+" folder", "View all files in folder" },
   };
   // clang-format on
 

--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -358,15 +358,15 @@ void ConfigurationOptions::PrintHelpPair(
 //----------------------------------------------------------------------------
 void ConfigurationOptions::PrintHelp(cxxopts::Options& cxxOptions)
 {
-  // clang-format off
-  const std::vector<std::pair<std::string, std::string> > examples =
-  {
-    { this->ExecutableName+" file.vtu -xtgans", "View a unstructured mesh in a typical nice looking sciviz style" },
-    { this->ExecutableName+" file.glb -tuqap --hdri=file.hdr", "View a gltf file in a realistic environment" },
-    { this->ExecutableName+" file.ply -so --point-size=0 --comp=-2", "View a point cloud file with direct scalars rendering" },
-    { this->ExecutableName+" folder", "View all files in folder" },
+  const std::vector<std::pair<std::string, std::string> > examples = {
+    { this->ExecutableName + " file.vtu -xtgans",
+      "View a unstructured mesh in a typical nice looking sciviz style" },
+    { this->ExecutableName + " file.glb -tuqap --hdri=file.hdr",
+      "View a gltf file in a realistic environment" },
+    { this->ExecutableName + " file.ply -so --point-size=0 --comp=-2",
+      "View a point cloud file with direct scalars rendering" },
+    { this->ExecutableName + " folder", "View all files in folder" },
   };
-  // clang-format on
 
   f3d::log::setUseColoring(false);
   f3d::log::info(cxxOptions.help());

--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -359,13 +359,12 @@ void ConfigurationOptions::PrintHelpPair(
 void ConfigurationOptions::PrintHelp(cxxopts::Options& cxxOptions)
 {
   // clang-format off
-  const std::string f3d = this->ExecutableName;
   const std::vector<std::pair<std::string, std::string> > examples =
   {
-    { f3d+" file.vtu -xtgans", "View a unstructured mesh in a typical nice looking sciviz style" },
-    { f3d+" file.glb -tuqap --hdri=file.hdr", "View a gltf file in a realistic environment" },
-    { f3d+" file.ply -so --point-size=0 --comp=-2", "View a point cloud file with direct scalars rendering" },
-    { f3d+" folder", "View all files in folder" },
+    { this->ExecutableName+" file.vtu -xtgans", "View a unstructured mesh in a typical nice looking sciviz style" },
+    { this->ExecutableName+" file.glb -tuqap --hdri=file.hdr", "View a gltf file in a realistic environment" },
+    { this->ExecutableName+" file.ply -so --point-size=0 --comp=-2", "View a point cloud file with direct scalars rendering" },
+    { this->ExecutableName+" folder", "View all files in folder" },
   };
   // clang-format on
 

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -332,8 +332,8 @@ void F3DStarter::LoadFile(f3d::loader::LoadFileEnum load)
 
   // Recover info about the file to be loaded
   int index;
-  std::string filePath, fileInfo;
-  this->Internals->Engine->getLoader().getFileInfo(load, index, filePath, fileInfo);
+  std::string filePath, fileName, fileInfo;
+  this->Internals->Engine->getLoader().getFileInfo(load, index, filePath, fileName, fileInfo);
 
   // Update options for the file to load, using dynamic options as default
   this->Internals->FileOptions = this->Internals->DynamicOptions;
@@ -360,6 +360,11 @@ void F3DStarter::LoadFile(f3d::loader::LoadFileEnum load)
     {
       // Setup the camera according to options
       this->Internals->SetupCamera(fileAppOptions);
+    }
+
+    if (!fileName.empty())
+    {
+      this->Internals->Engine->getWindow().setWindowName(fileName + " - " + F3D::AppName);
     }
   }
 }

--- a/library/private/loader_impl.h
+++ b/library/private/loader_impl.h
@@ -42,7 +42,7 @@ public:
   bool loadFile(LoadFileEnum load) override;
 
   void getFileInfo(LoadFileEnum load, int& nextFileIndex, std::string& filePath,
-    std::string& fileInfo) const override;
+    std::string& fileName, std::string& fileInfo) const override;
   ///@}
 
   /**

--- a/library/public/loader.h
+++ b/library/public/loader.h
@@ -80,8 +80,8 @@ public:
    * filePath the path to the file and fileInfo a more complete information about the file,
    * including index in list.
    */
-  virtual void getFileInfo(
-    LoadFileEnum load, int& nextFileIndex, std::string& filePath, std::string& fileInfo) const = 0;
+  virtual void getFileInfo(LoadFileEnum load, int& nextFileIndex, std::string& filePath,
+    std::string& fileName, std::string& fileInfo) const = 0;
 
 protected:
   //! @cond

--- a/library/src/loader_impl.cxx
+++ b/library/src/loader_impl.cxx
@@ -236,8 +236,8 @@ loader& loader_impl::addFile(const std::string& path, bool recursive)
 }
 
 //----------------------------------------------------------------------------
-void loader_impl::getFileInfo(
-  LoadFileEnum load, int& nextFileIndex, std::string& filePath, std::string& fileInfo) const
+void loader_impl::getFileInfo(LoadFileEnum load, int& nextFileIndex, std::string& filePath,
+  std::string& fileName, std::string& fileInfo) const
 {
   int size = static_cast<int>(this->Internals->FilesList.size());
   if (size > 0)
@@ -273,8 +273,9 @@ void loader_impl::getFileInfo(
     }
 
     filePath = this->Internals->FilesList[nextFileIndex];
-    fileInfo = "(" + std::to_string(nextFileIndex + 1) + "/" + std::to_string(size) + ") " +
-      vtksys::SystemTools::GetFilenameName(filePath);
+    fileName = vtksys::SystemTools::GetFilenameName(filePath);
+    fileInfo =
+      "(" + std::to_string(nextFileIndex + 1) + "/" + std::to_string(size) + ") " + fileName;
   }
   else
   {
@@ -308,9 +309,9 @@ bool loader_impl::loadFile(loader::LoadFileEnum load)
   this->Internals->LoadedFile = false;
 
   // Recover information about the file to load
-  std::string filePath, fileInfo;
+  std::string filePath, fileName, fileInfo;
   int nextFileIndex;
-  this->getFileInfo(load, nextFileIndex, filePath, fileInfo);
+  this->getFileInfo(load, nextFileIndex, filePath, fileName, fileInfo);
 
   if (filePath.empty())
   {

--- a/library/testing/TestSDKLoader.cxx
+++ b/library/testing/TestSDKLoader.cxx
@@ -12,13 +12,13 @@ int TestSDKLoader(int argc, char* argv[])
   f3d::engine eng(f3d::window::Type::NONE);
   f3d::loader& load = eng.getLoader();
 
-  std::string filePath, fileInfo;
+  std::string filePath, fileName, fileInfo;
   int idx;
 
   // Test empty file list
   std::string empty = "";
   load.addFile(empty);
-  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileInfo);
+  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
   if (idx != -1)
   {
     std::cerr << "Unexpected idx with empty filelist: " << idx << std::endl;
@@ -43,7 +43,7 @@ int TestSDKLoader(int argc, char* argv[])
   std::vector<std::string> filesVecCheck{ cow, dragon, suzanne };
 
   load.addFile(dummy).addFile(cow).addFiles(filesVec);
-  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileInfo);
+  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
   if (filePath != cow)
   {
     std::cerr << "Unexpected file loaded on LOAD_CURRENT: " << filePath << std::endl;
@@ -56,7 +56,7 @@ int TestSDKLoader(int argc, char* argv[])
   }
 
   load.loadFile(f3d::loader::LoadFileEnum::LOAD_LAST);
-  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileInfo);
+  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
   if (filePath != suzanne)
   {
     std::cerr << "Unexpected file loaded on LOAD_LAST: " << filePath << std::endl;
@@ -64,7 +64,7 @@ int TestSDKLoader(int argc, char* argv[])
   }
 
   load.loadFile(f3d::loader::LoadFileEnum::LOAD_FIRST);
-  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileInfo);
+  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
   if (filePath != cow)
   {
     std::cerr << "Unexpected file loaded on LOAD_FIRST: " << filePath << std::endl;
@@ -72,7 +72,7 @@ int TestSDKLoader(int argc, char* argv[])
   }
 
   load.loadFile(f3d::loader::LoadFileEnum::LOAD_NEXT);
-  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileInfo);
+  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
   if (filePath != dragon)
   {
     std::cerr << "Unexpected file loaded on LOAD_NEXT: " << filePath << std::endl;
@@ -80,7 +80,7 @@ int TestSDKLoader(int argc, char* argv[])
   }
 
   load.loadFile(f3d::loader::LoadFileEnum::LOAD_NEXT);
-  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileInfo);
+  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
   if (filePath != suzanne)
   {
     std::cerr << "Unexpected file loaded on second LOAD_NEXT: " << filePath << std::endl;
@@ -96,7 +96,7 @@ int TestSDKLoader(int argc, char* argv[])
 
   // Check current index
   load.setCurrentFileIndex(1).loadFile();
-  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileInfo);
+  load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
   if (filePath != dragon)
   {
     std::cerr << "Unexpected file loaded on LOAD_CURRENT after setCurrentFileIndex: " << filePath

--- a/library/testing/TestSDKLoader.cxx
+++ b/library/testing/TestSDKLoader.cxx
@@ -44,7 +44,7 @@ int TestSDKLoader(int argc, char* argv[])
 
   load.addFile(dummy).addFile(cow).addFiles(filesVec);
   load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
-  if (filePath != cow)
+  if (filePath != cow || fileName != cowFilename)
   {
     std::cerr << "Unexpected file loaded on LOAD_CURRENT: " << filePath << std::endl;
     return EXIT_FAILURE;
@@ -57,7 +57,7 @@ int TestSDKLoader(int argc, char* argv[])
 
   load.loadFile(f3d::loader::LoadFileEnum::LOAD_LAST);
   load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
-  if (filePath != suzanne)
+  if (filePath != suzanne || fileName != suzanneFilename)
   {
     std::cerr << "Unexpected file loaded on LOAD_LAST: " << filePath << std::endl;
     return EXIT_FAILURE;
@@ -65,7 +65,7 @@ int TestSDKLoader(int argc, char* argv[])
 
   load.loadFile(f3d::loader::LoadFileEnum::LOAD_FIRST);
   load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
-  if (filePath != cow)
+  if (filePath != cow || fileName != cowFilename)
   {
     std::cerr << "Unexpected file loaded on LOAD_FIRST: " << filePath << std::endl;
     return EXIT_FAILURE;
@@ -73,7 +73,7 @@ int TestSDKLoader(int argc, char* argv[])
 
   load.loadFile(f3d::loader::LoadFileEnum::LOAD_NEXT);
   load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
-  if (filePath != dragon)
+  if (filePath != dragon || fileName != dragonFilename)
   {
     std::cerr << "Unexpected file loaded on LOAD_NEXT: " << filePath << std::endl;
     return EXIT_FAILURE;
@@ -81,7 +81,7 @@ int TestSDKLoader(int argc, char* argv[])
 
   load.loadFile(f3d::loader::LoadFileEnum::LOAD_NEXT);
   load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
-  if (filePath != suzanne)
+  if (filePath != suzanne || fileName != suzanneFilename)
   {
     std::cerr << "Unexpected file loaded on second LOAD_NEXT: " << filePath << std::endl;
     return EXIT_FAILURE;
@@ -97,7 +97,7 @@ int TestSDKLoader(int argc, char* argv[])
   // Check current index
   load.setCurrentFileIndex(1).loadFile();
   load.getFileInfo(f3d::loader::LoadFileEnum::LOAD_CURRENT, idx, filePath, fileName, fileInfo);
-  if (filePath != dragon)
+  if (filePath != dragon || fileName != dragonFilename)
   {
     std::cerr << "Unexpected file loaded on LOAD_CURRENT after setCurrentFileIndex: " << filePath
               << std::endl;


### PR DESCRIPTION
Proposal to have the window title change from `F3D - Fast and minimalist 3D viewer` to `model.ext - F3D` when `~/foo/bar/model.ext` is loaded.

This PR currently appends `F3D::AppName` which makes the title `model.ext - f3d` (lower case `f3d`) and needs further changes but I don't know what the best way to do that would be (can we just upper-case `AppName` to `F3D`? do we need a new variable?)