### PR TITLE
Free memory allocated by CommandLineToArgvW

### DIFF
--- a/application/main.cxx
+++ b/application/main.cxx
@@ -59,6 +59,8 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
     argv[i][mbs.size()] = 0;
   }
 
+  LocalFree(wargv);
+
   int rc = main(argc, argv);
 
   for (int i = 0; i < argc; i++)


### PR DESCRIPTION
According to [CommandLineToArgvW](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw):

> CommandLineToArgvW allocates a block of contiguous memory for pointers to the argument strings, and for the argument strings themselves; the calling application must free the memory used by the argument list when it is no longer needed. To free the memory, use a single call to the [LocalFree](https://learn.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-localfree) function.