### PR TITLE
Add reader for .exr images

### DIFF
--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -22,6 +22,9 @@ runs:
     - name: Install Imath dependency
       uses: ./source/.github/actions/imath-install-dep
 
+    - name: Install OpenEXR dependency
+      uses: ./source/.github/actions/openexr-install-dep
+
     - name: Install Alembic dependency
       uses: ./source/.github/actions/alembic-install-dep
 

--- a/.github/actions/openexr-install-dep/action.yml
+++ b/.github/actions/openexr-install-dep/action.yml
@@ -1,0 +1,55 @@
+name: 'Install OpenEXR Dependency'
+description: 'Install OpenEXR Dependency using cache when possible'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Cache OpenEXR
+      id: cache-openexr
+      uses: actions/cache@v3
+      with:
+        path: dependencies/openexr_install
+        key: openexr-v3.1.8-${{runner.os}}-0
+
+    - name: Checkout OpenEXR
+      if: steps.cache-openexr.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: AcademySoftwareFoundation/openexr
+        path: './dependencies/openexr'
+        ref: v3.1.8
+
+    - name: Setup OpenEXR
+      if: steps.cache-openexr.outputs.cache-hit != 'true'
+      working-directory: ${{github.workspace}}/dependencies
+      shell: bash
+      run: |
+        mkdir openexr_build
+        mkdir openexr_install
+
+    - name: Configure OpenEXR
+      if: steps.cache-openexr.outputs.cache-hit != 'true'
+      working-directory: ${{github.workspace}}/dependencies/openexr_build
+      shell: bash
+      run: >
+        cmake ../openexr
+        -DBUILD_SHARED_LIBS=ON
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_INSTALL_PREFIX:PATH=../openexr_install
+        -DCMAKE_PREFIX_PATH:PATH=../install/
+        -DOPENEXR_INSTALL_TOOLS=OFF
+        -DOPENEXR_INSTALL_EXAMPLES=OFF
+        ${{ runner.os == 'macOS' && '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_MACOSX_RPATH=ON' || null }}
+        ${{ runner.os == 'Windows' && '-Ax64 -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL' || null }}
+
+    - name: Build OpenEXR
+      if: steps.cache-openexr.outputs.cache-hit != 'true'
+      working-directory: ${{github.workspace}}/dependencies/openexr_build
+      shell: bash
+      run: cmake --build . --parallel 2 --target install --config Release
+
+    - name: Copy to install
+      working-directory: ${{github.workspace}}/dependencies/openexr_install
+      shell: bash
+      run: cp -r ./* ../install/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
         -DF3D_LINUX_INSTALL_DEFAULT_CONFIGURATION_FILE_IN_PREFIX=ON
         -DF3D_MACOS_BUNDLE=${{ matrix.bundle_label == 'bundle' && 'ON' || 'OFF' }}
         -DF3D_MODULE_EXTERNAL_RENDERING=ON
+        -DF3D_MODULE_EXR=ON
         -DF3D_MODULE_RAYTRACING=${{ matrix.raytracing_label == 'raytracing' && 'ON' || 'OFF' }}
         -DF3D_PLUGINS_STATIC_BUILD=${{ matrix.bundle_label == 'bundle' && 'ON' || 'OFF' }}
         -DF3D_PLUGIN_BUILD_ALEMBIC=ON
@@ -456,6 +457,7 @@ jobs:
         -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
         -DCMAKE_PREFIX_PATH:PATH=$(pwd)/../dependencies/install/
         -DF3D_MODULE_EXTERNAL_RENDERING=ON
+        -DF3D_MODULE_EXR=ON
         -DF3D_PLUGIN_BUILD_ALEMBIC=ON
         -DF3D_PLUGIN_BUILD_ASSIMP=ON
         -DF3D_PLUGIN_BUILD_DRACO=ON
@@ -550,6 +552,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_PREFIX_PATH:PATH=$(pwd)/../dependencies/install/
         -DF3D_MODULE_EXTERNAL_RENDERING=ON
+        -DF3D_MODULE_EXR=ON
         -DF3D_PLUGIN_BUILD_ALEMBIC=ON
         -DF3D_PLUGIN_BUILD_ASSIMP=ON
         -DF3D_PLUGIN_BUILD_DRACO=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(F3D_SYSTEM_PROCESSOR "${F3D_SYSTEM_PROCESSOR}-bits")
 # Modules
 option(F3D_MODULE_EXTERNAL_RENDERING "External rendering module" OFF)
 option(F3D_MODULE_RAYTRACING "Raytracing module" OFF)
+option(F3D_MODULE_EXR "OpenEXR images module" OFF)
 
 # Use externals
 option(F3D_USE_EXTERNAL_CXXOPTS "Use external cxxopts dependency" OFF)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -308,6 +308,10 @@ if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20221220)
 
   configure_file("${CMAKE_SOURCE_DIR}/testing/configs/hdri.json.in" "${CMAKE_BINARY_DIR}/hdri.json")
   f3d_test(NAME TestConfigFileHDRI DATA dragon.vtu CONFIG "${CMAKE_BINARY_DIR}/hdri.json" HDRI DEFAULT_LIGHTS)
+
+  if(F3D_MODULE_EXR)
+    f3d_test(NAME TestHDRIEXR HDRI DATA suzanne.ply ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/kloofendal_43d_clear_1k.exr DEFAULT_LIGHTS)
+  endif()
 endif()
 
 if(F3D_MODULE_RAYTRACING)

--- a/cmake/f3dConfig.cmake.in
+++ b/cmake/f3dConfig.cmake.in
@@ -9,6 +9,7 @@
 #
 #   f3d_MODULE_EXTERNAL_RENDERING  Will be enabled if F3D was built with external rendering support
 #   f3d_MODULE_RAYTRACING          Will be enabled if F3D was built with raytracing support
+#   f3d_MODULE_EXR                 Will be enabled if F3D was built with OpenEXR images support
 #   f3d_BINDINGS_PYTHON            Will be enabled if F3D was built with python bindings
 #   f3d_BINDINGS_JAVA              Will be enabled if F3D was built with java bindings
 #   f3d_INCLUDE_DIR                Absolute path to the include directory of public f3d library classes
@@ -19,6 +20,7 @@
 
 set(f3d_MODULE_EXTERNAL_RENDERING "@F3D_MODULE_EXTERNAL_RENDERING@")
 set(f3d_MODULE_RAYTRACING "@F3D_MODULE_RAYTRACING@")
+set(f3d_MODULE_EXR "@F3D_MODULE_EXR@")
 set(f3d_BINDINGS_PYTHON "@F3D_BINDINGS_PYTHON@")
 set(f3d_BINDINGS_JAVA "@F3D_BINDINGS_JAVA@")
 set(f3d_CONFIG_DIR "@f3d_config_dir@")

--- a/doc/dev/BUILD.md
+++ b/doc/dev/BUILD.md
@@ -36,7 +36,8 @@ Here is some CMake options of interest:
 Some modules, plugins and bindings depending on external libraries can be optionally enabled with the following CMake variables:
 
 * `F3D_MODULE_RAYTRACING`: Support for raytracing rendering. Requires that VTK has been built with `OSPRay` and `VTK_MODULE_ENABLE_VTK_RenderingRayTracing` turned on. Disabled by default.
-* `F3D_MODULE_EXTERNAL_RENDERING`: Support for external render window, Requires that VTK has been built with `VTK_MODULE_ENABLE_VTK_RenderingExternal` turned on. Disabled by default.
+* `F3D_MODULE_EXTERNAL_RENDERING`: Support for external render window. Requires that VTK has been built with `VTK_MODULE_ENABLE_VTK_RenderingExternal` turned on. Disabled by default.
+* `F3D_MODULE_EXR`: Support for OpenEXR images. Requires `OpenEXR`. Disabled by default.
 * `F3D_PLUGIN_BUILD_EXODUS`: Support for ExodusII (.ex2) file format. Requires that VTK has been built with `IOExodus` module (and `hdf5`). Enabled by default.
 * `F3D_PLUGIN_BUILD_OCCT`: Support for STEP and IGES file formats. Requires `OpenCASCADE`. Disabled by default.
 * `F3D_PLUGIN_BUILD_ASSIMP`: Support for FBX, DAE, OFF and DXF file formats. Requires `Assimp`. Disabled by default.

--- a/doc/libf3d/OPTIONS.md
+++ b/doc/libf3d/OPTIONS.md
@@ -72,7 +72,7 @@ render.raytracing.enable|bool<br>false<br>render|Enable *raytracing*. Requires t
 render.raytracing.samples|int<br>5<br>render|The number of *samples per pixel*.|\-\-samples
 render.raytracing.denoise|bool<br>false<br>render|*Denoise* the raytracing rendering.|\-\-denoise
 render.background.color|vector\<double\><br>0.2,0.2,0.2<br>render|Set the window *background color*.<br>Ignored if *hdri* is set.|\-\-bg-color
-render.background.hdri|string<br>-<br>render|Set the *HDRI* image used to create the environment.<br>The environment act as a light source and is reflected on the material.<br>Valid file format are hdr, png, jpg, pnm, tiff, bmp. Override the color.|\-\-hdri
+render.background.hdri|string<br>-<br>render|Set the *HDRI* image used to create the environment.<br>The environment act as a light source and is reflected on the material.<br>Valid file format are hdr, exr, png, jpg, pnm, tiff, bmp. Override the color.|\-\-hdri
 render.background.blur|bool<br>false<br>render|Blur background when using a HDRI.|\-\-blur-background
 render.background.blur.coc|double<br>20.0<br>render|Blur background circle of confusion radius.|\-\-blur-background-coc
 

--- a/doc/user/OPTIONS.md
+++ b/doc/user/OPTIONS.md
@@ -51,7 +51,7 @@ Options|Default|Description
 \-\-opacity=\<opacity\>|1.0|Set *opacity* on the geometry. Multiplied with the base color texture when present. <br>Requires a default scene. Usually used with Depth Peeling option.
 \-\-roughness=\<roughness\>|0.3|Set the *roughness coefficient* on the geometry (0.0-1.0). Multiplied with the material texture when present. <br>Requires a default scene.
 \-\-metallic=\<metallic\>|0.0|Set the *metallic coefficient* on the geometry (0.0-1.0). Multiplied with the material texture when present. <br>Requires a default scene.
-\-\-hdri=\<HDRi file\>||Set the *HDRI* image used to create the environment.<br>The environment act as a light source and is reflected on the material.<br>Valid file format are hdr, png, jpg, pnm, tiff, bmp.
+\-\-hdri=\<HDRi file\>||Set the *HDRI* image used to create the environment.<br>The environment act as a light source and is reflected on the material.<br>Valid file format are hdr, exr, png, jpg, pnm, tiff, bmp.
 \-\-texture-base-color=\<texture file\>||Set the texture file to control the color of the object. Please note this will be multiplied with the color and opacity options.
 \-\-texture-material=\<texture file\>||Set the texture file to control the occlusion, roughness and metallic values of the object. Please note this will be multiplied with the roughness and metallic options, which have impactful default values. To obtain true results, use \-\-roughness=1 \-\-metallic=1.
 \-\-texture-emissive=\<texture file\>||Set the texture file to control the emitted light of the object. Please note this will be multiplied with the emissive factor.

--- a/examples/libf3d/check-engine/CMakeLists.txt
+++ b/examples/libf3d/check-engine/CMakeLists.txt
@@ -14,6 +14,7 @@ endfunction()
 
 check_variable_defined(f3d_MODULE_EXTERNAL_RENDERING)
 check_variable_defined(f3d_MODULE_RAYTRACING)
+check_variable_defined(f3d_MODULE_EXR)
 check_variable_defined(f3d_BINDINGS_PYTHON)
 check_variable_defined(f3d_BINDINGS_JAVA)
 

--- a/library/VTKExtensions/Core/vtkF3DConfigure.h.in
+++ b/library/VTKExtensions/Core/vtkF3DConfigure.h.in
@@ -10,4 +10,5 @@ static const std::string F3D_EXIT_HOTKEY_SYM = "Escape";
 
 #cmakedefine01 F3D_MODULE_EXTERNAL_RENDERING
 #cmakedefine01 F3D_MODULE_RAYTRACING
+#cmakedefine01 F3D_MODULE_EXR
 #endif

--- a/library/VTKExtensions/Readers/CMakeLists.txt
+++ b/library/VTKExtensions/Readers/CMakeLists.txt
@@ -3,7 +3,16 @@ set(classes
   vtkF3DPostProcessFilter
   )
 
+if(F3D_MODULE_EXR)
+  find_package(OpenEXR REQUIRED)
+  list(APPEND classes vtkF3DEXRReader)
+endif()
+
 vtk_module_add_module(f3d::VTKExtensionsReaders
   ${libf3d_vtk_no_install}
   FORCE_STATIC
   CLASSES ${classes})
+
+if(F3D_MODULE_EXR)
+  vtk_module_link(f3d::VTKExtensionsReaders PRIVATE OpenEXR::OpenEXR)
+endif()

--- a/library/VTKExtensions/Readers/CMakeLists.txt
+++ b/library/VTKExtensions/Readers/CMakeLists.txt
@@ -4,7 +4,7 @@ set(classes
   )
 
 if(F3D_MODULE_EXR)
-  find_package(OpenEXR REQUIRED)
+  find_package(OpenEXR 3.0 REQUIRED)
   list(APPEND classes vtkF3DEXRReader)
 endif()
 

--- a/library/VTKExtensions/Readers/Testing/CMakeLists.txt
+++ b/library/VTKExtensions/Readers/Testing/CMakeLists.txt
@@ -3,6 +3,10 @@ list(APPEND VTKExtensionsReaderTests_list
      TestF3DGenericImporterMultiColoring.cxx
     )
 
+if(F3D_MODULE_EXR)
+  list(APPEND VTKExtensionsReaderTests_list TestF3DEXRReader.cxx)
+endif()
+
 if(VTK_VERSION VERSION_LESS_EQUAL 9.1.0)
   cmake_policy(SET CMP0115 OLD)
 endif()

--- a/library/VTKExtensions/Readers/Testing/TestF3DEXRReader.cxx
+++ b/library/VTKExtensions/Readers/Testing/TestF3DEXRReader.cxx
@@ -1,0 +1,31 @@
+#include <vtkNew.h>
+
+#include <vtkImageData.h>
+
+#include "vtkF3DEXRReader.h"
+
+#include <iostream>
+
+int TestF3DEXRReader(int argc, char* argv[])
+{
+  vtkNew<vtkF3DEXRReader> reader;
+
+  std::string filename = std::string(argv[1]) + "data/kloofendal_43d_clear_1k.exr";
+  reader->SetFileName(filename.c_str());
+  reader->Update();
+
+  reader->Print(cout);
+
+  vtkImageData* img = reader->GetOutput();
+
+  int* dims = img->GetDimensions();
+
+  if (dims[0] != 1024 && dims[1] != 512)
+  {
+    std::cerr << "Incorrect EXR image size." << std::endl;
+
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/library/VTKExtensions/Readers/Testing/TestF3DEXRReader.cxx
+++ b/library/VTKExtensions/Readers/Testing/TestF3DEXRReader.cxx
@@ -1,6 +1,5 @@
-#include <vtkNew.h>
-
 #include <vtkImageData.h>
+#include <vtkNew.h>
 
 #include "vtkF3DEXRReader.h"
 
@@ -23,7 +22,6 @@ int TestF3DEXRReader(int argc, char* argv[])
   if (dims[0] != 1024 && dims[1] != 512)
   {
     std::cerr << "Incorrect EXR image size." << std::endl;
-
     return EXIT_FAILURE;
   }
 

--- a/library/VTKExtensions/Readers/vtk.module
+++ b/library/VTKExtensions/Readers/vtk.module
@@ -3,6 +3,7 @@ NAME
 DESCRIPTION
   A VTK module containing all F3D provided readers and reader factory logic
 DEPENDS
+  VTK::IOImage
   VTK::IOImport
 PRIVATE_DEPENDS
   VTK::CommonExecutionModel

--- a/library/VTKExtensions/Readers/vtkF3DEXRReader.cxx
+++ b/library/VTKExtensions/Readers/vtkF3DEXRReader.cxx
@@ -1,0 +1,146 @@
+#include "vtkF3DEXRReader.h"
+
+#include "vtkFloatArray.h"
+#include "vtkImageData.h"
+#include "vtkNew.h"
+#include "vtkObjectFactory.h"
+#include "vtkPointData.h"
+#include "vtksys/FStream.hxx"
+
+#include <ImfArray.h>
+#include <ImfRgbaFile.h>
+
+#include <sstream>
+
+vtkStandardNewMacro(vtkF3DEXRReader);
+
+//------------------------------------------------------------------------------
+vtkF3DEXRReader::vtkF3DEXRReader() = default;
+
+//------------------------------------------------------------------------------
+vtkF3DEXRReader::~vtkF3DEXRReader() = default;
+
+//------------------------------------------------------------------------------
+void vtkF3DEXRReader::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//------------------------------------------------------------------------------
+void vtkF3DEXRReader::ExecuteInformation()
+{
+  // Setup filename to read the header
+  this->ComputeInternalFileName(this->DataExtent[4]);
+  if (this->InternalFileName == nullptr || this->InternalFileName[0] == '\0')
+  {
+    return;
+  }
+
+  try
+  {
+    Imf::RgbaInputFile file(this->InternalFileName);
+
+    Imath::Box2i dw = file.dataWindow();
+    this->DataExtent[0] = dw.min.x;
+    this->DataExtent[1] = dw.max.x;
+    this->DataExtent[2] = dw.min.y;
+    this->DataExtent[3] = dw.max.y;
+
+    Imf::RgbaChannels channels = file.channels();
+    if (channels != Imf::RgbaChannels::WRITE_RGBA && channels != Imf::RgbaChannels::WRITE_RGB)
+    {
+      throw std::runtime_error("type of channels not supported yet");
+    }
+  }
+  catch (const std::exception& e)
+  {
+    vtkErrorMacro("Error reading EXR file: " << e.what());
+    return;
+  }
+
+  this->SetNumberOfScalarComponents(3);
+  this->SetDataScalarTypeToFloat();
+
+  this->vtkImageReader::ExecuteInformation();
+}
+
+//------------------------------------------------------------------------------
+int vtkF3DEXRReader::CanReadFile(const char* fname)
+{
+  // get the magic number by reading in a file
+  vtksys::ifstream ifs(fname, vtksys::ifstream::in);
+
+  if (ifs.fail())
+  {
+    vtkErrorMacro(<< "Could not open file " << fname);
+    return 0;
+  }
+
+  // The file must begin with magic number 76 2F 31 01
+  if ((ifs.get() != 0x76) && (ifs.get() != 0x2F) && (ifs.get() != 0x31) && (ifs.get() != 0x01))
+  {
+    ifs.close();
+    return 0;
+  }
+
+  ifs.close();
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+void vtkF3DEXRReader::ExecuteDataWithInformation(vtkDataObject* output, vtkInformation* outInfo)
+{
+  vtkImageData* data = this->AllocateOutputData(output, outInfo);
+
+  if (this->UpdateExtentIsEmpty(outInfo, output))
+  {
+    return;
+  }
+
+  if (this->InternalFileName == nullptr)
+  {
+    vtkErrorMacro(<< "Either a FileName or FilePrefix must be specified.");
+    return;
+  }
+
+  vtkFloatArray* scalars = vtkFloatArray::SafeDownCast(data->GetPointData()->GetScalars());
+  scalars->SetName("Pixels");
+  float* dataPtr = scalars->GetPointer(0);
+
+  try
+  {
+    Imf::RgbaInputFile file(this->InternalFileName);
+
+    Imf::Array2D<Imf::Rgba> pixels(this->GetHeight(), this->GetWidth());
+
+    file.setFrameBuffer(&pixels[0][0], 1, this->GetWidth());
+    file.readPixels(this->DataExtent[2], this->DataExtent[3]);
+
+    for (int y = this->GetHeight() - 1; y >= 0; y--)
+    {
+      for (int x = 0; x < this->GetWidth(); x++)
+      {
+        const Imf::Rgba& p = pixels[y][x];
+        dataPtr[0] = std::clamp(static_cast<float>(p.r), 0.f, 10000.f);
+        dataPtr[1] = std::clamp(static_cast<float>(p.g), 0.f, 10000.f);
+        dataPtr[2] = std::clamp(static_cast<float>(p.b), 0.f, 10000.f);
+        dataPtr += 3;
+      }
+    }
+  }
+  catch (const std::exception& e)
+  {
+    vtkErrorMacro("Error reading EXR file: " << e.what());
+    return;
+  }
+}
+
+int vtkF3DEXRReader::GetWidth() const
+{
+  return this->DataExtent[1] - this->DataExtent[0] + 1;
+}
+
+int vtkF3DEXRReader::GetHeight() const
+{
+  return this->DataExtent[3] - this->DataExtent[2] + 1;
+}

--- a/library/VTKExtensions/Readers/vtkF3DEXRReader.cxx
+++ b/library/VTKExtensions/Readers/vtkF3DEXRReader.cxx
@@ -49,7 +49,7 @@ void vtkF3DEXRReader::ExecuteInformation()
     Imf::RgbaChannels channels = file.channels();
     if (channels != Imf::RgbaChannels::WRITE_RGBA && channels != Imf::RgbaChannels::WRITE_RGB)
     {
-      throw std::runtime_error("type of channels not supported yet");
+      throw std::runtime_error("only RGB and RGBA channels are supported");
     }
   }
   catch (const std::exception& e)
@@ -135,11 +135,13 @@ void vtkF3DEXRReader::ExecuteDataWithInformation(vtkDataObject* output, vtkInfor
   }
 }
 
+//------------------------------------------------------------------------------
 int vtkF3DEXRReader::GetWidth() const
 {
   return this->DataExtent[1] - this->DataExtent[0] + 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkF3DEXRReader::GetHeight() const
 {
   return this->DataExtent[3] - this->DataExtent[2] + 1;

--- a/library/VTKExtensions/Readers/vtkF3DEXRReader.h
+++ b/library/VTKExtensions/Readers/vtkF3DEXRReader.h
@@ -1,0 +1,35 @@
+#ifndef vtkF3DEXRReader_h
+#define vtkF3DEXRReader_h
+
+#include "vtkImageReader.h"
+
+class vtkF3DEXRReader : public vtkImageReader
+{
+public:
+  static vtkF3DEXRReader* New();
+  vtkTypeMacro(vtkF3DEXRReader, vtkImageReader);
+
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  int CanReadFile(const char* fname) override;
+
+  const char* GetFileExtensions() override { return ".exr"; }
+
+  const char* GetDescriptiveName() override { return "OpenEXR"; }
+
+protected:
+  vtkF3DEXRReader();
+  ~vtkF3DEXRReader() override;
+
+  void ExecuteInformation() override;
+  void ExecuteDataWithInformation(vtkDataObject* out, vtkInformation* outInfo) override;
+
+  int GetWidth() const;
+  int GetHeight() const;
+
+private:
+  vtkF3DEXRReader(const vtkF3DEXRReader&) = delete;
+  void operator=(const vtkF3DEXRReader&) = delete;
+};
+
+#endif

--- a/library/VTKExtensions/Readers/vtkF3DEXRReader.h
+++ b/library/VTKExtensions/Readers/vtkF3DEXRReader.h
@@ -8,13 +8,21 @@ class vtkF3DEXRReader : public vtkImageReader
 public:
   static vtkF3DEXRReader* New();
   vtkTypeMacro(vtkF3DEXRReader, vtkImageReader);
-
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
+  /**
+   * Return 1 if the reader is compatible with the given file
+   */
   int CanReadFile(const char* fname) override;
 
