### PR TITLE
Fix an issue with the drop zone when no mapper is set

### DIFF
--- a/library/VTKExtensions/Rendering/vtkF3DDropZoneActor.h
+++ b/library/VTKExtensions/Rendering/vtkF3DDropZoneActor.h
@@ -46,6 +46,16 @@ public:
    */
   int RenderOverlay(vtkViewport* viewport) override;
 
+  /**
+   * Reimplemented for noop
+   */
+  int RenderTranslucentPolygonalGeometry(vtkViewport* vtkNotUsed(viewport)) override { return 0; };
+
+  /**
+   * Reimplemented for noop
+   */
+  int RenderOpaqueGeometry(vtkViewport* vtkNotUsed(viewport)) override { return 0; };
+
 protected:
   vtkF3DDropZoneActor();
   ~vtkF3DDropZoneActor() override;


### PR DESCRIPTION
When no mapper is set vtkActor2D is erroring in the default impl of rendering methods. Override them to avoid that.