### PR TITLE
Fix config mechanism when no file is provided

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -369,8 +369,13 @@ void F3DStarter::LoadFile(int index, bool relativeIndex)
   }
   else
   {
+    f3d::log::info("No file to load provided.");
     filenameInfo = "No file to load provided, please drop one into this window";
     this->Internals->CurrentFileIndex = -1;
+
+    // Copy dynamic options into files options to get the global config
+    this->Internals->FileOptions = this->Internals->DynamicOptions;
+    this->Internals->Engine->setOptions(this->Internals->FileOptions);
   }
 
   if (this->Internals->CurrentFileIndex >= 0)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -496,6 +496,9 @@ f3d_test(NAME TestInvalidConfigFile DATA cow.vtp CONFIG ${CMAKE_SOURCE_DIR}/test
 # Test quiet in config file
 f3d_test(NAME TestConfigFileQuiet DATA nonExistentFile.vtp CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/quiet.json REGEXP_FAIL "File .*/testing/data/nonExistentFile.vtp does not exist" NO_RENDER)
 
+# Test no file with config file
+f3d_test(NAME TestNoFileConfigFile CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/verbose.json REGEXP "No file to load provided." NO_BASELINE)
+
 # Test help display
 f3d_test(NAME TestHelp ARGS --help REGEXP "Usage:")
 

--- a/testing/configs/verbose.json
+++ b/testing/configs/verbose.json
@@ -1,0 +1,6 @@
+{
+  "global":
+  {
+    "verbose": true
+  }
+}


### PR DESCRIPTION
- Set options when no file is provided
- Add a log
- Add a log test, however there is no way to test the option are actually set as we cant render to a png without a loaded file