+  /**
+   * List of extensions supported by this reader
+   */
   const char* GetFileExtensions() override { return ".exr"; }
 
+  /**
+   * Descriptive name of the reader
+   */
   const char* GetDescriptiveName() override { return "OpenEXR"; }
 
 protected:

--- a/library/public/engine.h
+++ b/library/public/engine.h
@@ -151,6 +151,7 @@ public:
     std::string Compiler;
     std::string RaytracingModule;
     std::string ExternalRenderingModule;
+    std::string OpenEXRModule;
     std::string VTKVersion;
     std::string PreviousCopyright;
     std::string Copyright;

--- a/library/public/image.h
+++ b/library/public/image.h
@@ -21,6 +21,7 @@ public:
   /**
    * Create an image from file, the following formats are supported:
    * PNG, PNM, TIFF, BMP, HDR, JPEG, GESigna, MetaImage, TGA.
+   * EXR files are also supported if the associated module is built.
    * Throw an image::read_exception in case of failure.
    */
   explicit image(const std::string& path);

--- a/library/src/engine.cxx
+++ b/library/src/engine.cxx
@@ -298,6 +298,13 @@ engine::libInformation engine::getLibInfo()
 #endif
   libInfo.ExternalRenderingModule = tmp;
 
+#if F3D_MODULE_EXR
+  tmp = "ON";
+#else
+  tmp = "OFF";
+#endif
+  libInfo.OpenEXRModule = tmp;
+
   // First version of VTK including the version check (and the feature used)
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 0, 20200527)
   std::string vtkVersion = std::string(vtkVersion::GetVTKVersionFull());

