### PR TITLE
Allow python camera's `setPosition`, `setFocalPoint`, `setViewUp` to accept tuples

### DIFF
--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -24,6 +24,19 @@ void pyseq_to_array(const py::sequence& seq, std::array<T, S>& arr)
     arr[i] = py::cast<T>(seq[i]);
 }
 
+size_t py_index(int i, size_t len)
+{
+  if (i < 0)
+  {
+    i += len;
+  }
+  if (i < 0 || i >= len)
+  {
+    throw py::index_error();
+  }
+  return i;
+}
+
 PYBIND11_MODULE(f3d, module)
 {
   module.doc() = "f3d library bindings";
@@ -35,8 +48,9 @@ PYBIND11_MODULE(f3d, module)
     .def(
       "__iter__", [](const f3d::point3_t& p) { return py::make_iterator(p); },
       py::keep_alive<0, 1>()) /* keep alive while iterator is used */
-    .def("__getitem__", [](const f3d::point3_t& p, int i) { return p[i]; })
-    .def("__setitem__", [](f3d::point3_t& p, int i, double value) { p[i] = value; });
+    .def("__getitem__", [](const f3d::point3_t& p, int i) { return p[py_index(i, p.size())]; })
+    .def("__setitem__",
+      [](f3d::point3_t& p, int i, double value) { p[py_index(i, p.size())] = value; });
 
   py::class_<f3d::vector3_t>(module, "vector3_t")
     .def(py::init<double, double, double>())
@@ -44,8 +58,9 @@ PYBIND11_MODULE(f3d, module)
     .def(
       "__iter__", [](const f3d::vector3_t& v) { return py::make_iterator(v); },
       py::keep_alive<0, 1>()) /* keep alive while iterator is used */
-    .def("__getitem__", [](const f3d::vector3_t& v, int i) { return v[i]; })
-    .def("__setitem__", [](f3d::vector3_t& v, int i, double value) { v[i] = value; });
+    .def("__getitem__", [](const f3d::vector3_t& v, int i) { return v[py_index(i, v.size())]; })
+    .def("__setitem__",
+      [](f3d::vector3_t& v, int i, double value) { v[py_index(i, v.size())] = value; });
 
   // f3d::image
   py::class_<f3d::image>(module, "image")

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -19,9 +19,13 @@ void pyseq_to_array(const py::sequence& seq, std::array<T, S>& arr)
 {
   const size_t len = py::len(seq);
   if (len != arr.size())
+  {
     throw py::value_error("wrong length");
+  }
   for (size_t i = 0; i < len; ++i)
+  {
     arr[i] = py::cast<T>(seq[i]);
+  }
 }
 
 size_t py_index(int i, size_t len)

--- a/python/testing/TestPythonCamera.py
+++ b/python/testing/TestPythonCamera.py
@@ -24,6 +24,17 @@ assert tuple(point) == xyz
 assert (point[0], point[1], point[2]) == xyz
 point[1] += 1
 assert tuple(point) == (xyz[0], xyz[1] + 1, xyz[2])
+point[-1] -= 1
+assert tuple(point) == (xyz[0], xyz[1] + 1, xyz[2] - 1)
+
+try:
+    point[3] = 2
+except IndexError:
+    assert True
+try:
+    point[-4] = 2
+except IndexError:
+    assert True
 
 # vector3_t
 vector = f3d.vector3_t(*xyz)
@@ -31,6 +42,17 @@ assert tuple(vector) == xyz
 assert (vector[0], vector[1], vector[2]) == xyz
 vector[1] += 1
 assert tuple(vector) == (xyz[0], xyz[1] + 1, xyz[2])
+vector[-1] -= 1
+assert tuple(vector) == (xyz[0], xyz[1] + 1, xyz[2] - 1)
+
+try:
+    vector[3] = 2
+except IndexError:
+    assert True
+try:
+    vector[-4] = 2
+except IndexError:
+    assert True
 
 
 # position as point3_t

--- a/python/testing/TestPythonCamera.py
+++ b/python/testing/TestPythonCamera.py
@@ -1,7 +1,8 @@
 import sys
-if sys.platform.startswith('win32'):
-  import os
-  os.add_dll_directory(sys.argv[1])
+import os
+
+if sys.platform.startswith("win32"):
+    os.add_dll_directory(sys.argv[1])
 
 import f3d
 
@@ -16,19 +17,68 @@ camera.setViewAngle(angle)
 camera.getViewAngle(angle)
 angle = camera.getViewAngle()
 
-point = f3d.point3_t(0, 0, 0)
-camera.setPosition(point)
-camera.getPosition(point)
-point = camera.getPosition()
+# point3_t
+xyz = 1, 2, 3
+point = f3d.point3_t(*xyz)
+assert tuple(point) == xyz
+assert (point[0], point[1], point[2]) == xyz
+point[1] += 1
+assert tuple(point) == (xyz[0], xyz[1] + 1, xyz[2])
 
-camera.setFocalPoint(point)
-camera.getFocalPoint(point)
-point = camera.getFocalPoint()
+# vector3_t
+vector = f3d.vector3_t(*xyz)
+assert tuple(vector) == xyz
+assert (vector[0], vector[1], vector[2]) == xyz
+vector[1] += 1
+assert tuple(vector) == (xyz[0], xyz[1] + 1, xyz[2])
 
-vector = f3d.vector3_t(0, 0, 1)
-camera.setViewUp(vector)
-camera.getViewUp(vector)
-vector = camera.getViewUp()
+
+# position as point3_t
+point_in = f3d.point3_t(1, 2, 3)
+point_out = f3d.point3_t(0, 0, 0)
+camera.setPosition(point_in)
+camera.getPosition(point_out)
+assert tuple(point_out) == tuple(point_in)
+
+# position as tuple
+tuple_in = 3, 4, 5
+camera.setPosition(tuple_in)
+assert tuple(camera.getPosition()) == tuple_in
+
+
+# focalPoint as point3_t
+point_in = f3d.point3_t(1, 2, 3)
+point_out = f3d.point3_t(0, 0, 0)
+camera.setFocalPoint(point_in)
+camera.getFocalPoint(point_out)
+assert tuple(point_out) == tuple(point_in)
+
+# focalPoint as tuple
+tuple_in = 3, 4, 5
+camera.setFocalPoint(tuple_in)
+assert tuple(camera.getFocalPoint()) == tuple_in
+
+
+# viewUp as vector3_t
+camera.setPosition((1, 0, 0))
+camera.setFocalPoint((0, 0, 0))
+camera.setViewUp((0, 1, 0))
+
+vector_in = f3d.vector3_t(0, 0, 1)
+vector_out = f3d.vector3_t(0, 0, 0)
+camera.setViewUp(vector_in)
+camera.getViewUp(vector_out)
+assert tuple(vector_out) == tuple(vector_in)
+
+# viewUp as tuple
+camera.setPosition((1, 0, 0))
+camera.setFocalPoint((0, 0, 0))
+camera.setViewUp((0, 1, 0))
+
+tuple_in = 0, 0, 1
+camera.setViewUp(tuple_in)
+assert tuple(camera.getViewUp()) == tuple_in
+
 
 camera.dolly(10)
 camera.roll(angle)


### PR DESCRIPTION
Also allow `vector3_t` and `point3_t` to be subscriptable  (eg. `point[1]` to get y coord) and iterable (eg. `xyz = tuple(point)` or `x,y,z = point`)