### PR TITLE
Alternative python `point3_t` and `vector3_t` refactor

### DIFF
--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -14,25 +14,27 @@
 
 namespace py = pybind11;
 
-namespace PYBIND11_NAMESPACE
-{
-namespace detail
-{
 template<>
-class type_caster<f3d::point3_t>
+class py::detail::type_caster<f3d::point3_t>
 {
 public:
   bool load(handle src, bool convert)
   {
     if (!isinstance<sequence>(src))
+    {
       return false;
+    }
     py::sequence l = reinterpret_borrow<sequence>(src);
     if (l.size() != 3)
+    {
       return false;
+    }
 
     size_t i = 0;
     for (auto it : l)
+    {
       value[i++] = py::cast<double>(it);
+    }
     return true;
   }
 
@@ -45,20 +47,26 @@ public:
 };
 
 template<>
-class type_caster<f3d::vector3_t>
+class py::detail::type_caster<f3d::vector3_t>
 {
 public:
   bool load(handle src, bool convert)
   {
     if (!isinstance<sequence>(src))
+    {
       return false;
+    }
     py::sequence l = reinterpret_borrow<sequence>(src);
     if (l.size() != 3)
+    {
       return false;
+    }
 
     size_t i = 0;
     for (auto it : l)
+    {
       value[i++] = py::cast<double>(it);
+    }
     return true;
   }
 
@@ -69,9 +77,6 @@ public:
 
   PYBIND11_TYPE_CASTER(f3d::vector3_t, const_name("f3d.vector3_t"));
 };
-
-}
-}
 
 PYBIND11_MODULE(f3d, module)
 {

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -43,7 +43,7 @@ public:
 
   static handle cast(const f3d::point3_t& src, return_value_policy, handle /* parent */)
   {
-    return Py_BuildValue("fff", src[0], src[1], src[2]);
+    return Py_BuildValue("ddd", src[0], src[1], src[2]);
   }
 
   PYBIND11_TYPE_CASTER(f3d::point3_t, const_name("f3d.point3_t"));
@@ -57,7 +57,7 @@ public:
 
   static handle cast(const f3d::vector3_t& src, return_value_policy, handle /* parent */)
   {
-    return Py_BuildValue("fff", src[0], src[1], src[2]);
+    return Py_BuildValue("ddd", src[0], src[1], src[2]);
   }
 
   PYBIND11_TYPE_CASTER(f3d::vector3_t, const_name("f3d.vector3_t"));

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -14,28 +14,34 @@
 
 namespace py = pybind11;
 
+template<typename T, size_t S>
+bool load_array(const py::handle& src, bool convert, std::array<T, S>& value)
+{
+  if (!py::isinstance<py::sequence>(src))
+  {
+    return false;
+  }
+  const py::sequence l = py::reinterpret_borrow<py::sequence>(src);
+  if (l.size() != S)
+  {
+    return false;
+  }
+
+  size_t i = 0;
+  for (auto it : l)
+  {
+    value[i++] = py::cast<T>(it);
+  }
+  return true;
+}
+
 template<>
 class py::detail::type_caster<f3d::point3_t>
 {
 public:
   bool load(handle src, bool convert)
   {
-    if (!isinstance<sequence>(src))
-    {
-      return false;
-    }
-    py::sequence l = reinterpret_borrow<sequence>(src);
-    if (l.size() != 3)
-    {
-      return false;
-    }
-
-    size_t i = 0;
-    for (auto it : l)
-    {
-      value[i++] = py::cast<double>(it);
-    }
-    return true;
+    return load_array(src, convert, value);
   }
 
   static handle cast(const f3d::point3_t& src, return_value_policy, handle /* parent */)
@@ -52,22 +58,7 @@ class py::detail::type_caster<f3d::vector3_t>
 public:
   bool load(handle src, bool convert)
   {
-    if (!isinstance<sequence>(src))
-    {
-      return false;
-    }
-    py::sequence l = reinterpret_borrow<sequence>(src);
-    if (l.size() != 3)
-    {
-      return false;
-    }
-
-    size_t i = 0;
-    for (auto it : l)
-    {
-      value[i++] = py::cast<double>(it);
-    }
-    return true;
+    return load_array(src, convert, value);
   }
 
   static handle cast(const f3d::vector3_t& src, return_value_policy, handle /* parent */)

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -39,10 +39,7 @@ template<>
 class py::detail::type_caster<f3d::point3_t>
 {
 public:
-  bool load(handle src, bool convert)
-  {
-    return load_array(src, convert, value);
-  }
+  bool load(handle src, bool convert) { return load_array(src, convert, value); }
 
   static handle cast(const f3d::point3_t& src, return_value_policy, handle /* parent */)
   {
@@ -56,10 +53,7 @@ template<>
 class py::detail::type_caster<f3d::vector3_t>
 {
 public:
-  bool load(handle src, bool convert)
-  {
-    return load_array(src, convert, value);
-  }
+  bool load(handle src, bool convert) { return load_array(src, convert, value); }
 
   static handle cast(const f3d::vector3_t& src, return_value_policy, handle /* parent */)
   {

--- a/python/testing/TestPythonCamera.py
+++ b/python/testing/TestPythonCamera.py
@@ -1,7 +1,8 @@
 import sys
-if sys.platform.startswith('win32'):
-  import os
-  os.add_dll_directory(sys.argv[1])
+import os
+
+if sys.platform.startswith("win32"):
+    os.add_dll_directory(sys.argv[1])
 
 import f3d
 
@@ -10,27 +11,56 @@ camera = engine.getWindow().getCamera()
 
 # Behavior is tested in the SDK test, test only the bindings
 
-# TODO Once angle_deg_t is an actual struct, this will need to be changed
-angle = 30
+pos = 1, 2, 3
+foc = 1, 22, 3
+up = 0, 0, 1
+angle = 32
+
+camera.setPosition(pos)
+camera.setFocalPoint(foc)
+camera.setViewUp(up)
 camera.setViewAngle(angle)
-camera.getViewAngle(angle)
-angle = camera.getViewAngle()
+assert camera.getPosition() == pos
+assert camera.getFocalPoint() == foc
+assert camera.getViewUp() == up
+assert camera.getViewAngle() == angle
 
-point = f3d.point3_t(0, 0, 0)
-camera.setPosition(point)
-camera.getPosition(point)
-point = camera.getPosition()
 
-camera.setFocalPoint(point)
-camera.getFocalPoint(point)
-point = camera.getFocalPoint()
+state = camera.getState()
+assert state.pos == pos
+assert state.foc == foc
+assert state.up == up
+assert state.angle == angle
 
-vector = f3d.vector3_t(0, 0, 1)
-camera.setViewUp(vector)
-camera.getViewUp(vector)
-vector = camera.getViewUp()
+
+new_default_state = f3d.camera_state_t()
+assert new_default_state.pos == (0, 0, 1)
+assert new_default_state.foc == (0, 0, 0)
+assert new_default_state.up == (0, 1, 0)
+assert new_default_state.angle == 30
+
+camera.setState(new_default_state)
+assert camera.getPosition() == new_default_state.pos
+assert camera.getFocalPoint() == new_default_state.foc
+assert camera.getViewUp() == new_default_state.up
+assert camera.getViewAngle() == new_default_state.angle
+
+
+new_state = f3d.camera_state_t(pos, foc, up, angle)
+assert new_state.pos == pos
+assert new_state.foc == foc
+assert new_state.up == up
+assert new_state.angle == angle
+
+camera.setState(new_state)
+assert camera.getPosition() == new_state.pos
+assert camera.getFocalPoint() == new_state.foc
+assert camera.getViewUp() == new_state.up
+assert camera.getViewAngle() == new_state.angle
+
 
 camera.dolly(10)
+angle = 30
 camera.roll(angle)
 camera.azimuth(angle)
 camera.yaw(angle)


### PR DESCRIPTION
In the previous episode (#867) we added support for built-in method to the `point3_t` and `vector3_t` classes so they could behave like tuples, and we added overloads to methods so they could accept tuples in place of these classes.

In this alternative installment we drop the bindings for `point3_t` and `vector3_t` altogether and use `pybind`'s type casters to transparently use tuples instead.
We also drop the getter methods with out parameters that won't work anymore (or haven't ever worked like `camera.getViewAngle(angle_out)`).

This approach seems simpler and more straight-forward, `point3_t` and `vector3_t` being simply `array<double, 3>` in c++ it makes sense they'd be simple `(float, float, float)` tuples in python.

The only thing that might be an issue for some is that python tuples are immutable so this wouldn't work anymore:
```py
p = camera.getPosition()  # point3_t auto casts to tuple
p[1] += 10  # TypeError: 'tuple' object does not support item assignment
camera.setPosition(p)  # point3_t auto casts from tuple, won't run cause we crashed above
```
but one could easilly enough do:
```py
p = list(camera.getPosition())  # manually re-convert to list
p[1] += 10  # p is a list now so all good
camera.setPosition(p)  # point3_t auto casts from any Sequence type so a list works
```

Thoughts?