### PR TITLE
Avoid hardcoded path to conform to current CMake pratice

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -174,20 +174,20 @@ if(BUILD_SHARED_LIBS)
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library)
 
   install(FILES ${F3D_PUBLIC_HEADERS}
-    DESTINATION "include/f3d"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/f3d"
     COMPONENT sdk
     EXCLUDE_FROM_ALL)
 
   install(EXPORT f3dTargets
     NAMESPACE f3d::
-    DESTINATION "lib/cmake/f3d"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
     COMPONENT sdk
     EXCLUDE_FROM_ALL)
 
   include(CMakePackageConfigHelpers)
   configure_package_config_file(
     "${CMAKE_SOURCE_DIR}/cmake/f3dConfig.cmake.in" "${CMAKE_BINARY_DIR}/cmake/f3dConfig.cmake"
-    INSTALL_DESTINATION "lib/cmake/f3d")
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/f3d")
 
   # Write PROJECT_VERSION instead of F3D_VERSION to avoid any potential issues with version comparison
   # because of the potential suffix
@@ -207,7 +207,7 @@ if(BUILD_SHARED_LIBS)
       "${CMAKE_SOURCE_DIR}/cmake/plugin.thumbnailer.in"
       "${CMAKE_SOURCE_DIR}/cmake/readerBoilerPlate.h.in"
     DESTINATION
-      "lib/cmake/f3d"
+      "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
     COMPONENT sdk
     EXCLUDE_FROM_ALL)
 endif()


### PR DESCRIPTION
It maybe be better to use the `${CMAKE_INSTALL_LIBDIR}`, `${CMAKE_INSTALL_INCLUDEDIR}`, instead of hardcoding the directory. `${CMAKE_INSTALL_LIBDIR}`, `${CMAKE_INSTALL_INCLUDEDIR}`, et al. are defined by the `GNUInstallDirs` that represents the platform-specific installation directory and provides install directory variables defined by the [GNU Coding Standards](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html).

Ref:
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8111
https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
https://github.com/libsdl-org/SDL/commit/6956f4aa1982b66b234026b46f7bb2dd44c67894