--- a/library/src/init.cxx
+++ b/library/src/init.cxx
@@ -2,8 +2,14 @@
 
 #include "log.h"
 
+#include "vtkF3DConfigure.h"
 #include "vtkF3DObjectFactory.h"
 
+#if F3D_MODULE_EXR
+#include "vtkF3DEXRReader.h"
+#endif
+
+#include <vtkImageReader2Factory.h>
 #include <vtkLogger.h>
 #include <vtkNew.h>
 #include <vtkVersion.h>
@@ -38,6 +44,11 @@ init::init()
   vtkObjectFactory::SetAllEnableFlags(0, "vtkRenderWindow", "vtkOpenGLRenderWindow");
   vtkObjectFactory::SetAllEnableFlags(
     0, "vtkRenderWindowInteractor", "vtkGenericRenderWindowInteractor");
+#endif
+
+#if F3D_MODULE_EXR
+  vtkNew<vtkF3DEXRReader> reader;
+  vtkImageReader2Factory::RegisterReader(reader);
 #endif
 }
 

--- a/testing/baselines/TestHDRIEXR.png
+++ b/testing/baselines/TestHDRIEXR.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a67742e156289e154ad3cc98c75ad19874f2adf51308bf504eb50d08aab929e
+size 75357

--- a/testing/data/DATA_LICENSES.md
+++ b/testing/data/DATA_LICENSES.md
@@ -20,6 +20,7 @@
 - iflamigm.3ds: VTK Data: BSD-3-Clause
 - IM-0001-1983.dcm: VTK Data: BSD-3-Clause
 - InterpolationTest.glb: glTF-Sample-Models: Public Domain
