### PR TITLE
Improving default config for PLY files

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -199,7 +199,7 @@ if(NOT F3D_MACOS_BUNDLE)
   f3d_test(NAME TestDefaultConfigFileVTI DATA vase_4comp.vti CONFIG config_build DEFAULT_LIGHTS)
   f3d_test(NAME TestDefaultConfigFileSTL DATA suzanne.stl CONFIG config_build DEFAULT_LIGHTS)
   f3d_test(NAME TestDefaultConfigFileTIFF DATA logo.tif CONFIG config_build DEFAULT_LIGHTS)
-  f3d_test(NAME TestDefaultConfigFilePLY DATA cube.ply CONFIG config_build DEFAULT_LIGHTS)
+  f3d_test(NAME TestDefaultConfigFilePLY DATA cube.ply CONFIG config_build DEFAULT_LIGHTS THRESHOLD 100)
   f3d_test(NAME TestDefaultConfigFileAndCommand DATA suzanne.stl ARGS --up=-Y CONFIG config_build DEFAULT_LIGHTS)
 
   # no-background test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8501
@@ -209,7 +209,7 @@ if(NOT F3D_MACOS_BUNDLE)
     f3d_test(NAME TestThumbnailConfigFileVTI DATA vase_4comp.vti CONFIG thumbnail_build DEFAULT_LIGHTS)
     f3d_test(NAME TestThumbnailConfigFileSTL DATA suzanne.stl CONFIG thumbnail_build DEFAULT_LIGHTS)
     f3d_test(NAME TestThumbnailConfigFileTIFF DATA logo.tif CONFIG thumbnail_build DEFAULT_LIGHTS)
-    f3d_test(NAME TestThumbnailConfigFilePLY DATA cube.ply CONFIG thumbnail_build DEFAULT_LIGHTS)
+    f3d_test(NAME TestThumbnailConfigFilePLY DATA cube.ply CONFIG thumbnail_build DEFAULT_LIGHTS THRESHOLD 100)
   endif()
 endif()
 

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -199,6 +199,7 @@ if(NOT F3D_MACOS_BUNDLE)
   f3d_test(NAME TestDefaultConfigFileVTI DATA vase_4comp.vti CONFIG config_build DEFAULT_LIGHTS)
   f3d_test(NAME TestDefaultConfigFileSTL DATA suzanne.stl CONFIG config_build DEFAULT_LIGHTS)
   f3d_test(NAME TestDefaultConfigFileTIFF DATA logo.tif CONFIG config_build DEFAULT_LIGHTS)
+  f3d_test(NAME TestDefaultConfigFilePLY DATA cube.ply CONFIG config_build DEFAULT_LIGHTS)
   f3d_test(NAME TestDefaultConfigFileAndCommand DATA suzanne.stl ARGS --up=-Y CONFIG config_build DEFAULT_LIGHTS)
 
   # no-background test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8501
@@ -208,6 +209,7 @@ if(NOT F3D_MACOS_BUNDLE)
     f3d_test(NAME TestThumbnailConfigFileVTI DATA vase_4comp.vti CONFIG thumbnail_build DEFAULT_LIGHTS)
     f3d_test(NAME TestThumbnailConfigFileSTL DATA suzanne.stl CONFIG thumbnail_build DEFAULT_LIGHTS)
     f3d_test(NAME TestThumbnailConfigFileTIFF DATA logo.tif CONFIG thumbnail_build DEFAULT_LIGHTS)
+    f3d_test(NAME TestThumbnailConfigFilePLY DATA cube.ply CONFIG thumbnail_build DEFAULT_LIGHTS)
   endif()
 endif()
 

--- a/plugins/native/configs/config.d/10_native.json
+++ b/plugins/native/configs/config.d/10_native.json
@@ -15,5 +15,10 @@
   {
     "up": "-Y",
     "comp": "-2"
+  },
+  ".*(ply)":
+  {
+    "comp": "-2",
+    "translucency-support": true
   }
 }

--- a/plugins/native/configs/thumbnail.d/10_native.json
+++ b/plugins/native/configs/thumbnail.d/10_native.json
@@ -14,7 +14,7 @@
   },
   ".*(ply)":
   {
-    "comp": "-2"
+    "comp": "-2",
     "translucency-support": true
   }
 }

--- a/plugins/native/configs/thumbnail.d/10_native.json
+++ b/plugins/native/configs/thumbnail.d/10_native.json
@@ -11,5 +11,10 @@
   {
     "up": "-Y",
     "comp": "-2"
+  },
+  ".*(ply)":
+  {
+    "comp": "-2"
+    "translucency-support": true
   }
 }

--- a/testing/baselines/TestDefaultConfigFilePLY.png
+++ b/testing/baselines/TestDefaultConfigFilePLY.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f036db24debb9e0da2967c614fa761395728e1e07b726a95731c357f2cafc1b
-size 49749
+oid sha256:e00adcc9b011f2cf61e77d38a31c006821f0716076bcaf1c0b0ecec479b4d7b9
+size 50782

--- a/testing/baselines/TestDefaultConfigFilePLY.png
+++ b/testing/baselines/TestDefaultConfigFilePLY.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f036db24debb9e0da2967c614fa761395728e1e07b726a95731c357f2cafc1b
+size 49749

--- a/testing/baselines/TestThumbnailConfigFilePLY.png
+++ b/testing/baselines/TestThumbnailConfigFilePLY.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44bbf610b494cac6aac31fe417a2b368912b1fa020f8e23dd13007ee0112309d
+size 54982

--- a/testing/baselines/TestThumbnailConfigFilePLY.png
+++ b/testing/baselines/TestThumbnailConfigFilePLY.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44bbf610b494cac6aac31fe417a2b368912b1fa020f8e23dd13007ee0112309d
-size 54982
+oid sha256:1af3e7ed247267066999d2c30b9baa797dc304480749f4300651145a91fcca99
+size 56206

--- a/testing/data/cube.ply
+++ b/testing/data/cube.ply
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bacdef9e3215ea85aefa2061f7a6335fff901fc296c4a93412839011e58f5a9
+size 79568


### PR DESCRIPTION
- PLY files usually contains a RGB or RGBA field  which should be displayed with direct scalars and translucency
- Add a test
- Fix #750 