### PR TITLE
Grid improvements

### DIFF
--- a/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.cxx
@@ -11,7 +11,6 @@
 #include <vtkRenderer.h>
 #include <vtkShaderProgram.h>
 #include <vtkVersion.h>
-
 vtkStandardNewMacro(vtkF3DOpenGLGridMapper);
 
 //----------------------------------------------------------------------------
@@ -27,6 +26,7 @@ void vtkF3DOpenGLGridMapper::PrintSelf(ostream& os, vtkIndent indent)
   this->Superclass::PrintSelf(os, indent);
   os << indent << "FadeDistance: " << this->FadeDistance << "\n";
   os << indent << "UnitSquare: " << this->UnitSquare << "\n";
+  os << indent << "MinorSquare: " << this->MinorSquares << "\n";
   os << indent << "UpIndex: " << this->UpIndex << "\n";
 }
 
@@ -39,57 +39,68 @@ void vtkF3DOpenGLGridMapper::ReplaceShaderValues(
   std::string VSSource = shaders[vtkShader::Vertex]->GetSource();
   std::string FSSource = shaders[vtkShader::Fragment]->GetSource();
 
-  vtkShaderProgram::Substitute(
-    VSSource, "//VTK::PositionVC::Dec", "out vec4 positionMCVSOutput;\n");
+  const std::string axes = this->UpIndex == 0 ? "zyx" : this->UpIndex == 1 ? "xzy" : "xyz";
 
-  vtkShaderProgram::Substitute(FSSource, "//VTK::PositionVC::Dec",
-    "in vec4 positionMCVSOutput;\n"
-    "uniform float fadeDist;\n"
-    "uniform float unitSquare;\n");
+  // clang-format off
+  vtkShaderProgram::Substitute(VSSource, "//VTK::PositionVC::Dec",
+    "uniform float fadeDist = 100.0;\n"
+    "out vec2 gridCoord;\n"
+  );
+  vtkShaderProgram::Substitute(VSSource, "//VTK::PositionVC::Impl",
+    "gridCoord = vertexMC.xy * fadeDist;\n"
+    "gl_Position = MCDCMatrix * vec4(vertexMC." + axes + " * fadeDist, 1.0);\n"
+  );
+  
+  vtkShaderProgram::Substitute(FSSource, "//VTK::CustomUniforms::Dec",
+    "uniform float fadeDist = 100.0;\n"
+    "uniform float unitSquare = 10.0;\n"
+    "uniform int minorSquares = 1;\n"
+    "uniform float axesLineWidth = 1.0;\n"
+    "uniform float gridLineWidth = 1.0;\n"
+    "uniform float minorOpacity = 0.5;\n"
+    "uniform float lineAntialias = 1.0;\n"
+    "uniform vec4 axis1Color = vec4(1., 1., 1., 1.);\n"
+    "uniform vec4 axis2Color = vec4(1., 1., 1., 1.);\n"
+    "in vec2 gridCoord;\n"
 
-  std::string posImpl;
-  std::string uniformImpl;
+    "float antialias(float dist, float linewidth){\n"
+    "  float aa = lineAntialias;\n"
+    "  float lw = max(linewidth, 1.0) / 2;\n"
+    "  float alpha = min(linewidth, 1.0);\n"
+    "  float d = dist - lw;\n"
+    "  return d < .0 ? alpha\n"
+    "       : d < aa ? (1 - d / aa) * alpha\n"
+    "       : 0.0;\n"
+    "}\n"
+  );
+  vtkShaderProgram::Substitute(FSSource, "//VTK::UniformFlow::Impl",
+    "  vec2 majorCoord = gridCoord / unitSquare;\n"
+    "  vec2 minorCoord = majorCoord * minorSquares;\n"
+    "  vec2 majorGrid = abs(fract(majorCoord - 0.5) - 0.5) / fwidth(majorCoord);\n"
+    "  vec2 minorGrid = abs(fract(minorCoord - 0.5) - 0.5) / fwidth(minorCoord);\n"
+  );
+  vtkShaderProgram::Substitute(FSSource, "//VTK::Color::Impl",
+    "  float majorAlpha = antialias(min(majorGrid.x, majorGrid.y), gridLineWidth);\n"
+    "  float minorAlpha = antialias(min(minorGrid.x, minorGrid.y), gridLineWidth);\n"
+    "  float zoomFadeFactor = 1.0 - clamp(fwidth(majorCoord.x / unitSquare * fadeDist), 0.0, 1.0);"
+    "  float alpha = max(majorAlpha, minorAlpha * minorOpacity * zoomFadeFactor);\n"
+    "  vec4 color = vec4(diffuseColorUniform, alpha);\n"
 
-  std::string colorImpl =
-    "  float line = min(grid.x, grid.y);\n"
-    "  float dist2 = unitSquare * unitSquare * (coord.x * coord.x + coord.y * coord.y);\n"
-    "  float opacity = (1.0 - min(line, 1.0)) * (1.0 - dist2 / (fadeDist * fadeDist));\n"
-    "  vec3 color = diffuseColorUniform;\n";
+    "  float axis1Weight = abs(majorCoord.y) < 0.5 ? antialias(majorGrid.y, axesLineWidth) : 0.0;\n"
+    "  float axis2Weight = abs(majorCoord.x) < 0.5 ? antialias(majorGrid.x, axesLineWidth) : 0.0;\n"
+    "  color = mix(color, axis2Color, axis2Weight);\n"
+    "  color = mix(color, axis1Color, axis1Weight);\n"
 
-  switch (this->UpIndex)
-  {
-    case 0:
-      posImpl += "positionMCVSOutput = vec4(0.0, vertexMC.x, vertexMC.y, 1.0);\n";
-      uniformImpl +=
-        "  vec2 coord = positionMCVSOutput.yz / (unitSquare * positionMCVSOutput.w);\n";
-      colorImpl += "  if (abs(coord.x) < 0.1 && grid.y != line) color = vec3(0.0, 0.0, 1.0);\n"
-                   "  if (abs(coord.y) < 0.1 && grid.x != line) color = vec3(0.0, 1.0, 0.0);\n";
-      break;
-    case 1:
-      posImpl += "positionMCVSOutput = vec4(vertexMC.x, 0.0, vertexMC.y, 1.0);\n";
-      uniformImpl +=
-        "  vec2 coord = positionMCVSOutput.xz / (unitSquare * positionMCVSOutput.w);\n";
-      colorImpl += "  if (abs(coord.x) < 0.1 && grid.y != line) color = vec3(0.0, 0.0, 1.0);\n"
-                   "  if (abs(coord.y) < 0.1 && grid.x != line) color = vec3(1.0, 0.0, 0.0);\n";
-      break;
-    case 2:
-      posImpl += "positionMCVSOutput = vec4(vertexMC.x, vertexMC.y, 0.0, 1.0);\n";
-      uniformImpl +=
-        "  vec2 coord = positionMCVSOutput.xy / (unitSquare * positionMCVSOutput.w);\n";
-      colorImpl += "  if (abs(coord.x) < 0.1 && grid.y != line) color = vec3(0.0, 1.0, 0.0);\n"
-                   "  if (abs(coord.y) < 0.1 && grid.x != line) color = vec3(1.0, 0.0, 0.0);\n";
-      break;
-  }
-  posImpl += "gl_Position = MCDCMatrix * positionMCVSOutput;\n";
-  uniformImpl += "  vec2 grid = abs(fract(coord - 0.5) - 0.5) / fwidth(coord);\n";
-  colorImpl += "  gl_FragData[0] = vec4(color, opacity);\n";
+    "  float sqDist = unitSquare * unitSquare * dot(majorCoord, majorCoord);\n"
+    "  float radialFadeFactor = 1.0 - sqDist / (fadeDist * fadeDist);\n"
+    "  color.w *= radialFadeFactor;\n"
 
-  vtkShaderProgram::Substitute(VSSource, "//VTK::PositionVC::Impl", posImpl);
-  vtkShaderProgram::Substitute(FSSource, "  //VTK::UniformFlow::Impl", uniformImpl);
-  vtkShaderProgram::Substitute(FSSource, "  //VTK::Color::Impl", colorImpl);
+    "  gl_FragData[0] = color;\n"
+  );
+  // clang-format on
 
-  shaders[vtkShader::Vertex]->SetSource(VSSource);
   shaders[vtkShader::Fragment]->SetSource(FSSource);
+  shaders[vtkShader::Vertex]->SetSource(VSSource);
 
   // add camera uniforms declaration
   this->ReplaceShaderPositionVC(shaders, ren, actor);
@@ -133,6 +144,31 @@ void vtkF3DOpenGLGridMapper::SetMapperShaderParameters(
 
   cellBO.Program->SetUniformf("fadeDist", this->FadeDistance);
   cellBO.Program->SetUniformf("unitSquare", this->UnitSquare);
+  cellBO.Program->SetUniformi("minorSquares", this->MinorSquares);
+  cellBO.Program->SetUniformf("axesLineWidth", 0.8);
+  cellBO.Program->SetUniformf("gridLineWidth", 0.6);
+  cellBO.Program->SetUniformf("minorOpacity", 0.5);
+  cellBO.Program->SetUniformf("lineAntialias", 1);
+
+  const float xColor[4] = { 1, 0, 0, 1 };
+  const float yColor[4] = { 0, 1, 0, 1 };
+  const float zColor[4] = { 0, 0, 1, 1 };
+  switch (this->UpIndex)
+  {
+    case 0:
+      cellBO.Program->SetUniform4f("axis1Color", zColor);
+      cellBO.Program->SetUniform4f("axis2Color", yColor);
+      break;
+    case 1:
+      cellBO.Program->SetUniform4f("axis1Color", xColor);
+      cellBO.Program->SetUniform4f("axis2Color", zColor);
+      break;
+    case 2:
+    default:
+      cellBO.Program->SetUniform4f("axis1Color", xColor);
+      cellBO.Program->SetUniform4f("axis2Color", yColor);
+      break;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -142,11 +178,10 @@ void vtkF3DOpenGLGridMapper::BuildBufferObjects(vtkRenderer* ren, vtkActor* vtkN
   infinitePlane->SetNumberOfComponents(2);
   infinitePlane->SetNumberOfTuples(4);
 
-  float d = static_cast<float>(this->FadeDistance);
-  float corner1[] = { -d, -d };
-  float corner2[] = { d, -d };
-  float corner3[] = { -d, d };
-  float corner4[] = { d, d };
+  float corner1[] = { -1, -1 };
+  float corner2[] = { +1, -1 };
+  float corner3[] = { -1, +1 };
+  float corner4[] = { +1, +1 };
 
   infinitePlane->SetTuple(0, corner1);
   infinitePlane->SetTuple(1, corner2);
@@ -168,7 +203,7 @@ void vtkF3DOpenGLGridMapper::BuildBufferObjects(vtkRenderer* ren, vtkActor* vtkN
 double* vtkF3DOpenGLGridMapper::GetBounds()
 {
   this->Bounds[0] = this->Bounds[2] = this->Bounds[4] = -this->FadeDistance;
-  this->Bounds[1] = this->Bounds[3] = this->Bounds[5] = this->FadeDistance;
+  this->Bounds[1] = this->Bounds[3] = this->Bounds[5] = +this->FadeDistance;
   return this->Bounds;
 }
 

--- a/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.cxx
@@ -11,6 +11,7 @@
 #include <vtkRenderer.h>
 #include <vtkShaderProgram.h>
 #include <vtkVersion.h>
+
 vtkStandardNewMacro(vtkF3DOpenGLGridMapper);
 
 //----------------------------------------------------------------------------

--- a/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.h
+++ b/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.h
@@ -17,33 +17,25 @@ public:
   vtkTypeMacro(vtkF3DOpenGLGridMapper, vtkOpenGLPolyDataMapper);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  ///@{
   /**
    * Set the distance where the grid disappear.
    */
   vtkSetMacro(FadeDistance, double);
-  ///@}
 
-  ///@{
   /**
    * Set the size of a square on the grid.
    */
   vtkSetMacro(UnitSquare, double);
-  ///@}
 
-  ///@{
   /**
    * Set the number of minor lines per square on the grid.
    */
-  vtkSetMacro(MinorSquares, double);
-  ///@}
+  vtkSetMacro(MinorSquares, int);
 
-  ///@{
   /**
    * Set the up vector index (X, Y, Z axis respectively).
    */
   vtkSetClampMacro(UpIndex, int, 0, 2);
-  ///@}
 
   using vtkOpenGLPolyDataMapper::GetBounds;
   double* GetBounds() override;

--- a/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.h
+++ b/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.h
@@ -33,6 +33,13 @@ public:
 
   ///@{
   /**
+   * Set the number of minor lines per square on the grid.
+   */
+  vtkSetMacro(MinorSquares, double);
+  ///@}
+
+  ///@{
+  /**
    * Set the up vector index (X, Y, Z axis respectively).
    */
   vtkSetClampMacro(UpIndex, int, 0, 2);
@@ -59,6 +66,7 @@ protected:
 
   double FadeDistance = 10.0;
   double UnitSquare = 1.0;
+  int MinorSquares = 10;
   int UpIndex = 1;
 
 private:

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -390,7 +390,7 @@ void vtkF3DRenderer::ShowGrid(bool show)
       vtkNew<vtkF3DOpenGLGridMapper> gridMapper;
       gridMapper->SetFadeDistance(diag);
       gridMapper->SetUnitSquare(unitSquare);
-      gridMapper->SetMinorSquare(10);
+      gridMapper->SetMinorSquares(10);
       gridMapper->SetUpIndex(this->UpIndex);
 
       this->GridActor->GetProperty()->SetColor(0.0, 0.0, 0.0);

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -390,6 +390,7 @@ void vtkF3DRenderer::ShowGrid(bool show)
       vtkNew<vtkF3DOpenGLGridMapper> gridMapper;
       gridMapper->SetFadeDistance(diag);
       gridMapper->SetUnitSquare(unitSquare);
+      gridMapper->SetMinorSquare(10);
       gridMapper->SetUpIndex(this->UpIndex);
 
       this->GridActor->GetProperty()->SetColor(0.0, 0.0, 0.0);

--- a/testing/baselines/TestDefaultConfigFile.png
+++ b/testing/baselines/TestDefaultConfigFile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81d21fa0c9ba884ffc6bfbb61dfddacbce408957bee366a62805c3e1b25a7035
-size 40347
+oid sha256:16708a1f2ddf56aaea82dcc6eab5d8f30bf9bad2fe0d8bf5d62ce35c22abb3ee
+size 36932

--- a/testing/baselines/TestDefaultConfigFileAndCommand.png
+++ b/testing/baselines/TestDefaultConfigFileAndCommand.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:553f956b47aa6845135f53ca96b05fa101bd7144bf2a71294bca51b8355a5f80
-size 23434
+oid sha256:b8ffead8544781d72359c021ecc3a94acafbf28bb2daf44aa5e314b7b07825e1
+size 24980

--- a/testing/baselines/TestDefaultConfigFileAnotherBlock.png
+++ b/testing/baselines/TestDefaultConfigFileAnotherBlock.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e6c8070c685ae84d891aad133cf30965037a16f1b267257f1a0611c3cb6dd39
-size 35234
+oid sha256:1847ebe8da863b8fcd963fb8ae9bb4c0d20b458a3a6dbad9712673c20763782d
+size 31992

--- a/testing/baselines/TestDefaultConfigFileUp.png
+++ b/testing/baselines/TestDefaultConfigFileUp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa082fce928dec97bd5699b4dac990255c4ea6023fcdac9e68be9422b1446d79
-size 23243
+oid sha256:1a97ab821e16da516295d76b15495ae4753d750332c2a9c95c09f88eccbd8abd
+size 24888

--- a/testing/baselines/TestGridWithDepthPeeling.png
+++ b/testing/baselines/TestGridWithDepthPeeling.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc45fb07158d25ded73240834acfc8777957f958a43687b1af0fce771b44efb1
-size 14605
+oid sha256:e9357ab40c5bb8855e8da7f20552c85357c2f8018c81f3e8db8b2bc2bf7170bb
+size 15395

--- a/testing/baselines/TestGridX.png
+++ b/testing/baselines/TestGridX.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d5ee6140d9a0498afce3a432005bff05a27fd8c3af121452ff37423f8ae226bc
-size 18960
+oid sha256:ba062fb1805ac51896f4c8074bc7918de80820554781d2ba818efefa5bdb1574
+size 20336

--- a/testing/baselines/TestGridY.png
+++ b/testing/baselines/TestGridY.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:019bfc6c65a4b5be99c17bb7b55b7cdfe96498ae119d14eda8c19505c5ce5de4
-size 22923
+oid sha256:2a947b3ebeee4c12a386f765dc6a6ce202c95f8de35ebf45ed454c40a773794a
+size 23625

--- a/testing/baselines/TestGridZ.png
+++ b/testing/baselines/TestGridZ.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e243849832d9611f5fd5ddc6854aad56305387cb2a4d41741998dbce3cf256ac
-size 15631
+oid sha256:e2ed3a5edef57fd59092f8d0eccf6415d9291c60aed06b2fb9714de81f5a105b
+size 16256

--- a/testing/baselines/TestInteractionActors.png
+++ b/testing/baselines/TestInteractionActors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb3b4ecdabc0839e61bf026e2a9bda4b6f4144e27f641c5bab8c4d59ac6050b4
-size 52128
+oid sha256:9af160d338ec41ab23df2bcacec161ce1081cff1f53aa26e45700ac6acc35155
+size 51694

--- a/testing/baselines/TestInteractionConfigFileAndCommand.png
+++ b/testing/baselines/TestInteractionConfigFileAndCommand.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbe7422f8742afbf9aa77c2aa9bbf6b28fe56f6ecd7fcc43638a873d7bd14d21
-size 22870
+oid sha256:71bdd4ba1bf3a7bd36641ee67e25c1ceeecf4000e5eb316ae210f0573027ebc5
+size 23768

--- a/testing/baselines/TestInteractionConfigFileMulti.png
+++ b/testing/baselines/TestInteractionConfigFileMulti.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4660190f498cfde5331adde572c8b431665ac7efc26b23df58df9a33af9338cd
-size 22185
+oid sha256:60e1c10893c78b7321240d9845ea5f6f38483e6c167a6ff2b71e2a83571cde6e
+size 23027


### PR DESCRIPTION
Some grid shader refactoring and improvements:
- untangled shader code generation (less branching, hopefully easier to follow)
- added grid subdivisions
- improved rendering details (line width/opacity, line overlaps), or at least made them configurable (passed through uniforms) for further tweaking

Comparison pictures, old vs new without AA:
![a-ssao-master](https://user-images.githubusercontent.com/489715/221092151-4b2c5eb0-5e19-4e0f-b772-ad89feeddd77.png)
![a-ssao-wip](https://user-images.githubusercontent.com/489715/221092162-1ae6192e-a720-43ad-a8ca-ee2c2f8179ea.png)

old vs new with AA and tone mapping:
![a-ssao,fxaa,tone-master](https://user-images.githubusercontent.com/489715/221092203-115e774a-3c48-4778-ad3f-5ae24758e688.png)
![a-ssao,fxaa,tone-wip](https://user-images.githubusercontent.com/489715/221092211-e8e34e2e-75ca-449f-91e7-1cdc6beff52a.png)

If you guys could run it and let me know what you think that'd be great.

Questions/notes:
- do we really need all the ugly `\n`s in the glsl code we pass to `vtkShaderProgram::Substitute`?
- the number of subdivisions should be user-configurable but that could be a later PR where we also make the unit square size user-configurable too