### PR TITLE
make `AddFile` return index

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -180,11 +180,15 @@ int F3DStarter::Start(int argc, char** argv)
       [this](std::vector<std::string> filesVec) -> bool
       {
         this->Internals->Engine->getInteractor().stopAnimation();
+        int index = -1;
         for (std::string file : filesVec)
         {
-          this->AddFile(fs::path(file));
+          index = this->AddFile(fs::path(file));
         }
-        this->LoadFile(static_cast<int>(this->Internals->FilesList.size()) - 1);
+        if (index > -1)
+        {
+          this->LoadFile(index);
+        }
         this->Render();
         return true;
       });
@@ -495,7 +499,7 @@ void F3DStarter::Render()
 }
 
 //----------------------------------------------------------------------------
-void F3DStarter::AddFile(const fs::path& path, bool quiet)
+int F3DStarter::AddFile(const fs::path& path, bool quiet)
 {
   auto tmpPath = fs::absolute(path);
   if (!fs::exists(tmpPath))
@@ -504,10 +508,9 @@ void F3DStarter::AddFile(const fs::path& path, bool quiet)
     {
       f3d::log::error("File ", tmpPath, " does not exist");
     }
-    return;
+    return -1;
   }
-
-  if (fs::is_directory(tmpPath))
+  else if (fs::is_directory(tmpPath))
   {
     std::set<fs::path> sortedPaths;
     for (const auto& entry : fs::directory_iterator(tmpPath))
@@ -519,6 +522,7 @@ void F3DStarter::AddFile(const fs::path& path, bool quiet)
       // Recursively add all files
       this->AddFile(entryPath, quiet);
     }
+    return this->Internals->FilesList.size() - 1;
   }
   else
   {
@@ -533,5 +537,6 @@ void F3DStarter::AddFile(const fs::path& path, bool quiet)
     {
       f3d::log::warn("File ", tmpPath, " has already been added");
     }
+    return std::distance(this->Internals->FilesList.begin(), it);
   }
 }

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -522,7 +522,7 @@ int F3DStarter::AddFile(const fs::path& path, bool quiet)
       // Recursively add all files
       this->AddFile(entryPath, quiet);
     }
-    return this->Internals->FilesList.size() - 1;
+    return static_cast<int>(this->Internals->FilesList.size()) - 1;
   }
   else
   {
@@ -532,11 +532,15 @@ int F3DStarter::AddFile(const fs::path& path, bool quiet)
     if (it == this->Internals->FilesList.end())
     {
       this->Internals->FilesList.push_back(tmpPath);
+      return static_cast<int>(this->Internals->FilesList.size()) - 1;
     }
-    else if (!quiet)
+    else
     {
-      f3d::log::warn("File ", tmpPath, " has already been added");
+      if (!quiet)
+      {
+        f3d::log::warn("File ", tmpPath, " has already been added");
+      }
+      return static_cast<int>(std::distance(this->Internals->FilesList.begin(), it));
     }
-    return std::distance(this->Internals->FilesList.begin(), it);
   }
 }

--- a/application/F3DStarter.h
+++ b/application/F3DStarter.h
@@ -23,7 +23,7 @@ public:
   /**
    * Add a file or directory to the list of paths
    */
-  void AddFile(const std::filesystem::path& path, bool quiet = false);
+  int AddFile(const std::filesystem::path& path, bool quiet = false);
 
   /**
    * Load a file if any have been added

--- a/testing/baselines/TestInteractionDropSameFiles.png
+++ b/testing/baselines/TestInteractionDropSameFiles.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9a295d9c71549482b01d66cef7f101d42dc421b9bc96d6c61fea7040d0e9d86
-size 22636
+oid sha256:4692812c8e071d44ad6b56ef3ae441605369a0b0674a500a5cc26adfacdba7a5
+size 18303


### PR DESCRIPTION
When loading files, F3D checks for duplicate to avoid loading them twice but always displays the last file of the unique list regardless.

Making `F3DStarter::AddFile` return the index of the last added file allows to show the last dropped file even it was already present in the list.