### PR TITLE
Fix a leak with HDRI caching

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -237,6 +237,7 @@ endif()
 # HDRI test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9767
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20221220)
   f3d_test(NAME TestHDRI HDRI DATA suzanne.ply ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
+  f3d_test(NAME TestHDRICache HDRI DATA suzanne.ply ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEPENDS TestHDRI DEFAULT_LIGHTS)
   f3d_test(NAME TestHDRIBlur HDRI DATA suzanne.ply ARGS -u --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
   f3d_test(NAME TestHDRIBlurCoC HDRI DATA suzanne.ply ARGS -u --blur-coc=50 --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
   f3d_test(NAME TestHDRIBlurRatio HDRI DATA suzanne.ply RESOLUTION 600,100 ARGS -u --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -107,6 +107,7 @@ vtkSmartPointer<vtkImageData> SaveTextureToImage(
     vtkPixelBufferObject* pbo = tex->Download(target + i, level);
 
     pbo->Download2D(type, img->GetScalarPointer(0, 0, i), dims, tex->GetComponents(), incr);
+    pbo->Delete();
   }
 
   return img;

--- a/library/testing/TestSDKDynamicHDRI.cxx
+++ b/library/testing/TestSDKDynamicHDRI.cxx
@@ -6,10 +6,18 @@
 
 #include "TestSDKHelpers.h"
 
+#include <random>
+
 int TestSDKDynamicHDRI(int argc, char* argv[])
 {
+  // Generate a random number to avoid reusing any existing cache
+  std::random_device r;
+  std::default_random_engine e1(r());
+  std::uniform_int_distribution<int> dist(1, 100000);
+  std::string cachePath = std::string(argv[2]) + "/cache_" + std::to_string(dist(e1));
+
   f3d::engine eng(f3d::window::Type::NATIVE_OFFSCREEN);
-  eng.setCachePath(std::string(argv[2]) + "/cache");
+  eng.setCachePath(cachePath);
 
   f3d::loader& load = eng.getLoader();
   f3d::window& win = eng.getWindow();
@@ -40,7 +48,7 @@ int TestSDKDynamicHDRI(int argc, char* argv[])
   }
 
   // Check caching is working
-  std::ifstream lutFile(std::string(argv[2]) + "/cache/lut.vti");
+  std::ifstream lutFile(cachePath + "/lut.vti");
 
   if (!lutFile.is_open())
   {

--- a/testing/baselines/TestHDRICache.png
+++ b/testing/baselines/TestHDRICache.png
@@ -1,0 +1,1 @@
+TestHDRI.png


### PR DESCRIPTION
- Fix a leak with HDRI caching and improve testing so that such leak will be catched in the future
- Add an explicit  TestHDRICache