### PR TITLE
Add MatCap texture option

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -312,6 +312,7 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
     this->DeclareOption(grp2, "roughness", "", "Roughness coefficient (0.0-1.0)", options.getAsDoubleRef("model.material.roughness"), HasDefault::YES, MayHaveConfig::YES, "<roughness>");
     this->DeclareOption(grp2, "metallic", "", "Metallic coefficient (0.0-1.0)", options.getAsDoubleRef("model.material.metallic"), HasDefault::YES, MayHaveConfig::YES, "<metallic>");
     this->DeclareOption(grp2, "hdri", "", "Path to an image file that will be used as a light source", options.getAsStringRef("render.background.hdri"), LocalHasDefaultNo, MayHaveConfig::YES, "<file path>");
+    this->DeclareOption(grp2, "texture-matcap", "", "Path to a texture file containing a material capture", options.getAsStringRef("model.matcap.texture"), LocalHasDefaultNo, MayHaveConfig::YES, "<file path>");
     this->DeclareOption(grp2, "texture-base-color", "", "Path to a texture file that sets the color of the object", options.getAsStringRef("model.color.texture"), LocalHasDefaultNo, MayHaveConfig::YES, "<file path>");
     this->DeclareOption(grp2, "texture-material", "", "Path to a texture file that sets the Occlusion, Roughness and Metallic values of the object", options.getAsStringRef("model.material.texture"), LocalHasDefaultNo, MayHaveConfig::YES, "<file path>");
     this->DeclareOption(grp2, "texture-emissive", "", "Path to a texture file that sets the emitted light of the object", options.getAsStringRef("model.emissive.texture"), LocalHasDefaultNo, MayHaveConfig::YES, "<file path>");

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -179,7 +179,7 @@ f3d_test(NAME TestGroupGeometries DATA mb/recursive ARGS --group-geometries DEFA
 f3d_test(NAME TestGroupGeometriesColoring DATA mb/recursive ARGS --group-geometries --scalars=Polynomial -b DEFAULT_LIGHTS)
 f3d_test(NAME TestInvalidUpDirection DATA suzanne.ply ARGS -g --up=W REGEXP "W is not a valid up direction" NO_BASELINE)
 f3d_test(NAME TestUpDirectionNoSign DATA suzanne.ply ARGS --up=X DEFAULT_LIGHTS)
-f3d_test(NAME TestTextureMatCap DATA suzanne.ply ARGS --texture-matcap=${CMAKE_SOURCE_DIR}/testing/data/skin.png)
+f3d_test(NAME TestTextureMatCap DATA suzanne.ply ARGS --texture-matcap=${CMAKE_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
 
 if (NOT APPLE)
   # This test is broken on apple because of #792

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -179,6 +179,7 @@ f3d_test(NAME TestGroupGeometries DATA mb/recursive ARGS --group-geometries DEFA
 f3d_test(NAME TestGroupGeometriesColoring DATA mb/recursive ARGS --group-geometries --scalars=Polynomial -b DEFAULT_LIGHTS)
 f3d_test(NAME TestInvalidUpDirection DATA suzanne.ply ARGS -g --up=W REGEXP "W is not a valid up direction" NO_BASELINE)
 f3d_test(NAME TestUpDirectionNoSign DATA suzanne.ply ARGS --up=X DEFAULT_LIGHTS)
+f3d_test(NAME TestTextureMatCap DATA suzanne.ply ARGS --texture-matcap=${CMAKE_SOURCE_DIR}/testing/data/skin.png)
 
 if (NOT APPLE)
   # This test is broken on apple because of #792

--- a/doc/libf3d/OPTIONS.md
+++ b/doc/libf3d/OPTIONS.md
@@ -34,7 +34,7 @@ interactor.trackball|bool<br>false<br>render|Enable trackball interaction.|\-\-t
 
 Option|Type<br>Default<br>Trigger|Description|F3D option
 :---:|:---:|:---|:---:
-model.matcap.texture|string<br>-<br>render|Path to a texture file containing a material capture. All other model options are ignored if this is set.|\-\-texture-matcap
+model.matcap.texture|string<br>-<br>render|Path to a texture file containing a material capture. All other model options for surfaces are ignored if this is set.|\-\-texture-matcap
 model.color.opacity|double<br>1.0<br>render|Set *opacity* on the geometry. Usually used with Depth Peeling option. Multiplied with the `model.color.texture` when present.|\-\-opacity
 model.color.rgb|vector\<double\><br>1.0,1.0,1.0<br>render|Set a *color* on the geometry. Multiplied with the `model.color.texture` when present.|\-\-color
 model.color.texture|string<br>-<br>render|Path to a texture file that sets the color of the object. Will be multiplied with rgb and opacity.|\-\-texture-base-color

--- a/doc/libf3d/OPTIONS.md
+++ b/doc/libf3d/OPTIONS.md
@@ -34,6 +34,7 @@ interactor.trackball|bool<br>false<br>render|Enable trackball interaction.|\-\-t
 
 Option|Type<br>Default<br>Trigger|Description|F3D option
 :---:|:---:|:---|:---:
+model.matcap.texture|string<br>-<br>render|Path to a texture file containing a material capture. All other model options are ignored if this is set.|\-\-texture-matcap
 model.color.opacity|double<br>1.0<br>render|Set *opacity* on the geometry. Usually used with Depth Peeling option. Multiplied with the `model.color.texture` when present.|\-\-opacity
 model.color.rgb|vector\<double\><br>1.0,1.0,1.0<br>render|Set a *color* on the geometry. Multiplied with the `model.color.texture` when present.|\-\-color
 model.color.texture|string<br>-<br>render|Path to a texture file that sets the color of the object. Will be multiplied with rgb and opacity.|\-\-texture-base-color
@@ -43,7 +44,7 @@ model.material.metallic|double<br>0.0<br>render|Set the *metallic coefficient* o
 model.material.roughness|double<br>0.3<br>render|Set the *roughness coefficient* on the geometry (0.0-1.0). Multiplied with the `model.material.texture` when present.|\-\-roughness
 model.material.texture|string<br>-<br>render|Path to a texture file that sets the Occlusion, Roughness and Metallic values of the object. Multiplied with the `model.material.roughness` and `model.material.metallic`, set both of them to 1.0 to get a true result.|\-\-texture-material
 model.normal.scale|double<br>1.0<br>render|Normal scale affects the strength of the normal deviation from the normal texture.|\-\-normal-scale
-model.normal.texture|string<br>-<br>render|Path to a texture file that sets the normal map of the object.|\-\-texrture-normal
+model.normal.texture|string<br>-<br>render|Path to a texture file that sets the normal map of the object.|\-\-texture-normal
 model.scivis.cells|bool<br>false<br>render|Color the data with value found *on the cells* instead of points|\-\-cells
 model.scivis.colormap|vector\<double\><br>\<inferno\><br>render|Set a *custom colormap for the coloring*.<br>This is a list of colors in the format `val1,red1,green1,blue1,...,valN,redN,greenN,blueN`<br>where all values are in the range (0,1).|\-\-colormap
 model.scivis.component|int<br>-1<br>render|Specify the component to color with. -1 means *magnitude*. -2 means *direct values*.|\-\-comp

--- a/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
@@ -212,7 +212,6 @@ void vtkF3DPolyDataMapper::ReplaceShaderLight(
   if (this->RenderWithMatCap(actor))
   {
     auto fragmentShader = shaders[vtkShader::Fragment];
-
     auto FSSource = fragmentShader->GetSource();
 
     std::string customLight = "//VTK::Light::Impl\n"
@@ -220,7 +219,6 @@ void vtkF3DPolyDataMapper::ReplaceShaderLight(
                               "gl_FragData[0] = texture(matcap, uv);\n";
 
     vtkShaderProgram::Substitute(FSSource, "//VTK::Light::Impl", customLight);
-
     fragmentShader->SetSource(FSSource);
   }
   else

--- a/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
@@ -180,3 +180,53 @@ void vtkF3DPolyDataMapper::ReplaceShaderValues(
 
   this->Superclass::ReplaceShaderValues(shaders, ren, actor);
 }
+
+//-----------------------------------------------------------------------------
+bool vtkF3DPolyDataMapper::RenderWithMatCap(vtkActor* actor)
+{
+  // check if we have normals
+  if (this->VBOs->GetNumberOfComponents("normalMC") != 3)
+  {
+    return false;
+  }
+
+  auto textures = actor->GetProperty()->GetAllTextures();
+
+  auto fn = [](const std::pair<std::string, vtkTexture*>& tex) { return tex.first == "matcap"; };
+
+  return std::find_if(textures.begin(), textures.end(), fn) != textures.end();
+}
+
+//-----------------------------------------------------------------------------
+void vtkF3DPolyDataMapper::ReplaceShaderColor(
+  std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor)
+{
+  if (!this->RenderWithMatCap(actor))
+  {
+    this->Superclass::ReplaceShaderColor(shaders, ren, actor);
+  }
+}
+
+//-----------------------------------------------------------------------------
+void vtkF3DPolyDataMapper::ReplaceShaderLight(
+  std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor)
+{
+  if (this->RenderWithMatCap(actor))
+  {
+    auto fragmentShader = shaders[vtkShader::Fragment];
+
+    auto FSSource = fragmentShader->GetSource();
+
+    std::string customLight = "//VTK::Light::Impl\n";
+    customLight += "vec2 uv = vec2(normalVCVSOutput.xy) * 0.5 + vec2(0.5,0.5);\n";
+    customLight += "gl_FragData[0] = texture(matcap, uv);\n";
+
+    vtkShaderProgram::Substitute(FSSource, "//VTK::Light::Impl", customLight);
+
+    fragmentShader->SetSource(FSSource);
+  }
+  else
+  {
+    this->Superclass::ReplaceShaderLight(shaders, ren, actor);
+  }
+}

--- a/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
@@ -191,9 +191,7 @@ bool vtkF3DPolyDataMapper::RenderWithMatCap(vtkActor* actor)
   }
 
   auto textures = actor->GetProperty()->GetAllTextures();
-
   auto fn = [](const std::pair<std::string, vtkTexture*>& tex) { return tex.first == "matcap"; };
-
   return std::find_if(textures.begin(), textures.end(), fn) != textures.end();
 }
 
@@ -217,9 +215,9 @@ void vtkF3DPolyDataMapper::ReplaceShaderLight(
 
     auto FSSource = fragmentShader->GetSource();
 
-    std::string customLight = "//VTK::Light::Impl\n";
-    customLight += "vec2 uv = vec2(normalVCVSOutput.xy) * 0.5 + vec2(0.5,0.5);\n";
-    customLight += "gl_FragData[0] = texture(matcap, uv);\n";
+    std::string customLight = "//VTK::Light::Impl\n"
+                              "vec2 uv = vec2(normalVCVSOutput.xy) * 0.5 + vec2(0.5,0.5);\n"
+                              "gl_FragData[0] = texture(matcap, uv);\n";
 
     vtkShaderProgram::Substitute(FSSource, "//VTK::Light::Impl", customLight);
 

--- a/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.h
+++ b/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.h
@@ -36,6 +36,9 @@ protected:
   ~vtkF3DPolyDataMapper() override = default;
 
 private:
+  /**
+   * Returns true if a MatCap texture is defined by the user and the actor has normals
+   */
   bool RenderWithMatCap(vtkActor* actor);
 };
 

--- a/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.h
+++ b/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.h
@@ -21,11 +21,22 @@ public:
   void ReplaceShaderValues(
     std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor) override;
 
+  ///@{
+  /**
+   * Modify the shaders to use MatCap if enabled
+   */
+  void ReplaceShaderColor(
+    std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor) override;
+  void ReplaceShaderLight(
+    std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor) override;
+  ///@}
+
 protected:
   vtkF3DPolyDataMapper();
   ~vtkF3DPolyDataMapper() override = default;
 
-  bool HaveJoints = false;
+private:
+  bool RenderWithMatCap(vtkActor* actor);
 };
 
 #endif

--- a/library/VTKExtensions/Rendering/vtkF3DRendererWithColoring.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRendererWithColoring.cxx
@@ -52,6 +52,7 @@ vtkSmartPointer<vtkTexture> GetTexture(const std::string& filePath, bool isSRGB 
           texture->UseSRGBColorSpaceOn();
         }
         texture->InterpolateOn();
+        texture->SetColorModeToDirectScalars();
         return texture;
       }
       else
@@ -156,6 +157,16 @@ void vtkF3DRendererWithColoring::SetEmissiveFactor(double* factor)
 }
 
 //----------------------------------------------------------------------------
+void vtkF3DRendererWithColoring::SetTextureMatCap(const std::string& tex)
+{
+  if (this->TextureMatCap != tex)
+  {
+    this->TextureMatCap = tex;
+    this->ColoringActorsPropertiesConfigured = false;
+  }
+}
+
+//----------------------------------------------------------------------------
 void vtkF3DRendererWithColoring::SetTextureBaseColor(const std::string& tex)
 {
   if (this->TextureBaseColor != tex)
@@ -217,6 +228,7 @@ void vtkF3DRendererWithColoring::ConfigureColoringActorsProperties()
     actorAndMapper.first->GetProperty()->SetEmissiveFactor(this->EmissiveFactor);
     actorAndMapper.first->GetProperty()->SetNormalTexture(::GetTexture(this->TextureNormal));
     actorAndMapper.first->GetProperty()->SetNormalScale(this->NormalScale);
+    actorAndMapper.first->GetProperty()->SetTexture("matcap", ::GetTexture(this->TextureMatCap));
 
     // If the input texture is RGBA, flag the actor as translucent
     if (colorTex && colorTex->GetImageDataInput(0)->GetNumberOfScalarComponents() == 4)

--- a/library/VTKExtensions/Rendering/vtkF3DRendererWithColoring.h
+++ b/library/VTKExtensions/Rendering/vtkF3DRendererWithColoring.h
@@ -63,6 +63,11 @@ public:
   void SetNormalScale(double normalScale);
 
   /**
+   * Set the material capture texture on all coloring actors
+   */
+  void SetTextureMatCap(const std::string& tex);
+
+  /**
    * Set the base color texture on all coloring actors
    */
   void SetTextureBaseColor(const std::string& tex);
@@ -276,6 +281,7 @@ protected:
   double NormalScale = 1.;
   double SurfaceColor[3] = { 1., 1., 1. };
   double EmissiveFactor[3] = { 1., 1., 1. };
+  std::string TextureMatCap;
   std::string TextureBaseColor;
   std::string TextureMaterial;
   std::string TextureEmissive;

--- a/library/VTKExtensions/Rendering/vtkF3DRendererWithColoring.h
+++ b/library/VTKExtensions/Rendering/vtkF3DRendererWithColoring.h
@@ -63,7 +63,9 @@ public:
   void SetNormalScale(double normalScale);
 
   /**
-   * Set the material capture texture on all coloring actors
+   * Set the material capture texture on all coloring actors.
+   * This texture includes baked lighting effect,
+   * so all other material textures are ignored.
    */
   void SetTextureMatCap(const std::string& tex);
 

--- a/library/src/options.cxx
+++ b/library/src/options.cxx
@@ -152,6 +152,8 @@ options::options()
   this->Internals->init("ui.loader-progress", false);
 
   // Model
+  this->Internals->init("model.matcap.texture", std::string());
+
   this->Internals->init("model.color.opacity", 1.0);
   // XXX: Not compatible with scivis: https://github.com/f3d-app/f3d/issues/347
   this->Internals->init("model.color.rgb", std::vector<double>{ 1., 1., 1. });

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -341,6 +341,7 @@ void window_impl::UpdateDynamicOptions()
       this->Internals->Options.getAsDoubleVector("model.emissive.factor").data());
     renWithColor->SetTextureNormal(this->Internals->Options.getAsString("model.normal.texture"));
     renWithColor->SetNormalScale(this->Internals->Options.getAsDouble("model.normal.scale"));
+    renWithColor->SetTextureMatCap(this->Internals->Options.getAsString("model.matcap.texture"));
 
     renWithColor->SetColoring(this->Internals->Options.getAsBool("model.scivis.cells"),
       this->Internals->Options.getAsString("model.scivis.array-name"),

--- a/testing/baselines/TestTextureMatCap.png
+++ b/testing/baselines/TestTextureMatCap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8cec002181292257cd7b95e0d87bff4e3911ac895220a0bded4ceaf4b767da9
+size 31369

--- a/testing/data/DATA_LICENSES.md
+++ b/testing/data/DATA_LICENSES.md
@@ -33,6 +33,7 @@
 - SimpleMorph.gltf: glTF-Sample-Models: Public Domain
 - SimpleSkin.gltf: glTF-Sample-Models: Public Domain
 - samplePTS.pts: VTK Data: BSD-3-Clause
+- skin.png: Blender: [CC0](https://creativecommons.org/publicdomain/zero/1.0/)
 - small.ex2: VTK Data: BSD-3-Clause
 - teapot.off: Utah Teapot: Public Domain
 - tensors.vti: VTK Data: BSD-3-Clause

--- a/testing/data/skin.png
+++ b/testing/data/skin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f7eb242c063c32508a7182ae87cf3d788ed6b2cc3d56d303d0cb4ce2e989407
+size 613902


### PR DESCRIPTION
Fixes #811 

![2023-06-07-230145_window](https://github.com/f3d-app/f3d/assets/6069752/39f49ab3-507a-45b3-96c2-012d5dce7bb6)

Add a new shading model based on MatCap textures.  
These textures encode everything: ambient, diffuse, specular and baked lighting.
When the texture is given throught `--texture-matcap` option, all other materials and lights are ignored.

For example, the image above is generated using the following texture:
![skin](https://github.com/f3d-app/f3d/assets/6069752/7221a444-5a32-4e0d-b567-90bb55ca77a6)

Usually the textures will be squared and should look like a sphere touching the edge of the texture.

This PR also fixes an issue when textures given by the user have a depth of 16 or 32 bits per channel.