+- kloofendal_43d_clear_1k.exr: Polyhaven: Public Domain
 - normal.png: glTF-Sample-Models: Public Domain
 - normalMapping.fbx: assimp test models: BSD-3-Clause; rubberduck: [CC0](https://creativecommons.org/publicdomain/zero/1.0/)
 - palermo_park_1k.hdr: Polyhaven: Public Domain

--- a/testing/data/DATA_LICENSES.md
+++ b/testing/data/DATA_LICENSES.md
@@ -20,10 +20,10 @@
 - iflamigm.3ds: VTK Data: BSD-3-Clause
 - IM-0001-1983.dcm: VTK Data: BSD-3-Clause
 - InterpolationTest.glb: glTF-Sample-Models: Public Domain
-- kloofendal_43d_clear_1k.exr: Polyhaven: Public Domain
+- kloofendal_43d_clear_1k.exr: Polyhaven: [CC0](https://creativecommons.org/publicdomain/zero/1.0/)
 - normal.png: glTF-Sample-Models: Public Domain
 - normalMapping.fbx: assimp test models: BSD-3-Clause; rubberduck: [CC0](https://creativecommons.org/publicdomain/zero/1.0/)
-- palermo_park_1k.hdr: Polyhaven: Public Domain
+- palermo_park_1k.hdr: Polyhaven: [CC0](https://creativecommons.org/publicdomain/zero/1.0/)
 - Part-4-Buildings-V4-one.gml: VTK Data: BSD-3-Clause
 - phong_cube.fbx: assimp test models: BSD-3-Clause
 - PinkEggFromLW.dxf: assimp test models: BSD-3-Clause

--- a/testing/data/kloofendal_43d_clear_1k.exr
+++ b/testing/data/kloofendal_43d_clear_1k.exr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:294fcdbd1414db9637a50fa09f7ef88420eff68a6439b78dff3a62bb0f7bed45
+size 6087369

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,7 @@
         "assimp",
         "draco",
         "opencascade",
+        "openexr",
         {
             "name": "vtk",
             "default-features": false,


### PR DESCRIPTION
Add a reader for EXR files using OpenEXR library.  
It's enabled using `F3D_MODULE_EXR` option and the reader is automatically registered using the image reader factory.