### PR TITLE
Fixup macOS config

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -85,14 +85,6 @@ list(APPEND f3d_link_options_public ${f3d_sanitizer_link_options})
 if(F3D_MACOS_BUNDLE)
   set_target_properties(f3d PROPERTIES MACOSX_BUNDLE TRUE)
 
-  # Add default configuration
-  if(F3D_INSTALL_DEFAULT_CONFIGURATION_FILE)
-    set(f3d_CONFIG ${CMAKE_SOURCE_DIR}/resources/configs)
-    set_source_files_properties(${f3d_CONFIG} PROPERTIES
-      MACOSX_PACKAGE_LOCATION "Resources")
-    target_sources(f3d PRIVATE ${f3d_CONFIG})
-  endif()
-
   # Add logo icon
   set(MACOSX_BUNDLE_ICON_FILE logo.icns)
   set(f3d_ICON ${CMAKE_SOURCE_DIR}/resources/logo.icns)

--- a/application/F3DConfigFileTools.cxx
+++ b/application/F3DConfigFileTools.cxx
@@ -88,7 +88,7 @@ fs::path F3DConfigFileTools::GetBinaryConfigFileDirectory()
 
     // Add binary specific paths
 #if F3D_MACOS_BUNDLE
-    dirPath /= "Resources";
+    dirPath /= "Resources/configs";
 #else
     dirPath /= "share/f3d/configs";
 #endif

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Shared resources dir
 set(f3d_resources_dir "share/f3d")
+if (F3D_MACOS_BUNDLE)
+  set(f3d_resources_dir "f3d.app/Contents/Resources")
+endif()
 set(f3d_configs_dir "${f3d_resources_dir}/configs")
 if (UNIX AND NOT APPLE)
   if (F3D_INSTALL_DEFAULT_CONFIGURATION_FILE AND NOT F3D_LINUX_INSTALL_DEFAULT_CONFIGURATION_FILE_IN_PREFIX)
@@ -9,10 +12,8 @@ endif()
 
 # Default config files
 if (F3D_INSTALL_DEFAULT_CONFIGURATION_FILE)
-  if(NOT APPLE OR NOT F3D_MACOS_BUNDLE) # MacOS Bundle config file is handled in the bundle directly
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/configs/"
-      DESTINATION "${f3d_configs_dir}" COMPONENT configuration)
-  endif()
+  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/configs/"
+    DESTINATION "${f3d_configs_dir}" COMPONENT configuration)
 endif()
 
 # Other ressoure files


### PR DESCRIPTION
Config used be handled in the macOS bundle directly. Now directly install them instead for simplicity sake.

Tested locally in my macOS VM with the installed F3D.