### PR TITLE
Build TBB in CI

### DIFF
--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -9,7 +9,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: dependencies/ospray_install
-        key: ospray-sb-v2.7.1-${{runner.os}}-0
+        key: ospray-sb-v2.7.1-${{runner.os}}-1
 
     - name: Checkout ospray
       if: steps.cache-ospray.outputs.cache-hit != 'true'
@@ -48,7 +48,7 @@ runs:
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX:PATH=../ospray_install
         -DDOWNLOAD_ISPC=ON
-        -DDOWNLOAD_TBB=ON
+        -DDOWNLOAD_TBB=OFF
         -DINSTALL_DEPENDENCIES=ON
         -DINSTALL_IN_SEPARATE_DIRECTORIES=OFF
         ${{ runner.os == 'macOS' && '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15' || null }}

--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -47,6 +47,7 @@ runs:
         -DBUILD_OSPRAY_APPS=OFF
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX:PATH=../ospray_install
+        -DCMAKE_PREFIX_PATH:PATH=../install/
         -DDOWNLOAD_ISPC=ON
         -DDOWNLOAD_TBB=OFF
         -DINSTALL_DEPENDENCIES=ON

--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -34,12 +34,15 @@ runs:
         mkdir ospray_build
         mkdir ospray_install
 
+    - name: Set TBB_ROOT
+      working-directory: ${{github.workspace}}/dependencies/
+      shell: bash
+      run: echo "TBB_ROOT=$(pwd)/install" >> $GITHUB_ENV
+
     - name: Configure ospray
       if: steps.cache-ospray.outputs.cache-hit != 'true'
       working-directory: ${{github.workspace}}/dependencies/ospray_build
       shell: bash
-      env:
-        TBB_ROOT: ${{github.workspace}}/dependencies/install
       run: >
         cmake ../ospray/scripts/superbuild/
         -DBUILD_EMBREE_FROM_SOURCE=OFF

--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -38,6 +38,8 @@ runs:
       if: steps.cache-ospray.outputs.cache-hit != 'true'
       working-directory: ${{github.workspace}}/dependencies/ospray_build
       shell: bash
+      env:
+        TBB_ROOT: ${{github.workspace}}/dependencies/install
       run: >
         cmake ../ospray/scripts/superbuild/
         -DBUILD_EMBREE_FROM_SOURCE=OFF
@@ -47,7 +49,6 @@ runs:
         -DBUILD_OSPRAY_APPS=OFF
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX:PATH=../ospray_install
-        -DCMAKE_PREFIX_PATH:PATH=../install/
         -DDOWNLOAD_ISPC=ON
         -DDOWNLOAD_TBB=OFF
         -DINSTALL_DEPENDENCIES=ON

--- a/.github/actions/tbb-install-dep/action.yml
+++ b/.github/actions/tbb-install-dep/action.yml
@@ -1,0 +1,55 @@
+name: 'Install TBB Dependency'
+description: 'Install TBB Dependency using cache when possible'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Cache TBB
+      id: cache-tbb
+      uses: actions/cache@v3
+      with:
+        path: dependencies/tbb_install
+        key: tbb-v2021.9.0-${{runner.os}}-2
+
+    - name: Checkout TBB
+      if: steps.cache-tbb.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: oneapi-src/oneTBB
+        path: './dependencies/tbb'
+        ref: v2021.9.0
+
+    - name: Setup TBB
+      if: steps.cache-tbb.outputs.cache-hit != 'true'
+      working-directory: ${{github.workspace}}/dependencies
+      shell: bash
+      run: |
+        mkdir tbb_build
+        mkdir tbb_install
+
+    - name: Configure TBB
+      if: steps.cache-tbb.outputs.cache-hit != 'true'
+      working-directory: ${{github.workspace}}/dependencies/tbb_build
+      shell: bash
+      run: >
+        cmake ../tbb
+        -DBUILD_SHARED_LIBS=ON
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_INSTALL_PREFIX:PATH=../tbb_install
+        -DTBB_STRICT=OFF
+        -DTBB_TEST=OFF
+        -DTBB4PY_BUILD=OFF
+        ${{ runner.os == 'macOS' && '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_MACOSX_RPATH=ON' || null }}
+        ${{ runner.os == 'Windows' && '-Ax64 -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL' || null }}
+
+    - name: Build TBB
+      if: steps.cache-tbb.outputs.cache-hit != 'true'
+      working-directory: ${{github.workspace}}/dependencies/tbb_build
+      shell: bash
+      run: cmake --build . --parallel 2 --target install --config Release
+
+    - name: Copy to install
+      working-directory: ${{github.workspace}}/dependencies/tbb_install
+      shell: bash
+      run: cp -r ./* ../install/

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -43,7 +43,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: dependencies/vtk_install
-        key: vtk-${{env.VTK_SHA_OR_TAG}}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.egl_label}}-2
+        key: vtk-${{env.VTK_SHA_OR_TAG}}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.egl_label}}-3
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'
@@ -83,13 +83,6 @@ runs:
         sed -i '' '57i\'$'\n''herr_t H5O__fsinfo_set_version(H5F_t *f, H5O_fsinfo_t *fsinfo);' ThirdParty/hdf5/vtkhdf5/src/H5Fsuper.c
         sed -i '' '46i\'$'\n''#include "H5CXprivate.h"' ThirdParty/hdf5/vtkhdf5/src/H5Oint.c
         sed -i '' '36i\'$'\n''#include "H5CXprivate.h"' ThirdParty/hdf5/vtkhdf5/src/H5Rint.c
-
-    - name: Install TBB MacOS
-      if: |
-        runner.os == 'macOS' &&
-        inputs.vtk_version != 'v9.0.0'
-      shell: bash
-      run: brew install tbb
 
     - name: Configure VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
         cd dependencies
         mkdir install
 
+    - name: Install TBB
+      uses: ./source/.github/actions/tbb-install-dep
+
     - name: Install Raytracing Dependencies
       if: matrix.raytracing_label == 'raytracing'
       uses: ./source/.github/actions/ospray-sb-install-dep
@@ -348,6 +351,9 @@ jobs:
         cd dependencies
         mkdir install
 
+    - name: Install TBB
+      uses: ./source/.github/actions/tbb-install-dep
+
     - name: Install Raytracing Dependencies
       uses: ./source/.github/actions/ospray-sb-install-dep
 
@@ -453,6 +459,9 @@ jobs:
         mkdir dependencies
         cd dependencies
         mkdir install
+
+    - name: Install TBB
+      uses: ./source/.github/actions/tbb-install-dep
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep


### PR DESCRIPTION
TBB is currently automatically built by OSPRay in the CI.  
However if the raytracing is disabled, we still need TBB for VTK SMP backend, and for USD soon.  
Currently, we get TBB with brew for macOS where raytracing is disabled, but that's not great.

Let's build it ourself.