### PR TITLE
validate up direction string

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -174,7 +174,7 @@ f3d_test(NAME TestNoRender DATA dragon.vtu NO_RENDER)
 f3d_test(NAME TestGroupGeometries DATA mb/recursive ARGS --group-geometries DEFAULT_LIGHTS)
 f3d_test(NAME TestGroupGeometriesColoring DATA mb/recursive ARGS --group-geometries --scalars=Polynomial -b DEFAULT_LIGHTS)
 f3d_test(NAME TestInvalidUpDirection DATA suzanne.ply ARGS -g --up=W REGEXP "W is not a valid up direction" NO_BASELINE)
-f3d_test(NAME TestUpDirectionNoSign DATA suzanne.ply ARGS --up=X)
+f3d_test(NAME TestUpDirectionNoSign DATA suzanne.ply ARGS --up=X DEFAULT_LIGHTS)
 
 # Test plugin fail code path
 f3d_test(NAME TestPluginVerbose ARGS --verbose REGEXP "Loading plugin \"native\"" NO_BASELINE)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -174,6 +174,7 @@ f3d_test(NAME TestNoRender DATA dragon.vtu NO_RENDER)
 f3d_test(NAME TestGroupGeometries DATA mb/recursive ARGS --group-geometries DEFAULT_LIGHTS)
 f3d_test(NAME TestGroupGeometriesColoring DATA mb/recursive ARGS --group-geometries --scalars=Polynomial -b DEFAULT_LIGHTS)
 f3d_test(NAME TestInvalidUpDirection DATA suzanne.ply ARGS -g --up=W REGEXP "W is not a valid up direction" NO_BASELINE)
+f3d_test(NAME TestUpDirectionNoSign DATA suzanne.ply ARGS --up=X)
 
 # Test plugin fail code path
 f3d_test(NAME TestPluginVerbose ARGS --verbose REGEXP "Loading plugin \"native\"" NO_BASELINE)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -173,6 +173,7 @@ f3d_test(NAME TestComponentName DATA from_abq.vtu ARGS --scalars --bar --comp=2 
 f3d_test(NAME TestNoRender DATA dragon.vtu NO_RENDER)
 f3d_test(NAME TestGroupGeometries DATA mb/recursive ARGS --group-geometries DEFAULT_LIGHTS)
 f3d_test(NAME TestGroupGeometriesColoring DATA mb/recursive ARGS --group-geometries --scalars=Polynomial -b DEFAULT_LIGHTS)
+f3d_test(NAME TestInvalidUpDirection DATA suzanne.ply ARGS -g --up=W REGEXP "W is not a valid up direction" NO_BASELINE)
 
 # Test plugin fail code path
 f3d_test(NAME TestPluginVerbose ARGS --verbose REGEXP "Loading plugin \"native\"" NO_BASELINE)

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -194,28 +194,27 @@ void vtkF3DRenderer::Initialize(const std::string& up)
   {
     const float sign = match[1].str() == "-" ? -1.0 : +1.0;
     const int index = std::toupper(match[2].str()[0]) - 'X';
-    if (index >= 0 && index < 3)
-    {
-      this->UpIndex = index;
+    assert(index >= 0 && index < 3);
 
-      std::fill(this->UpVector, this->UpVector + 3, 0);
-      this->UpVector[this->UpIndex] = sign;
+    this->UpIndex = index;
 
-      std::fill(this->RightVector, this->RightVector + 3, 0);
-      this->RightVector[this->UpIndex == 0 ? 1 : 0] = 1.0;
+    std::fill(this->UpVector, this->UpVector + 3, 0);
+    this->UpVector[this->UpIndex] = sign;
 
-      double pos[3];
-      vtkMath::Cross(this->UpVector, this->RightVector, pos);
-      vtkMath::MultiplyScalar(pos, -1.0);
+    std::fill(this->RightVector, this->RightVector + 3, 0);
+    this->RightVector[this->UpIndex == 0 ? 1 : 0] = 1.0;
 
-      vtkCamera* cam = this->GetActiveCamera();
-      cam->SetFocalPoint(0.0, 0.0, 0.0);
-      cam->SetPosition(pos);
-      cam->SetViewUp(this->UpVector);
+    double pos[3];
+    vtkMath::Cross(this->UpVector, this->RightVector, pos);
+    vtkMath::MultiplyScalar(pos, -1.0);
 
-      this->SetEnvironmentUp(this->UpVector);
-      this->SetEnvironmentRight(this->RightVector);
-    }
+    vtkCamera* cam = this->GetActiveCamera();
+    cam->SetFocalPoint(0.0, 0.0, 0.0);
+    cam->SetPosition(pos);
+    cam->SetViewUp(this->UpVector);
+
+    this->SetEnvironmentUp(this->UpVector);
+    this->SetEnvironmentRight(this->RightVector);
   }
   else
   {

--- a/testing/baselines/TestUpDirectionNoSign.png
+++ b/testing/baselines/TestUpDirectionNoSign.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbf8a4e5c6be9d9ad5a7de5995d44f560c8f733d848619b98c4ff15654d07d96
+size 16164


### PR DESCRIPTION
Running `f3d foo.obj --up=X`, without the sign for the axis, we can observe that:

1. omitting sign does not default to positive
2. F3D does not warn/complain about `up` strings it does not expect/understand

This PR addresses both points.
