### PR TITLE
Keep camera on reload

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -144,7 +144,8 @@ int F3DStarter::Start(int argc, char** argv)
         f3d::camera& cam = this->Internals->Engine->getWindow().getCamera();
         const auto camState = cam.saveState();
         this->LoadFile(index, true);
-        cam.restoreState(camState, true);
+        cam.restoreState(camState);
+        cam.deleteState(camState);
       }
       else
       {

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -135,29 +135,40 @@ int F3DStarter::Start(int argc, char** argv)
     f3d::window& window = this->Internals->Engine->getWindow();
     f3d::interactor& interactor = this->Internals->Engine->getInteractor();
 
+    const auto loadFile = [this](int index, bool restoreCamera = false) -> bool
+    {
+      this->Internals->Engine->getInteractor().stopAnimation();
+
+      if (restoreCamera)
+      {
+        f3d::camera& cam = this->Internals->Engine->getWindow().getCamera();
+        const auto camState = cam.saveState();
+        this->LoadFile(index, true);
+        cam.restoreState(camState, true);
+      }
+      else
+      {
+        this->LoadFile(index, true);
+      }
+
+      this->Render();
+      return true;
+    };
+
     interactor.setKeyPressCallBack(
-      [this](int, std::string keySym) -> bool
+      [this, loadFile, &interactor](int, std::string keySym) -> bool
       {
         if (keySym == "Left")
         {
-          this->Internals->Engine->getInteractor().stopAnimation();
-          this->LoadFile(-1, true);
-          this->Render();
-          return true;
+          return loadFile(-1);
         }
         else if (keySym == "Right")
         {
-          this->Internals->Engine->getInteractor().stopAnimation();
-          this->LoadFile(1, true);
-          this->Render();
-          return true;
+          return loadFile(+1);
         }
         else if (keySym == "Up")
         {
-          this->Internals->Engine->getInteractor().stopAnimation();
-          this->LoadFile(0, true);
-          this->Render();
-          return true;
+          return loadFile(0, true); // TODO decide how to control whether we restore the camera
         }
         else if (keySym == "Down")
         {
@@ -168,12 +179,14 @@ int F3DStarter::Start(int argc, char** argv)
               this->Internals->FilesList[static_cast<size_t>(this->Internals->CurrentFileIndex)]
                 .parent_path(),
               true);
-            this->LoadFile(0, true);
-            this->Render();
+            return loadFile(0);
           }
           return true;
         }
-        return false;
+        else
+        {
+          return false;
+        }
       });
 
     interactor.setDropFilesCallBack(

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -145,7 +145,7 @@ int F3DStarter::Start(int argc, char** argv)
         const auto camState = cam.saveState();
         this->LoadFile(index, true);
         cam.restoreState(camState);
-        cam.deleteState(camState);
+        delete camState;
       }
       else
       {

--- a/library/private/camera_impl.h
+++ b/library/private/camera_impl.h
@@ -60,7 +60,8 @@ public:
   camera& resetToBounds() override;
 
   CameraStateKey saveState() override;
-  bool restoreState(const CameraStateKey&, bool remove) override;
+  bool restoreState(const CameraStateKey&) override;
+  bool deleteState(const CameraStateKey&) override;
   ///@}
 
   /**

--- a/library/private/camera_impl.h
+++ b/library/private/camera_impl.h
@@ -58,6 +58,9 @@ public:
   camera& setCurrentAsDefault() override;
   camera& resetToDefault() override;
   camera& resetToBounds() override;
+
+  CameraStateKey saveState() override;
+  bool restoreState(const CameraStateKey&, bool remove) override;
   ///@}
 
   /**

--- a/library/private/camera_impl.h
+++ b/library/private/camera_impl.h
@@ -12,12 +12,21 @@
 
 #include "camera.h"
 
+#include <vtkCamera.h>
+
 #include <memory>
 
 class vtkRenderer;
 class vtkCamera;
 namespace f3d::detail
 {
+class cameraState_impl : public cameraState
+{
+public:
+  vtkNew<vtkCamera> Camera;
+  cameraState_impl(vtkCamera* vtkCamera) { this->Camera->DeepCopy(vtkCamera); }
+};
+
 class camera_impl : public camera
 {
 public:
@@ -59,9 +68,8 @@ public:
   camera& resetToDefault() override;
   camera& resetToBounds() override;
 
-  CameraStateKey saveState() override;
-  bool restoreState(const CameraStateKey&) override;
-  bool deleteState(const CameraStateKey&) override;
+  cameraState* saveState() override;
+  void restoreState(const cameraState*) override;
   ///@}
 
   /**

--- a/library/public/camera.h
+++ b/library/public/camera.h
@@ -71,7 +71,7 @@ public:
   virtual camera& resetToBounds() = 0;
 
   virtual CameraStateKey saveState() = 0;
-  virtual bool restoreState(const CameraStateKey&, bool remove=false) = 0;
+  virtual bool restoreState(const CameraStateKey&, bool remove = false) = 0;
 
 protected:
   //! @cond

--- a/library/public/camera.h
+++ b/library/public/camera.h
@@ -9,6 +9,8 @@
 
 namespace f3d
 {
+typedef uint CameraStateKey;
+
 /**
  * @class   camera
  * @brief   Abstract class to control a camera in a window
@@ -67,6 +69,9 @@ public:
    * Reset the camera using the bounds of actors in the scene.
    */
   virtual camera& resetToBounds() = 0;
+
+  virtual CameraStateKey saveState() = 0;
+  virtual bool restoreState(const CameraStateKey&, bool remove=false) = 0;
 
 protected:
   //! @cond

--- a/library/public/camera.h
+++ b/library/public/camera.h
@@ -9,7 +9,11 @@
 
 namespace f3d
 {
-typedef uint CameraStateKey;
+class F3D_EXPORT cameraState
+{
+public:
+  virtual ~cameraState() = default;
+};
 
 /**
  * @class   camera
@@ -70,9 +74,8 @@ public:
    */
   virtual camera& resetToBounds() = 0;
 
-  virtual CameraStateKey saveState() = 0;
-  virtual bool restoreState(const CameraStateKey&) = 0;
-  virtual bool deleteState(const CameraStateKey&) = 0;
+  virtual cameraState* saveState() = 0;
+  virtual void restoreState(const cameraState*) = 0;
 
 protected:
   //! @cond

--- a/library/public/camera.h
+++ b/library/public/camera.h
@@ -71,7 +71,8 @@ public:
   virtual camera& resetToBounds() = 0;
 
   virtual CameraStateKey saveState() = 0;
-  virtual bool restoreState(const CameraStateKey&, bool remove = false) = 0;
+  virtual bool restoreState(const CameraStateKey&) = 0;
+  virtual bool deleteState(const CameraStateKey&) = 0;
 
 protected:
   //! @cond

--- a/library/src/camera_impl.cxx
+++ b/library/src/camera_impl.cxx
@@ -221,6 +221,7 @@ vtkCamera* camera_impl::GetVTKCamera()
   return this->Internals->VTKRenderer->GetActiveCamera();
 }
 
+//----------------------------------------------------------------------------
 cameraState* camera_impl::saveState()
 {
   return new cameraState_impl(this->GetVTKCamera());

--- a/library/src/camera_impl.cxx
+++ b/library/src/camera_impl.cxx
@@ -235,20 +235,22 @@ CameraStateKey camera_impl::saveState()
 }
 
 //----------------------------------------------------------------------------
-bool camera_impl::restoreState(const CameraStateKey& key, bool remove)
+bool camera_impl::restoreState(const CameraStateKey& key)
 {
   if (this->Internals->SavedStates.count(key))
   {
     this->GetVTKCamera()->DeepCopy(this->Internals->SavedStates[key]);
-    if (remove)
-    {
-      this->Internals->SavedStates.erase(key);
-    }
     return true;
   }
   else
   {
     return false;
   }
+}
+
+//----------------------------------------------------------------------------
+bool camera_impl::deleteState(const CameraStateKey& key)
+{
+  return this->Internals->SavedStates.erase(key) > 0;
 }
 };


### PR DESCRIPTION
Felt bad opening an issue without at least looking into it a bit so here's an attempt at reloading the current file without resetting the camera.

The use case is:
1. loading a procedural or otherwise generated model, navigating around
2. externally regenerating the model
3. reloading the model in F3D keeping the current view.

This implementation is based on what's been discussed on Discord:
1. adding a mechanism to save and restore camera states by key. I feel like this would be better using opaque state objects but I could not get it to work :(
2. saving the camera state before reloading, restoring afterwards before the next render

I don't know if this behaviour should be the default or not?
If not, `shift+up` could be used, but do we have access to modifiers in interactor callbacks?
The type of model/scene could also play a role maybe (eg. only reset the camera if the file defines cameras)?