### PR TITLE
Improve LFS data logic in CI

### DIFF
--- a/.github/actions/lfs-copy/action.yml
+++ b/.github/actions/lfs-copy/action.yml
@@ -4,6 +4,10 @@ inputs:
   lfs_sha:
     description: 'LFS sha to recover'
     required: true
+  workflow_label:
+    description: 'Whether this action produce/consume LFS data'
+    default: 'producer'
+
 runs:
   using: "composite"
   steps:
@@ -16,12 +20,32 @@ runs:
         key: lfs-data-${{inputs.lfs_sha}}-1
 
     - name: Checkout LFS data
-      if: steps.cache-lfs.outputs.cache-hit != 'true'
+      if: |
+        steps.cache-lfs.outputs.cache-hit != 'true' &&
+        inputs.workflow_label == 'producer'
       uses: actions/checkout@v3
       with:
         path: 'lfs_data'
         fetch-depth: 0
         lfs: true
+
+    - name: Upload LFS artifact
+      if: |
+        steps.cache-lfs.outputs.cache-hit != 'true' &&
+        inputs.workflow_label == 'producer'
+      uses: actions/upload-artifact@master
+      with:
+        name: lfs-data
+        path: lfs_data
+
+    - name: Download LFS artifact
+      if: |
+        steps.cache-lfs.outputs.cache-hit != 'true' &&
+        inputs.workflow_label == 'consumer'
+      uses: actions/download-artifact@master
+      with:
+        name: lfs-data
+        path: lfs_data
 
     - name: Setup LFS data
       working-directory: ${{github.workspace}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,41 @@ concurrency:
 jobs:
 
 #----------------------------------------------------------------------------
+# Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
+#----------------------------------------------------------------------------
+
+  cache_lfs:
+    runs-on: ubuntu-latest
+    name: Update LFS data cache
+    outputs:
+      lfs_sha: ${{ steps.lfs_sha_recover.outputs.lfs_sha }}
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        path: 'source'
+        fetch-depth: 0
+        lfs: false
+
+    - name: Set LFS env var
+      working-directory: ${{github.workspace}}/source
+      id: lfs_sha_recover
+      shell: bash
+      run: echo "lfs_sha=$(git log -n 1 --pretty=format:%H -- testing/data/ testing/baselines/ examples/**/*/data/ examples/**/*/baselines/ .github/baselines/)" >> $GITHUB_OUTPUT
+
+    - name: Copy LFS Data
+      uses: ./source/.github/actions/lfs-copy
+      with:
+        lfs_sha: ${{ steps.lfs_sha_recover.outputs.lfs_sha }}
+        workflow_label: 'producer'
+
+#----------------------------------------------------------------------------
 # MAIN CI: Build and test with a cross-platform, cross-vtk build matrix
 #----------------------------------------------------------------------------
   ci:
     if: github.event.pull_request.draft == false
+    needs: cache_lfs
 
     strategy:
       fail-fast: false
@@ -58,15 +89,11 @@ jobs:
         fetch-depth: 0
         lfs: false
 
-    - name: Set LFS env var
-      working-directory: ${{github.workspace}}/source
-      shell: bash
-      run: echo "LFS_SHA=$(git log -n 1 --pretty=format:%H -- testing/data/ testing/baselines/ examples/**/*/data/ examples/**/*/baselines/ .github/baselines/)" >> $GITHUB_ENV
-
     - name: Copy LFS Data
       uses: ./source/.github/actions/lfs-copy
       with:
-        lfs_sha: ${{env.LFS_SHA}}
+        lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        workflow_label: 'consumer'
 
     - name: Dependencies Dir
       working-directory: ${{github.workspace}}
@@ -288,6 +315,7 @@ jobs:
 # Coverage: Build and test on linux with last VTK with coverage option
 #----------------------------------------------------------------------------
   coverage:
+    needs: cache_lfs
     if: github.event.pull_request.draft == false
 
     runs-on: ubuntu-latest
@@ -307,15 +335,11 @@ jobs:
         fetch-depth: 0
         lfs: false
 
-    - name: Set LFS env var
-      working-directory: ${{github.workspace}}/source
-      shell: bash
-      run: echo "LFS_SHA=$(git log -n 1 --pretty=format:%H -- testing/data/ testing/baselines/)" >> $GITHUB_ENV
-
     - name: Copy LFS Data
       uses: ./source/.github/actions/lfs-copy
       with:
-        lfs_sha: ${{env.LFS_SHA}}
+        lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        workflow_label: 'consumer'
 
     - name: Dependencies Dir
       working-directory: ${{github.workspace}}
@@ -392,6 +416,7 @@ jobs:
 # "memory" returns false positives in VTK:
 # https://stackoverflow.com/questions/60097307/memory-sanitizer-reports-use-of-uninitialized-value-in-global-object-constructio
   sanitizer:
+    needs: cache_lfs
     if: github.event.pull_request.draft == false
 
     strategy:
@@ -416,15 +441,11 @@ jobs:
         fetch-depth: 0
         lfs: false
 
-    - name: Set LFS env var
-      working-directory: ${{github.workspace}}/source
-      shell: bash
-      run: echo "LFS_SHA=$(git log -n 1 --pretty=format:%H -- testing/data/ testing/baselines/)" >> $GITHUB_ENV
-
     - name: Copy LFS Data
       uses: ./source/.github/actions/lfs-copy
       with:
-        lfs_sha: ${{env.LFS_SHA}}
+        lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        workflow_label: 'consumer'
 
     - name: Dependencies Dir
       working-directory: ${{github.workspace}}
@@ -491,6 +512,7 @@ jobs:
 # static-analysis: Run static analysis on linux
 #----------------------------------------------------------------------------
   static-analysis:
+    needs: cache_lfs
     if: github.event.pull_request.draft == false
 
     strategy:
@@ -512,15 +534,11 @@ jobs:
         fetch-depth: 0
         lfs: false
 
-    - name: Set LFS env var
-      working-directory: ${{github.workspace}}/source
-      shell: bash
-      run: echo "LFS_SHA=$(git log -n 1 --pretty=format:%H -- testing/data/ testing/baselines/)" >> $GITHUB_ENV
-
     - name: Copy LFS Data
       uses: ./source/.github/actions/lfs-copy
       with:
-        lfs_sha: ${{env.LFS_SHA}}
+        lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        workflow_label: 'consumer'
 
     - name: Dependencies Dir
       working-directory: ${{github.workspace}}


### PR DESCRIPTION
- Add a artifact producer/consumer logic in lfs_copy action
- Add a job dedicated to checking the cache, and, if needed, checkout the repo  and produce the artifact
- All CI now either rely on the cache if available, or an artifact if not, never checking out the repo

Note: Cache is never available between steps or jobs in a single run, forcing the use of an artifact

Resulting CI with a LFS data change can be seen here: https://github.com/f3d-app/f3d/actions/runs/5202807452
One can note the the following in the logs:

```
Run ./source/.github/actions/lfs-copy
Run actions/cache@v3
/usr/bin/docker exec  c4dba2bf74f2d399112597fc536cc7a4360e914c2ebe99b01209a88af9c28f15 sh -c "cat /etc/*release | grep ^ID"
Cache not found for input keys: lfs-data-d6cd9dc92f9818782baf7bf34502d048a6503b21-1
Run actions/download-artifact@master
/usr/bin/docker exec  c4dba2bf74f2d399112597fc536cc7a4360e914c2ebe99b01209a88af9c28f15 sh -c "cat /etc/*release | grep ^ID"
Starting download for lfs-data
Directory structure has been setup for the artifact
```
