### PR TITLE
Initialize lib in instance instead of global

### DIFF
--- a/library/private/init.h
+++ b/library/private/init.h
@@ -2,14 +2,13 @@
  * @class   init
  * @brief   A private class used to initialize libf3d
  *
- * A private class used to initialize libf3d, it relies on a global static instance
+ * A private class used to initialize libf3d, it relies on a static initialization
+ * method that creates an static internal instance.
  * that will call the necessary code when loading the libf3d symbols
  */
 
 #ifndef f3d_init_h
 #define f3d_init_h
-
-#include <memory>
 
 namespace f3d::detail
 {
@@ -17,24 +16,26 @@ class init
 {
 public:
   /**
+   * Internally create an init static instance
+   */
+  static void initialize();
+
+  /**
    * libf3d initialization:
    *  - Control VTK global warning mechanism
    *  - Control VTK logger behavior
    *  - Create and register VTK factories
    *  - Set log verbose level to info to initialize the output window
+   *  - Register additional image readers
+   *
+   * Public is needed because initialize uses make_shared
    */
   init();
 
   /**
    * Default destructor
    */
-  ~init();
-
-private:
-  class internals;
-  std::unique_ptr<internals> Internals;
+  ~init() = default;
 };
 }
-
-static const f3d::detail::init gInitInstance;
 #endif

--- a/library/src/engine.cxx
+++ b/library/src/engine.cxx
@@ -1,7 +1,7 @@
 #include "engine.h"
 
 #include "config.h"
-#include "init.h" // This includes is needed on mac so that the global variable is created
+#include "init.h"
 #include "interactor_impl.h"
 #include "loader_impl.h"
 #include "log.h"
@@ -36,6 +36,9 @@ public:
 engine::engine(window::Type windowType)
   : Internals(new engine::internals)
 {
+  // Ensure all lib initialization is done (once)
+  detail::init::initialize();
+
   // build default cache path
 #if defined(_WIN32)
   std::string cachePath = vtksys::SystemTools::GetEnv("LOCALAPPDATA");
@@ -263,7 +266,7 @@ std::vector<std::string> engine::getPluginsList(const std::string& pluginPath)
         }
         catch (const nlohmann::json::parse_error& ex)
         {
-          f3d::log::warn(fullPath, " is not a valid JSON file: ", ex.what());
+          log::warn(fullPath, " is not a valid JSON file: ", ex.what());
         }
       }
     }

--- a/library/src/image.cxx
+++ b/library/src/image.cxx
@@ -1,5 +1,7 @@
 #include "image.h"
 
+#include "init.h"
+
 #include <vtkImageDifference.h>
 #include <vtkImageExport.h>
 #include <vtkImageImport.h>
@@ -58,12 +60,15 @@ public:
 image::image()
   : Internals(new image::internals())
 {
+  detail::init::initialize();
 }
 
 //----------------------------------------------------------------------------
 image::image(const std::string& path)
   : Internals(new image::internals())
 {
+  detail::init::initialize();
+
   std::string fullPath = vtksys::SystemTools::CollapseFullPath(path);
   if (!vtksys::SystemTools::FileExists(fullPath))
   {
@@ -196,7 +201,7 @@ bool image::compare(const image& reference, double threshold, image& diff, doubl
 //----------------------------------------------------------------------------
 bool image::operator==(const image& reference) const
 {
-  f3d::image diff;
+  image diff;
   double error;
   return this->compare(reference, 0, diff, error);
 }

--- a/library/src/init.cxx
+++ b/library/src/init.cxx
@@ -14,15 +14,23 @@
 #include <vtkNew.h>
 #include <vtkVersion.h>
 
+#include <memory>
+
 namespace f3d::detail
 {
-class init::internals
+
+//----------------------------------------------------------------------------
+void init::initialize()
 {
-};
+  static std::unique_ptr<init> instance;
+  if (!instance)
+  {
+    instance = std::make_unique<init>();
+  }
+}
 
 //----------------------------------------------------------------------------
 init::init()
-  : Internals(std::make_unique<init::internals>())
 {
 #if NDEBUG
   vtkObject::GlobalWarningDisplayOff();
@@ -51,8 +59,4 @@ init::init()
   vtkImageReader2Factory::RegisterReader(reader);
 #endif
 }
-
-//----------------------------------------------------------------------------
-init::~init() = default;
-
 }

--- a/library/src/log.cxx
+++ b/library/src/log.cxx
@@ -1,5 +1,7 @@
 #include "log.h"
 
+#include "init.h"
+
 #include "F3DLog.h"
 
 namespace f3d
@@ -8,6 +10,8 @@ namespace f3d
 //----------------------------------------------------------------------------
 void log::printInternal(log::VerboseLevel level, const std::string& str)
 {
+  detail::init::initialize();
+
   switch (level)
   {
     case (log::VerboseLevel::DEBUG):
@@ -31,36 +35,42 @@ void log::printInternal(log::VerboseLevel level, const std::string& str)
 //----------------------------------------------------------------------------
 void log::debugInternal(const std::string& str)
 {
+  detail::init::initialize();
   F3DLog::Print(F3DLog::Severity::Debug, str);
 }
 
 //----------------------------------------------------------------------------
 void log::infoInternal(const std::string& str)
 {
+  detail::init::initialize();
   F3DLog::Print(F3DLog::Severity::Info, str);
 }
 
 //----------------------------------------------------------------------------
 void log::warnInternal(const std::string& str)
 {
+  detail::init::initialize();
   F3DLog::Print(F3DLog::Severity::Warning, str);
 }
 
 //----------------------------------------------------------------------------
 void log::errorInternal(const std::string& str)
 {
+  detail::init::initialize();
   F3DLog::Print(F3DLog::Severity::Error, str);
 }
 
 //----------------------------------------------------------------------------
 void log::setUseColoring(bool use)
 {
+  detail::init::initialize();
   F3DLog::SetUseColoring(use);
 }
 
 //----------------------------------------------------------------------------
 void log::setVerboseLevel(log::VerboseLevel level)
 {
+  detail::init::initialize();
   F3DLog::SetQuiet(level == log::VerboseLevel::QUIET);
   switch (level)
   {
@@ -85,6 +95,7 @@ void log::setVerboseLevel(log::VerboseLevel level)
 //----------------------------------------------------------------------------
 void log::waitForUser()
 {
+  detail::init::initialize();
   F3DLog::WaitForUser();
 }
 }

--- a/library/src/options.cxx
+++ b/library/src/options.cxx
@@ -1,5 +1,6 @@
 #include "options.h"
 
+#include "init.h"
 #include "log.h"
 
 #include "vtkF3DConfigure.h"
@@ -106,6 +107,8 @@ public:
 options::options()
   : Internals(new options::internals)
 {
+  detail::init::initialize();
+
   // Scene
   this->Internals->init("scene.animation.index", 0);
   this->Internals->init("scene.animation.speed-factor", 1.0);


### PR DESCRIPTION
 - Move initialization logic from a global logic to an instance logic
 - Remove a few useless `f3d::`