### PR TITLE
Fix F3D build when added as a subproject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,9 +641,9 @@ jobs:
         mkdir install
 
     - name: Install VTK dependency
-      uses: ./source/.github/actions/vtk-install-dep
+      uses: ./source/f3d/.github/actions/vtk-install-dep
       with:
-        vtk_sha_file: ./source/.github/actions/vtk_commit_sha
+        vtk_sha_file: ./source/f3d/.github/actions/vtk_commit_sha
 
     - name: Setup Build Directory
       working-directory: ${{github.workspace}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,7 +624,7 @@ jobs:
       working-directory: ${{github.workspace}}
       run: |
         mkdir source
-        echo "project(toplevel)\nadd_subdirectory(f3d)" > source/CMakeLists.txt
+        echo "cmake_minimum_required(VERSION 3.21)\nproject(toplevel)\nadd_subdirectory(f3d)" > source/CMakeLists.txt
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,3 +604,62 @@ jobs:
         --enable=all
         --suppressions-list=.cppcheck.supp
         --error-exitcode=1
+
+#----------------------------------------------------------------------------
+# external-build: Check build of F3D as sub-project
+#----------------------------------------------------------------------------
+  external-build:
+    needs: cache_lfs
+    if: github.event.pull_request.draft == false
+
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+    container: ghcr.io/f3d-app/f3d-ci
+
+    steps:
+
+    - name: Create top level
+      working-directory: ${{github.workspace}}
+      run: |
+        mkdir source
+        echo "project(toplevel)\nadd_subdirectory(f3d)" > source/CMakeLists.txt
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        path: 'source/f3d'
+        fetch-depth: 0
+        lfs: false
+
+    - name: Dependencies Dir
+      working-directory: ${{github.workspace}}
+      run: |
+        mkdir dependencies
+        cd dependencies
+        mkdir install
+
+    - name: Install VTK dependency
+      uses: ./source/.github/actions/vtk-install-dep
+      with:
+        vtk_sha_file: ./source/.github/actions/vtk_commit_sha
+
+    - name: Setup Build Directory
+      working-directory: ${{github.workspace}}
+      run: mkdir build
+
+    - name: Configure
+      working-directory: ${{github.workspace}}/build
+      run: >
+        cmake ../source
+        -Werror=dev
+        -Werror=deprecated
+        --warn-uninitialized
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_PREFIX_PATH:PATH=$(pwd)/../dependencies/install/
+        -DF3D_STRICT_BUILD=ON
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      run: cmake --build . --parallel 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 include(CMakeDependentOption)
 
 # Generic CMake variables, should be done before project()

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -2,7 +2,7 @@
 include("f3dEmbed")
 
 f3d_embed_file(
-  INPUT "${CMAKE_SOURCE_DIR}/resources/logo32.png"
+  INPUT "${F3D_SOURCE_DIR}/resources/logo32.png"
   NAME F3DIcon
   BINARY)
 
@@ -19,7 +19,7 @@ set(F3D_SOURCE_FILES
 )
 
 if(WIN32)
-  list(APPEND F3D_SOURCE_FILES "${CMAKE_SOURCE_DIR}/resources/f3d.rc")
+  list(APPEND F3D_SOURCE_FILES "${F3D_SOURCE_DIR}/resources/f3d.rc")
 endif()
 
 if(APPLE)
@@ -52,7 +52,7 @@ if (APPLE)
 elseif (UNIX)
   set_target_properties(f3d PROPERTIES INSTALL_RPATH $ORIGIN/../${CMAKE_INSTALL_LIBDIR})
 elseif (MSVC)
-  set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT f3d) # Set f3d as startup project in visual studio
+  set_property(DIRECTORY ${F3D_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT f3d) # Set f3d as startup project in visual studio
   set_target_properties(f3d PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=$<TARGET_FILE_DIR:VTK::CommonCore>") # Add VTK in MSVC PATH environment variable
 endif ()
 
@@ -60,13 +60,13 @@ target_include_directories(f3d PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_D
 if (F3D_USE_EXTERNAL_CXXOPTS)
   target_link_libraries(f3d PRIVATE cxxopts::cxxopts)
 else ()
-  target_include_directories(f3d PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/external/cxxopts>)
+  target_include_directories(f3d PUBLIC $<BUILD_INTERFACE:${F3D_SOURCE_DIR}/external/cxxopts>)
 endif ()
 
 if (F3D_USE_EXTERNAL_NLOHMANN_JSON)
   target_link_libraries(f3d PRIVATE nlohmann_json::nlohmann_json)
 else ()
-  target_include_directories(f3d PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/external/nlohmann_json>)
+  target_include_directories(f3d PUBLIC $<BUILD_INTERFACE:${F3D_SOURCE_DIR}/external/nlohmann_json>)
 endif ()
 
 set(f3d_compile_options_private "")
@@ -102,7 +102,7 @@ if(F3D_MACOS_BUNDLE)
 
   # Add logo icon
   set(MACOSX_BUNDLE_ICON_FILE logo.icns)
-  set(f3d_ICON ${CMAKE_SOURCE_DIR}/resources/logo.icns)
+  set(f3d_ICON ${F3D_SOURCE_DIR}/resources/logo.icns)
   set_source_files_properties(${f3d_ICON} PROPERTIES
     MACOSX_PACKAGE_LOCATION "Resources")
   target_sources(f3d PRIVATE ${f3d_ICON})
@@ -118,7 +118,7 @@ if(F3D_MACOS_BUNDLE)
   set(MACOSX_BUNDLE_COPYRIGHT "Michael Migliore, Mathieu Westphal")
 
   # Generate MacOS bundle
-  configure_file("${CMAKE_SOURCE_DIR}/resources/BundleInfo.plist.in"
+  configure_file("${F3D_SOURCE_DIR}/resources/BundleInfo.plist.in"
     "${CMAKE_CURRENT_BINARY_DIR}/BundleInfo.plist")
   set_target_properties(f3d PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/BundleInfo.plist")
 endif()

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -10,11 +10,11 @@ function(f3d_test)
   endif()
 
   if (F3D_TEST_DATA)
-    list(APPEND F3D_TEST_ARGS "${CMAKE_SOURCE_DIR}/testing/data/${F3D_TEST_DATA}")
+    list(APPEND F3D_TEST_ARGS "${F3D_SOURCE_DIR}/testing/data/${F3D_TEST_DATA}")
   endif()
 
   if(F3D_TEST_INTERACTION)
-    list(APPEND F3D_TEST_ARGS "--interaction-test-play=${CMAKE_SOURCE_DIR}/testing/recordings/${F3D_TEST_NAME}.log")
+    list(APPEND F3D_TEST_ARGS "--interaction-test-play=${F3D_SOURCE_DIR}/testing/recordings/${F3D_TEST_NAME}.log")
   endif()
 
   if(F3D_TEST_NO_RENDER)
@@ -33,7 +33,7 @@ function(f3d_test)
 
   if(NOT F3D_TEST_NO_BASELINE)
     if(NOT (F3D_TEST_DEFAULT_LIGHTS AND F3D_TESTING_DISABLE_DEFAULT_LIGHTS_TESTS_COMPARISON))
-      list(APPEND F3D_TEST_ARGS "--ref=${CMAKE_SOURCE_DIR}/testing/baselines/${F3D_TEST_NAME}.png")
+      list(APPEND F3D_TEST_ARGS "--ref=${F3D_SOURCE_DIR}/testing/baselines/${F3D_TEST_NAME}.png")
 
       if(F3D_TEST_THRESHOLD)
         list(APPEND F3D_TEST_ARGS "--ref-threshold=${F3D_TEST_THRESHOLD}")
@@ -142,7 +142,7 @@ f3d_test(NAME TestPTS DATA samplePTS.pts DEFAULT_LIGHTS) # Using default lights 
 f3d_test(NAME TestColormap DATA IM-0001-1983.dcm ARGS --scalars --roughness=1 --colormap=0,1,0,0,1,0,1,0 DEFAULT_LIGHTS)
 f3d_test(NAME TestCameraConfiguration DATA suzanne.obj ARGS --camera-position=0,0,-10 -x --camera-view-up=1,0,0 --camera-focal-point=1,0,0 --camera-view-angle=20 --camera-azimuth-angle=40 --camera-elevation-angle=-80 --camera-direction=12,34,56 --camera-zoom-factor=78)
 f3d_test(NAME TestCameraDirection DATA suzanne.obj ARGS --camera-direction=-1,-1,1 DEFAULT_LIGHTS)
-f3d_test(NAME TestCameraClipping DATA checkerboard_colorful.obj CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/checkerboard_colorful.json RESOLUTION 800,600)
+f3d_test(NAME TestCameraClipping DATA checkerboard_colorful.obj CONFIG ${F3D_SOURCE_DIR}/testing/configs/checkerboard_colorful.json RESOLUTION 800,600)
 f3d_test(NAME TestToneMapping DATA suzanne.ply ARGS -t DEFAULT_LIGHTS)
 f3d_test(NAME TestDepthPeelingToneMapping DATA suzanne.ply ARGS --opacity=0.9 -pt DEFAULT_LIGHTS)
 f3d_test(NAME TestVolume DATA HeadMRVolume.mhd ARGS -v --camera-position=127.5,-400,127.5 --camera-view-up=0,0,1 LONG_TIMEOUT THRESHOLD 300 DEFAULT_LIGHTS) # Using default lights because of ResetCamera, High threshold for volume as it is dependent on the OpenGL implementation
@@ -152,12 +152,12 @@ f3d_test(NAME TestVolumeComp DATA vase_4comp.vti ARGS -vb --comp=3 LONG_TIMEOUT 
 f3d_test(NAME TestVolumeDirect DATA vase_4comp.vti ARGS -vb --comp=-2 LONG_TIMEOUT DEFAULT_LIGHTS) # Using default lights because of ResetCamera
 f3d_test(NAME TestVolumeCells DATA waveletArrays.vti ARGS -vb --cells LONG_TIMEOUT DEFAULT_LIGHTS) # Using default lights because of ResetCamera
 f3d_test(NAME TestVolumeNonScalars DATA waveletArrays.vti ARGS -vb --scalars=RandomPointScalars LONG_TIMEOUT DEFAULT_LIGHTS) # Using default lights because of ResetCamera
-f3d_test(NAME TestTextureNormal DATA WaterBottle.glb ARGS --geometry-only --texture-normal=${CMAKE_SOURCE_DIR}/testing/data/normal.png --normal-scale=0.1 DEFAULT_LIGHTS)
-f3d_test(NAME TestTextureMaterial DATA WaterBottle.glb ARGS --geometry-only --texture-material=${CMAKE_SOURCE_DIR}/testing/data/red_mod.jpg --roughness=1 --metallic=1 DEFAULT_LIGHTS)
-f3d_test(NAME TestTextureMaterialWithOptions DATA WaterBottle.glb ARGS --geometry-only --texture-material=${CMAKE_SOURCE_DIR}/testing/data/red_mod.jpg --roughness=0.5 --metallic=0.5 DEFAULT_LIGHTS)
-f3d_test(NAME TestTextureColor DATA WaterBottle.glb ARGS --geometry-only --texture-base-color=${CMAKE_SOURCE_DIR}/testing/data/albedo_mod.png --translucency-support DEFAULT_LIGHTS)
-f3d_test(NAME TestTextureEmissive DATA WaterBottle.glb ARGS --geometry-only --texture-emissive=${CMAKE_SOURCE_DIR}/testing/data/red.jpg --emissive-factor=0.1,0.1,0.1 DEFAULT_LIGHTS)
-f3d_test(NAME TestTextures DATA WaterBottle.glb ARGS --geometry-only --texture-material=${CMAKE_SOURCE_DIR}/testing/data/red.jpg --roughness=1 --metallic=1 --texture-base-color=${CMAKE_SOURCE_DIR}/testing/data/albedo.png --texture-normal=${CMAKE_SOURCE_DIR}/testing/data/normal.png --texture-emissive=${CMAKE_SOURCE_DIR}/testing/data/red.jpg --emissive-factor=0.1,0.1,0.1 DEFAULT_LIGHTS)
+f3d_test(NAME TestTextureNormal DATA WaterBottle.glb ARGS --geometry-only --texture-normal=${F3D_SOURCE_DIR}/testing/data/normal.png --normal-scale=0.1 DEFAULT_LIGHTS)
+f3d_test(NAME TestTextureMaterial DATA WaterBottle.glb ARGS --geometry-only --texture-material=${F3D_SOURCE_DIR}/testing/data/red_mod.jpg --roughness=1 --metallic=1 DEFAULT_LIGHTS)
+f3d_test(NAME TestTextureMaterialWithOptions DATA WaterBottle.glb ARGS --geometry-only --texture-material=${F3D_SOURCE_DIR}/testing/data/red_mod.jpg --roughness=0.5 --metallic=0.5 DEFAULT_LIGHTS)
+f3d_test(NAME TestTextureColor DATA WaterBottle.glb ARGS --geometry-only --texture-base-color=${F3D_SOURCE_DIR}/testing/data/albedo_mod.png --translucency-support DEFAULT_LIGHTS)
+f3d_test(NAME TestTextureEmissive DATA WaterBottle.glb ARGS --geometry-only --texture-emissive=${F3D_SOURCE_DIR}/testing/data/red.jpg --emissive-factor=0.1,0.1,0.1 DEFAULT_LIGHTS)
+f3d_test(NAME TestTextures DATA WaterBottle.glb ARGS --geometry-only --texture-material=${F3D_SOURCE_DIR}/testing/data/red.jpg --roughness=1 --metallic=1 --texture-base-color=${F3D_SOURCE_DIR}/testing/data/albedo.png --texture-normal=${F3D_SOURCE_DIR}/testing/data/normal.png --texture-emissive=${F3D_SOURCE_DIR}/testing/data/red.jpg --emissive-factor=0.1,0.1,0.1 DEFAULT_LIGHTS)
 f3d_test(NAME TestMetaDataImporter DATA BoxAnimated.gltf ARGS -m DEFAULT_LIGHTS)
 f3d_test(NAME TestMultiblockMetaData DATA mb.vtm ARGS -m DEFAULT_LIGHTS)
 f3d_test(NAME TestTIFF DATA logo.tif ARGS -sy --up=-Y DEFAULT_LIGHTS)
@@ -166,7 +166,7 @@ f3d_test(NAME TestLightIntensityDarker DATA cow.vtp ARGS --light-intensity=0.2 D
 f3d_test(NAME TestLightIntensityBrighterFullScene DATA WaterBottle.glb ARGS --light-intensity=5.0 THRESHOLD 60 DEFAULT_LIGHTS)
 f3d_test(NAME TestLightIntensityDarkerFullScene DATA WaterBottle.glb ARGS --light-intensity=0.2 DEFAULT_LIGHTS)
 f3d_test(NAME TestUTF8 DATA "(ノಠ益ಠ )ノ.vtp" DEFAULT_LIGHTS)
-f3d_test(NAME TestFont DATA suzanne.ply ARGS -n --font-file=${CMAKE_SOURCE_DIR}/testing/data/Crosterian.ttf DEFAULT_LIGHTS)
+f3d_test(NAME TestFont DATA suzanne.ply ARGS -n --font-file=${F3D_SOURCE_DIR}/testing/data/Crosterian.ttf DEFAULT_LIGHTS)
 f3d_test(NAME TestAnimationIndex DATA InterpolationTest.glb ARGS --animation-index=7 --animation-time=0.5 DEFAULT_LIGHTS)
 f3d_test(NAME TestMaxSizeBelow DATA suzanne.stl ARGS --max-size=1 DEFAULT_LIGHTS)
 f3d_test(NAME TestMaxSizeAbove DATA WaterBottle.glb ARGS --max-size=0.2 REGEXP "No file loaded, file is bigger than max size" NO_BASELINE)
@@ -178,8 +178,8 @@ f3d_test(NAME TestGroupGeometries DATA mb/recursive ARGS --group-geometries DEFA
 f3d_test(NAME TestGroupGeometriesColoring DATA mb/recursive ARGS --group-geometries --scalars=Polynomial -b DEFAULT_LIGHTS)
 f3d_test(NAME TestInvalidUpDirection DATA suzanne.ply ARGS -g --up=W REGEXP "W is not a valid up direction" NO_BASELINE)
 f3d_test(NAME TestUpDirectionNoSign DATA suzanne.ply ARGS --up=X DEFAULT_LIGHTS)
-f3d_test(NAME TestTextureMatCap DATA suzanne.ply ARGS --texture-matcap=${CMAKE_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
-f3d_test(NAME TestTextureMatCapWithTCoords DATA WaterBottle.glb ARGS --geometry-only --texture-matcap=${CMAKE_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
+f3d_test(NAME TestTextureMatCap DATA suzanne.ply ARGS --texture-matcap=${F3D_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
+f3d_test(NAME TestTextureMatCapWithTCoords DATA WaterBottle.glb ARGS --geometry-only --texture-matcap=${F3D_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
 
 if (NOT APPLE)
   # This test is broken on apple because of #792
@@ -189,7 +189,7 @@ endif ()
 # Test plugin fail code path
 f3d_test(NAME TestPluginVerbose ARGS --verbose REGEXP "Loading plugin \"native\"" NO_BASELINE)
 f3d_test(NAME TestPluginNonExistent ARGS --load-plugins=dummy REGEXP "Plugin failed to load" NO_BASELINE)
-f3d_test(NAME TestPluginInvalid ARGS --load-plugins=${CMAKE_SOURCE_DIR}/testing/data/invalid.so REGEXP "Cannot open the library" NO_BASELINE)
+f3d_test(NAME TestPluginInvalid ARGS --load-plugins=${F3D_SOURCE_DIR}/testing/data/invalid.so REGEXP "Cannot open the library" NO_BASELINE)
 if(WIN32)
   set(_dirname "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 else()
@@ -199,12 +199,12 @@ f3d_test(NAME TestPluginNoInit ARGS --verbose --load-plugins "${_dirname}/${CMAK
 
 if(NOT F3D_MACOS_BUNDLE)
   # On linux, we can easily test the config file search from the binary code by positioning a config file in the binary dir
-  configure_file("${CMAKE_SOURCE_DIR}/testing/configs/complex.json" "${CMAKE_BINARY_DIR}/share/f3d/configs/complex_build.json" COPYONLY)
+  configure_file("${F3D_SOURCE_DIR}/testing/configs/complex.json" "${CMAKE_BINARY_DIR}/share/f3d/configs/complex_build.json" COPYONLY)
   f3d_test(NAME TestConfigFileBuild DATA dragon.vtu CONFIG complex_build.json DEFAULT_LIGHTS)
   f3d_test(NAME TestConfigStemBuild DATA dragon.vtu CONFIG complex_build DEFAULT_LIGHTS)
   f3d_test(NAME TestConfigFileUpperCase DATA suzanne_upper.STL CONFIG config_build DEFAULT_LIGHTS)
 
-  file(COPY "${CMAKE_SOURCE_DIR}/resources/configs/config.d/" "${CMAKE_SOURCE_DIR}/plugins/native/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
+  file(COPY "${F3D_SOURCE_DIR}/resources/configs/config.d/" "${F3D_SOURCE_DIR}/plugins/native/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
   f3d_test(NAME TestDefaultConfigFileVTU DATA dragon.vtu CONFIG config_build DEFAULT_LIGHTS)
   f3d_test(NAME TestDefaultConfigFileVTI DATA vase_4comp.vti CONFIG config_build DEFAULT_LIGHTS)
   f3d_test(NAME TestDefaultConfigFileSTL DATA suzanne.stl CONFIG config_build DEFAULT_LIGHTS)
@@ -214,7 +214,7 @@ if(NOT F3D_MACOS_BUNDLE)
 
   # no-background test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8501
   if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)
-    file(COPY "${CMAKE_SOURCE_DIR}/resources/configs/thumbnail.d/" "${CMAKE_SOURCE_DIR}/plugins/native/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
+    file(COPY "${F3D_SOURCE_DIR}/resources/configs/thumbnail.d/" "${F3D_SOURCE_DIR}/plugins/native/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
     f3d_test(NAME TestThumbnailConfigFileVTU DATA dragon.vtu CONFIG thumbnail_build DEFAULT_LIGHTS)
     f3d_test(NAME TestThumbnailConfigFileVTI DATA vase_4comp.vti CONFIG thumbnail_build DEFAULT_LIGHTS)
     f3d_test(NAME TestThumbnailConfigFileSTL DATA suzanne.stl CONFIG thumbnail_build DEFAULT_LIGHTS)
@@ -224,7 +224,7 @@ endif()
 
 # color texture with opacity needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9467
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220811)
-  f3d_test(NAME TestTextureColorWithOptions DATA WaterBottle.glb ARGS --geometry-only --texture-base-color=${CMAKE_SOURCE_DIR}/testing/data/albedo_mod.png --color=1,1,0 --opacity=0.4 --translucency-support DEFAULT_LIGHTS)
+  f3d_test(NAME TestTextureColorWithOptions DATA WaterBottle.glb ARGS --geometry-only --texture-base-color=${F3D_SOURCE_DIR}/testing/data/albedo_mod.png --color=1,1,0 --opacity=0.4 --translucency-support DEFAULT_LIGHTS)
 endif()
 
 # Tests that do not work with VTK 9.0.1 and have been
@@ -238,7 +238,7 @@ if(VTK_VERSION VERSION_GREATER 9.0.1)
   f3d_test(NAME TestLineWidth DATA cow.vtk ARGS -e --line-width=5)
   f3d_test(NAME TestLineWidthFullScene DATA suzanne.obj ARGS -e --line-width=3 --up=-Y)
   f3d_test(NAME TestPointCloudFullScene DATA pointsCloud.gltf ARGS --point-size=20)
-  f3d_test(NAME TestTextureMatCapWithEdges DATA suzanne.ply ARGS -e --texture-matcap=${CMAKE_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
+  f3d_test(NAME TestTextureMatCapWithEdges DATA suzanne.ply ARGS -e --texture-matcap=${F3D_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
 
   # Test enabling all animations
   f3d_test(NAME TestAnimationAllAnimations DATA InterpolationTest.glb ARGS --animation-index=-1 --animation-time=1)
@@ -294,25 +294,25 @@ endif()
 
 # HDRI test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9767
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20221220)
-  f3d_test(NAME TestHDRI HDRI DATA suzanne.ply ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
-  f3d_test(NAME TestHDRICache HDRI DATA suzanne.ply ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEPENDS TestHDRI DEFAULT_LIGHTS)
-  f3d_test(NAME TestHDRIBlur HDRI DATA suzanne.ply ARGS -u --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
-  f3d_test(NAME TestHDRIBlurCoC HDRI DATA suzanne.ply ARGS -u --blur-coc=50 --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
-  f3d_test(NAME TestHDRIBlurRatio HDRI DATA suzanne.ply RESOLUTION 600,100 ARGS -u --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
-  f3d_test(NAME TestHDRIEdges HDRI DATA suzanne.ply ARGS -e --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
-  f3d_test(NAME TestHDRI8Bit DATA suzanne.ply ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/logo.tif HDRI)
-  f3d_test(NAME TestHDRIOrient DATA suzanne.stl ARGS --up=+Z --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr HDRI)
-  f3d_test(NAME TestHDRIToneMapping DATA suzanne.ply ARGS -t --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr HDRI)
-  f3d_test(NAME TestInteractionHDRIMove DATA suzanne.ply ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr HDRI INTERACTION THRESHOLD 60) #Shift+MouseRight;
-  f3d_test(NAME TestInteractionHDRIBlur DATA suzanne.ply ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr INTERACTION HDRI DEFAULT_LIGHTS) #U
-  f3d_test(NAME TestInteractionHDRIReload DATA suzanne.ply ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr INTERACTION HDRI DEFAULT_LIGHTS) #Up
-  f3d_test(NAME TestInteractionHDRIChange DATA multi ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr INTERACTION HDRI DEFAULT_LIGHTS) #Right
+  f3d_test(NAME TestHDRI HDRI DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
+  f3d_test(NAME TestHDRICache HDRI DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEPENDS TestHDRI DEFAULT_LIGHTS)
+  f3d_test(NAME TestHDRIBlur HDRI DATA suzanne.ply ARGS -u --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
+  f3d_test(NAME TestHDRIBlurCoC HDRI DATA suzanne.ply ARGS -u --blur-coc=50 --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
+  f3d_test(NAME TestHDRIBlurRatio HDRI DATA suzanne.ply RESOLUTION 600,100 ARGS -u --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
+  f3d_test(NAME TestHDRIEdges HDRI DATA suzanne.ply ARGS -e --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr DEFAULT_LIGHTS)
+  f3d_test(NAME TestHDRI8Bit DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/logo.tif HDRI)
+  f3d_test(NAME TestHDRIOrient DATA suzanne.stl ARGS --up=+Z --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr HDRI)
+  f3d_test(NAME TestHDRIToneMapping DATA suzanne.ply ARGS -t --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr HDRI)
+  f3d_test(NAME TestInteractionHDRIMove DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr HDRI INTERACTION THRESHOLD 60) #Shift+MouseRight;
+  f3d_test(NAME TestInteractionHDRIBlur DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr INTERACTION HDRI DEFAULT_LIGHTS) #U
+  f3d_test(NAME TestInteractionHDRIReload DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr INTERACTION HDRI DEFAULT_LIGHTS) #Up
+  f3d_test(NAME TestInteractionHDRIChange DATA multi ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr INTERACTION HDRI DEFAULT_LIGHTS) #Right
 
-  configure_file("${CMAKE_SOURCE_DIR}/testing/configs/hdri.json.in" "${CMAKE_BINARY_DIR}/hdri.json")
+  configure_file("${F3D_SOURCE_DIR}/testing/configs/hdri.json.in" "${CMAKE_BINARY_DIR}/hdri.json")
   f3d_test(NAME TestConfigFileHDRI DATA dragon.vtu CONFIG "${CMAKE_BINARY_DIR}/hdri.json" HDRI DEFAULT_LIGHTS)
 
   if(F3D_MODULE_EXR)
-    f3d_test(NAME TestHDRIEXR HDRI DATA suzanne.ply ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/kloofendal_43d_clear_1k.exr DEFAULT_LIGHTS)
+    f3d_test(NAME TestHDRIEXR HDRI DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/kloofendal_43d_clear_1k.exr DEFAULT_LIGHTS)
   endif()
 endif()
 
@@ -345,11 +345,11 @@ if(F3D_PLUGIN_BUILD_ALEMBIC)
   f3d_test(NAME TestABC DATA suzanne.abc ARGS --load-plugins=alembic DEFAULT_LIGHTS) # Using default lights because of ResetCamera
 
   if(NOT F3D_MACOS_BUNDLE)
-    file(COPY "${CMAKE_SOURCE_DIR}/plugins/alembic/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
+    file(COPY "${F3D_SOURCE_DIR}/plugins/alembic/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
     f3d_test(NAME TestDefaultConfigFileAlembic DATA suzanne.abc CONFIG config_build DEFAULT_LIGHTS)
 
     if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)
-      file(COPY "${CMAKE_SOURCE_DIR}/plugins/alembic/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
+      file(COPY "${F3D_SOURCE_DIR}/plugins/alembic/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
       f3d_test(NAME TestThumbnailConfigFileAlembic DATA suzanne.abc CONFIG thumbnail_build DEFAULT_LIGHTS)
     endif()
   endif()
@@ -389,14 +389,14 @@ if(F3D_PLUGIN_BUILD_ASSIMP)
   endif()
 
   if(NOT F3D_MACOS_BUNDLE)
-    file(COPY "${CMAKE_SOURCE_DIR}/plugins/assimp/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
+    file(COPY "${F3D_SOURCE_DIR}/plugins/assimp/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
     f3d_test(NAME TestDefaultConfigFileAssimpFBX DATA phong_cube.fbx CONFIG config_build DEFAULT_LIGHTS)
     f3d_test(NAME TestDefaultConfigFileAssimpDXF DATA PinkEggFromLW.dxf ARGS -p CONFIG config_build DEFAULT_LIGHTS)
     f3d_test(NAME TestDefaultConfigFileAssimpOFF DATA teapot.off CONFIG config_build DEFAULT_LIGHTS)
     f3d_test(NAME TestDefaultConfigFileAssimpDAE DATA duck.dae CONFIG config_build DEFAULT_LIGHTS)
 
     if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)
-      file(COPY "${CMAKE_SOURCE_DIR}/plugins/assimp/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
+      file(COPY "${F3D_SOURCE_DIR}/plugins/assimp/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
       f3d_test(NAME TestThumbnailConfigFileAssimpFBX DATA phong_cube.fbx CONFIG thumbnail_build DEFAULT_LIGHTS)
       f3d_test(NAME TestThumbnailConfigFileAssimpDXF DATA PinkEggFromLW.dxf ARGS -p CONFIG thumbnail_build DEFAULT_LIGHTS)
       f3d_test(NAME TestThumbnailConfigFileAssimpOFF DATA teapot.off CONFIG thumbnail_build DEFAULT_LIGHTS)
@@ -411,11 +411,11 @@ if(F3D_PLUGIN_BUILD_DRACO)
   f3d_test(NAME TestDRACOColoring DATA suzanne.drc DEFAULT_LIGHTS ARGS --scalars --comp=0 --load-plugins=draco)
 
   if(NOT F3D_MACOS_BUNDLE)
-    file(COPY "${CMAKE_SOURCE_DIR}/plugins/draco/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
+    file(COPY "${F3D_SOURCE_DIR}/plugins/draco/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
     f3d_test(NAME TestDefaultConfigFileDraco DATA suzanne.drc CONFIG config_build DEFAULT_LIGHTS)
 
     if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)
-      file(COPY "${CMAKE_SOURCE_DIR}/plugins/draco/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
+      file(COPY "${F3D_SOURCE_DIR}/plugins/draco/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
       f3d_test(NAME TestThumbnailConfigFileDraco DATA suzanne.drc CONFIG thumbnail_build DEFAULT_LIGHTS)
     endif()
   endif()
@@ -425,7 +425,7 @@ endif()
 if(F3D_PLUGIN_BUILD_EXODUS)
   f3d_test(NAME TestExodus DATA disk_out_ref.ex2 ARGS --load-plugins=exodus -s --camera-position=-11,-2,-49 DEFAULT_LIGHTS)
 
-  f3d_test(NAME TestExodusConfig DATA disk_out_ref.ex2 CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/exodus.json ARGS -s --camera-position=-11,-2,-49 DEFAULT_LIGHTS)
+  f3d_test(NAME TestExodusConfig DATA disk_out_ref.ex2 CONFIG ${F3D_SOURCE_DIR}/testing/configs/exodus.json ARGS -s --camera-position=-11,-2,-49 DEFAULT_LIGHTS)
 
   # Test Generic Importer Verbose animation. Regex contains the time range.
   f3d_test(NAME TestVerboseGenericImporterAnimation DATA small.ex2 ARGS --load-plugins=exodus --verbose NO_BASELINE REGEXP "0, 0.00429999")
@@ -443,11 +443,11 @@ if(F3D_PLUGIN_BUILD_EXODUS)
   f3d_test(NAME TestNoRenderAnimation DATA small.ex2 ARGS  --load-plugins=exodus --animation-time=0.003 REGEXP "-521950, 6.57485" NO_RENDER)
 
   if(NOT F3D_MACOS_BUNDLE)
-    file(COPY "${CMAKE_SOURCE_DIR}/plugins/exodus/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
+    file(COPY "${F3D_SOURCE_DIR}/plugins/exodus/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
     f3d_test(NAME TestDefaultConfigFileExodus DATA disk_out_ref.ex2 CONFIG config_build DEFAULT_LIGHTS)
 
     if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)
-      file(COPY "${CMAKE_SOURCE_DIR}/plugins/exodus/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
+      file(COPY "${F3D_SOURCE_DIR}/plugins/exodus/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
       f3d_test(NAME TestThumbnailConfigFileExodus DATA disk_out_ref.ex2 CONFIG thumbnail_build DEFAULT_LIGHTS)
     endif()
   endif()
@@ -468,11 +468,11 @@ if(F3D_PLUGIN_BUILD_OCCT)
   f3d_test(NAME TestIGES DATA f3d.igs DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
 
   if(F3D_PLUGIN_OCCT_COLORING_SUPPORT AND NOT F3D_MACOS_BUNDLE)
-    file(COPY "${CMAKE_SOURCE_DIR}/plugins/occt/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
+    file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
     f3d_test(NAME TestDefaultConfigFileOCCT DATA f3d.stp CONFIG config_build DEFAULT_LIGHTS)
 
     if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)
-      file(COPY "${CMAKE_SOURCE_DIR}/plugins/occt/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
+      file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
       f3d_test(NAME TestThumbnailConfigFileOCCT DATA f3d.stp CONFIG thumbnail_build DEFAULT_LIGHTS)
     endif()
   endif()
@@ -500,8 +500,8 @@ f3d_test(NAME TestInteractionAnimationNotStopped DATA InterpolationTest.glb NO_B
 f3d_test(NAME TestInteractionResetCamera DATA dragon.vtu INTERACTION DEFAULT_LIGHTS)#MouseMovements;Return;
 f3d_test(NAME TestInteractionTensorsCycleComp DATA tensors.vti ARGS --scalars --comp=-2  INTERACTION DEFAULT_LIGHTS) #SYYYYYYYYYY
 f3d_test(NAME TestInteractionCycleScalarsCompCheck DATA dragon.vtu ARGS -b --scalars --comp=2 INTERACTION DEFAULT_LIGHTS) #S
-f3d_test(NAME TestInteractionConfigFileMulti DATA multi CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/complex.json INTERACTION DEFAULT_LIGHTS) #XG;Right;N;Right;Right
-f3d_test(NAME TestInteractionConfigFileAndCommand DATA multi ARGS -o CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/complex.json INTERACTION DEFAULT_LIGHTS) #O;Left
+f3d_test(NAME TestInteractionConfigFileMulti DATA multi CONFIG ${F3D_SOURCE_DIR}/testing/configs/complex.json INTERACTION DEFAULT_LIGHTS) #XG;Right;N;Right;Right
+f3d_test(NAME TestInteractionConfigFileAndCommand DATA multi ARGS -o CONFIG ${F3D_SOURCE_DIR}/testing/configs/complex.json INTERACTION DEFAULT_LIGHTS) #O;Left
 f3d_test(NAME TestInteractionDumpSceneState DATA dragon.vtu NO_BASELINE INTERACTION REGEXP "Camera position: 2.23745,3.83305,507.598")#?
 f3d_test(NAME TestInteractionCycleVerbose DATA dragon.vtu ARGS --verbose -s NO_BASELINE INTERACTION REGEXP "Not coloring")#SSSSYC
 f3d_test(NAME TestInteractionEmptyDrop INTERACTION REGEXP "Drop event without any provided files.")#DropEvent Empty;
@@ -525,17 +525,17 @@ f3d_test(NAME TestInteractionProgressReload DATA cow.vtp ARGS --progress NO_BASE
 # Drop file test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9199
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20220519) # Drop file test uses stream version 1.2
 
-  configure_file("${CMAKE_SOURCE_DIR}/testing/recordings/TestInteractionDropFiles.log.in"
+  configure_file("${F3D_SOURCE_DIR}/testing/recordings/TestInteractionDropFiles.log.in"
     "${CMAKE_BINARY_DIR}/TestInteractionDropFiles.log")
 
   f3d_test(NAME TestInteractionDropFiles ARGS "--interaction-test-play=${CMAKE_BINARY_DIR}/TestInteractionDropFiles.log")#X;DropEvent cow.vtp;DropEvent dragon.vtu suzanne.stl;
 
-  configure_file("${CMAKE_SOURCE_DIR}/testing/recordings/TestInteractionGroupGeometriesDrop.log.in"
+  configure_file("${F3D_SOURCE_DIR}/testing/recordings/TestInteractionGroupGeometriesDrop.log.in"
     "${CMAKE_BINARY_DIR}/TestInteractionGroupGeometriesDrop.log")
 
   f3d_test(NAME TestInteractionGroupGeometriesDrop DATA mb/mb_1_0.vtp ARGS --group-geometries -e "--interaction-test-play=${CMAKE_BINARY_DIR}/TestInteractionGroupGeometriesDrop.log" DEFAULT_LIGHTS) #DropEvent mb_2_0.vtp
 
-  configure_file("${CMAKE_SOURCE_DIR}/testing/recordings/TestInteractionDropSameFiles.log.in"
+  configure_file("${F3D_SOURCE_DIR}/testing/recordings/TestInteractionDropSameFiles.log.in"
     "${CMAKE_BINARY_DIR}/TestInteractionDropSameFiles.log")
 
   f3d_test(NAME TestInteractionDropSameFiles ARGS -x "--interaction-test-play=${CMAKE_BINARY_DIR}/TestInteractionDropSameFiles.log")#DropEvent cow.vtp;#DropEvent dragon.vtu;#DropEvent cow.vtp#DropEvent cow.vtp;
@@ -543,13 +543,13 @@ if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20220519) # Drop file test uses stream 
   # HDRI test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9767
   if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20221220)
 
-    configure_file("${CMAKE_SOURCE_DIR}/testing/recordings/TestInteractionDropHDRI.log.in"
+    configure_file("${F3D_SOURCE_DIR}/testing/recordings/TestInteractionDropHDRI.log.in"
       "${CMAKE_BINARY_DIR}/TestInteractionDropHDRI.log")
 
     f3d_test(NAME TestInteractionDropHDRI ARGS "--interaction-test-play=${CMAKE_BINARY_DIR}/TestInteractionDropHDRI.log" HDRI)#X;DropEvent dragon.vtu palermo.hdr;
 
     if(F3D_MODULE_EXR)
-      configure_file("${CMAKE_SOURCE_DIR}/testing/recordings/TestInteractionDropHDRIExr.log.in"
+      configure_file("${F3D_SOURCE_DIR}/testing/recordings/TestInteractionDropHDRIExr.log.in"
         "${CMAKE_BINARY_DIR}/TestInteractionDropHDRIExr.log")
 
       f3d_test(NAME TestInteractionDropHDRIExr ARGS "--interaction-test-play=${CMAKE_BINARY_DIR}/TestInteractionDropHDRIExr.log" HDRI)#X;DropEvent kloofendal.exr;DropEvent dragon.vtu;
@@ -618,7 +618,7 @@ f3d_test(NAME TestVerboseNoArray DATA cow.vtp ARGS -s REGEXP "No array to color 
 f3d_test(NAME TestVerboseNonExistentFile DATA nonExistentFile.vtp ARGS --filename --verbose REGEXP "File \".*nonExistentFile.vtp\" does not exist" NO_RENDER)
 
 # Test non existent font file, do not create nonExistentFile.ttf
-f3d_test(NAME TestVerboseNonExistentFont DATA suzanne.ply ARGS -n --font-file=${CMAKE_SOURCE_DIR}/testing/data/nonExistentFile.ttf REGEXP "Cannot find \".*nonExistentFile.ttf\" font file" NO_BASELINE)
+f3d_test(NAME TestVerboseNonExistentFont DATA suzanne.ply ARGS -n --font-file=${F3D_SOURCE_DIR}/testing/data/nonExistentFile.ttf REGEXP "Cannot find \".*nonExistentFile.ttf\" font file" NO_BASELINE)
 
 # Test non existent file, do not create nonExistentFile.vtp
 f3d_test(NAME TestQuietNonExistentFile DATA nonExistentFile.vtp ARGS --filename --verbose --quiet REGEXP_FAIL "File \".*nonExistentFile.vtp\" does not exist" NO_RENDER)
@@ -627,7 +627,7 @@ f3d_test(NAME TestQuietNonExistentFile DATA nonExistentFile.vtp ARGS --filename 
 f3d_test(NAME TestUnsupportedFileText DATA unsupportedFile.dummy ARGS --filename REGEXP ".*unsupportedFile.dummy\" is not a file of a supported file format" NO_RENDER)
 
 # Test non existent texture, do not add a dummy.png
-f3d_test(NAME TestNonExistentTexture DATA cow.vtp ARGS --texture-material=${CMAKE_SOURCE_DIR}/testing/data/dummy.png REGEXP "Texture file does not exist" NO_BASELINE)
+f3d_test(NAME TestNonExistentTexture DATA cow.vtp ARGS --texture-material=${F3D_SOURCE_DIR}/testing/data/dummy.png REGEXP "Texture file does not exist" NO_BASELINE)
 
 # Test invalid geometry XXX should be improved
 f3d_test(NAME TestInvalidGeometry DATA invalid.vtp REGEXP "A reader did not produce any output" NO_BASELINE)
@@ -636,22 +636,22 @@ f3d_test(NAME TestInvalidGeometry DATA invalid.vtp REGEXP "A reader did not prod
 f3d_test(NAME TestInvalidFullScene DATA invalid.gltf ARGS --verbose REGEXP "Loading full scene" NO_BASELINE)
 
 # Test invalid texture
-f3d_test(NAME TestInvalidTexture DATA cow.vtp ARGS --texture-material=${CMAKE_SOURCE_DIR}/testing/data/invalid.png REGEXP "Cannot open texture file" NO_BASELINE)
+f3d_test(NAME TestInvalidTexture DATA cow.vtp ARGS --texture-material=${F3D_SOURCE_DIR}/testing/data/invalid.png REGEXP "Cannot open texture file" NO_BASELINE)
 
 # Test non existent HDRI, do not add a dummy.png
-f3d_test(NAME TestNonExistentHDRI DATA cow.vtp ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/dummy.png REGEXP "HDRI file does not exist" NO_BASELINE)
+f3d_test(NAME TestNonExistentHDRI DATA cow.vtp ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/dummy.png REGEXP "HDRI file does not exist" NO_BASELINE)
 
 # Test non existent interaction file, do not add a TestNonExistentInteraction
 f3d_test(NAME TestNonExistentInteraction DATA cow.vtp INTERACTION REGEXP "Interaction record file to play does not exist" NO_BASELINE)
 
 # Test invalid provided HDRI
-f3d_test(NAME TestInvalidHDRI DATA cow.vtp ARGS --hdri=${CMAKE_SOURCE_DIR}/testing/data/invalid.png REGEXP "Cannot open HDRI file" NO_BASELINE)
+f3d_test(NAME TestInvalidHDRI DATA cow.vtp ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/invalid.png REGEXP "Cannot open HDRI file" NO_BASELINE)
 
 # Test invalid options, do not add a --colour option
 f3d_test(NAME TestInvalidOption ARGS --colour=1,0,0 REGEXP "Did you mean '--color'?")
 
 # Test non-existent config filepath, do not add a dummy.json
-f3d_test(NAME TestNonExistentConfigFilePath DATA cow.vtp CONFIG "${CMAKE_SOURCE_DIR}/testing/configs/dummy.json" REGEXP "Configuration file does not exist" NO_BASELINE)
+f3d_test(NAME TestNonExistentConfigFilePath DATA cow.vtp CONFIG "${F3D_SOURCE_DIR}/testing/configs/dummy.json" REGEXP "Configuration file does not exist" NO_BASELINE)
 
 # Test non-existent config filename, do not add a dummy.json
 f3d_test(NAME TestNonExistentConfigFilename DATA cow.vtp CONFIG "dummy.json" REGEXP "Configuration file for \"dummy.json\" could not been found" NO_BASELINE)
@@ -660,13 +660,13 @@ f3d_test(NAME TestNonExistentConfigFilename DATA cow.vtp CONFIG "dummy.json" REG
 f3d_test(NAME TestNonExistentConfigFileStem DATA cow.vtp CONFIG "dummy" REGEXP "Configuration file for \"dummy\" could not been found" NO_BASELINE)
 
 # Test invalid config file
-f3d_test(NAME TestInvalidConfigFile DATA cow.vtp CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/invalid.json REGEXP "Unable to parse the configuration file" NO_BASELINE)
+f3d_test(NAME TestInvalidConfigFile DATA cow.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/invalid.json REGEXP "Unable to parse the configuration file" NO_BASELINE)
 
 # Test quiet in config file
-f3d_test(NAME TestConfigFileQuiet DATA nonExistentFile.vtp CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/quiet.json REGEXP_FAIL "File .*/testing/data/nonExistentFile.vtp does not exist" NO_RENDER)
+f3d_test(NAME TestConfigFileQuiet DATA nonExistentFile.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/quiet.json REGEXP_FAIL "File .*/testing/data/nonExistentFile.vtp does not exist" NO_RENDER)
 
 # Test no file with config file
-f3d_test(NAME TestNoFileConfigFile CONFIG ${CMAKE_SOURCE_DIR}/testing/configs/verbose.json ARGS --verbose REGEXP "No file to load provided." NO_BASELINE)
+f3d_test(NAME TestNoFileConfigFile CONFIG ${F3D_SOURCE_DIR}/testing/configs/verbose.json ARGS --verbose REGEXP "No file to load provided." NO_BASELINE)
 
 # Test help display
 f3d_test(NAME TestHelp ARGS --help REGEXP "Usage:")
@@ -686,13 +686,13 @@ set_tests_properties(f3d::TestNoDryRun PROPERTIES TIMEOUT 2)
 f3d_test(NAME TestNoRef DATA cow.vtp WILL_FAIL)
 
 # Test failure without a reference and without an output, please do not create a TestNoRef.png file
-f3d_test(NAME TestNoRefNoOutput DATA cow.vtp ARGS --ref ${CMAKE_SOURCE_DIR}/testing/baselines/TestNoRef.png REGEXP "use the output option to output current rendering into an image file." NO_BASELINE NO_OUTPUT)
+f3d_test(NAME TestNoRefNoOutput DATA cow.vtp ARGS --ref ${F3D_SOURCE_DIR}/testing/baselines/TestNoRef.png REGEXP "use the output option to output current rendering into an image file." NO_BASELINE NO_OUTPUT)
 
 # Test failure with a bad reference, please do not create a good TestBadRef.png file
 f3d_test(NAME TestBadRef DATA cow.vtp WILL_FAIL)
 
 # Test failure with a bad reference without an output, please do not create a good TestBadRef.png file
-f3d_test(NAME TestBadRefNoOutput DATA cow.vtp ARGS --ref ${CMAKE_SOURCE_DIR}/testing/baselines/TestBadRef.png REGEXP "Use the --output option to be able to output current rendering and diff images into files." NO_BASELINE NO_OUTPUT)
+f3d_test(NAME TestBadRefNoOutput DATA cow.vtp ARGS --ref ${F3D_SOURCE_DIR}/testing/baselines/TestBadRef.png REGEXP "Use the --output option to be able to output current rendering and diff images into files." NO_BASELINE NO_OUTPUT)
 
 # Test failure with a bad interaction play file, please do not create a dummy.log
 f3d_test(NAME TestPlayNoFile DATA cow.vtp ARGS --interaction-test-play=${CMAKE_BINARY_DIR}/Testing/Temporary/dummy.log WILL_FAIL)

--- a/cmake/f3dPlugin.cmake
+++ b/cmake/f3dPlugin.cmake
@@ -267,7 +267,7 @@ macro(f3d_plugin_build)
     set(_f3d_plugins_install_dir ${f3d_PLUGINS_INSTALL_DIR})
   else()
     # In-source plugin path
-    set(_f3d_include_path "${CMAKE_SOURCE_DIR}/library/plugin")
+    set(_f3d_include_path "${F3D_SOURCE_DIR}/library/plugin")
     set(_f3d_config_dir ${f3d_config_dir})
     set(_f3d_plugins_install_dir ${F3D_PLUGINS_INSTALL_DIR})
   endif()

--- a/java/testing/CMakeLists.txt
+++ b/java/testing/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(test_file ${javaf3dTests_list})
       -Djava.library.path=$<SHELL_PATH:$<TARGET_FILE_DIR:javaf3d>> # path to the JNI library
       ${java_test_args}
       -cp $<SHELL_PATH:$<TARGET_PROPERTY:f3d-jar,JAR_FILE>> # path to the JAR file
-      $<SHELL_PATH:${test_file}> ${CMAKE_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/
+      $<SHELL_PATH:${test_file}> ${F3D_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/
     )
 
     set_tests_properties(javaf3d::${TName} PROPERTIES DISABLED ${java_test_disabled})

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -107,7 +107,7 @@ if (F3D_USE_EXTERNAL_NLOHMANN_JSON)
   target_link_libraries(libf3d PRIVATE nlohmann_json::nlohmann_json)
 else ()
   target_include_directories(libf3d PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/external/nlohmann_json>)
+    $<BUILD_INTERFACE:${F3D_SOURCE_DIR}/external/nlohmann_json>)
 endif ()
 
 set_target_properties(libf3d PROPERTIES
@@ -196,7 +196,7 @@ if(BUILD_SHARED_LIBS)
 
   include(CMakePackageConfigHelpers)
   configure_package_config_file(
-    "${CMAKE_SOURCE_DIR}/cmake/f3dConfig.cmake.in" "${CMAKE_BINARY_DIR}/cmake/f3dConfig.cmake"
+    "${F3D_SOURCE_DIR}/cmake/f3dConfig.cmake.in" "${CMAKE_BINARY_DIR}/cmake/f3dConfig.cmake"
     INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/f3d")
 
   write_basic_package_version_file(
@@ -208,12 +208,12 @@ if(BUILD_SHARED_LIBS)
     FILES
       "${CMAKE_BINARY_DIR}/cmake/f3dConfig.cmake"
       "${CMAKE_BINARY_DIR}/cmake/f3dConfigVersion.cmake"
-      "${CMAKE_SOURCE_DIR}/cmake/f3dEmbed.cmake"
-      "${CMAKE_SOURCE_DIR}/cmake/f3dPlugin.cmake"
-      "${CMAKE_SOURCE_DIR}/cmake/plugin.cxx.in"
-      "${CMAKE_SOURCE_DIR}/cmake/plugin.desktop.in"
-      "${CMAKE_SOURCE_DIR}/cmake/plugin.thumbnailer.in"
-      "${CMAKE_SOURCE_DIR}/cmake/readerBoilerPlate.h.in"
+      "${F3D_SOURCE_DIR}/cmake/f3dEmbed.cmake"
+      "${F3D_SOURCE_DIR}/cmake/f3dPlugin.cmake"
+      "${F3D_SOURCE_DIR}/cmake/plugin.cxx.in"
+      "${F3D_SOURCE_DIR}/cmake/plugin.desktop.in"
+      "${F3D_SOURCE_DIR}/cmake/plugin.thumbnailer.in"
+      "${F3D_SOURCE_DIR}/cmake/readerBoilerPlate.h.in"
     DESTINATION
       "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
     COMPONENT sdk

--- a/library/VTKExtensions/Applicative/Testing/CMakeLists.txt
+++ b/library/VTKExtensions/Applicative/Testing/CMakeLists.txt
@@ -13,5 +13,5 @@ endif()
 vtk_add_test_cxx(VTKExtensionsApplicativeTests tests
   NO_DATA NO_VALID NO_OUTPUT
   ${test_sources}
-  ${CMAKE_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
+  ${F3D_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
 vtk_test_cxx_executable(VTKExtensionsApplicativeTests tests)

--- a/library/VTKExtensions/Core/Testing/CMakeLists.txt
+++ b/library/VTKExtensions/Core/Testing/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 vtk_add_test_cxx(VTKExtensionsCoreTests tests
   NO_DATA NO_VALID NO_OUTPUT
   TestF3DLog.cxx
-  ${CMAKE_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
+  ${F3D_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
 vtk_test_cxx_executable(VTKExtensionsCoreTests tests)
 
 if(UNIX)

--- a/library/VTKExtensions/Readers/Testing/CMakeLists.txt
+++ b/library/VTKExtensions/Readers/Testing/CMakeLists.txt
@@ -14,6 +14,6 @@ endif()
 vtk_add_test_cxx(VTKExtensionsReaderTests tests
   NO_DATA NO_VALID NO_OUTPUT
   ${VTKExtensionsReaderTests_list}
-  ${CMAKE_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
+  ${F3D_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
 vtk_test_cxx_executable(VTKExtensionsReaderTests tests)
 

--- a/library/VTKExtensions/Rendering/Testing/CMakeLists.txt
+++ b/library/VTKExtensions/Rendering/Testing/CMakeLists.txt
@@ -10,5 +10,5 @@ vtk_add_test_cxx(VTKExtensionsRenderingTests tests
   TestF3DRenderer.cxx
   TestF3DRendererWithColoring.cxx
   TestF3DCachedTexturesPrint.cxx
-  ${CMAKE_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
+  ${F3D_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
 vtk_test_cxx_executable(VTKExtensionsRenderingTests tests)

--- a/library/testing/CMakeLists.txt
+++ b/library/testing/CMakeLists.txt
@@ -47,9 +47,9 @@ if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20220519)
 endif()
 
 # Configure the log file for dropfile test
-configure_file("${CMAKE_SOURCE_DIR}/testing/recordings/TestSDKInteractorCallBack.log.in"
+configure_file("${F3D_SOURCE_DIR}/testing/recordings/TestSDKInteractorCallBack.log.in"
                "${CMAKE_BINARY_DIR}/TestSDKInteractorCallBack.log") # Dragon.vtu; S
-configure_file("${CMAKE_SOURCE_DIR}/testing/recordings/TestSDKInteractorDropFullScene.log.in"
+configure_file("${F3D_SOURCE_DIR}/testing/recordings/TestSDKInteractorDropFullScene.log.in"
                "${CMAKE_BINARY_DIR}/TestSDKInteractorDropFullScene.log") # world.obj; S
 
 # External window tests
@@ -92,7 +92,7 @@ list(APPEND libf3dSDKTestsNoRender_list
 # Add all the ADD_TEST for each test
 foreach (test ${libf3dSDKTests_list})
   get_filename_component (TName ${test} NAME_WE)
-  add_test (NAME libf3d::${TName} COMMAND libf3dSDKTests ${TName}  "${CMAKE_SOURCE_DIR}/testing/" "${CMAKE_BINARY_DIR}/Testing/Temporary/" "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+  add_test (NAME libf3d::${TName} COMMAND libf3dSDKTests ${TName}  "${F3D_SOURCE_DIR}/testing/" "${CMAKE_BINARY_DIR}/Testing/Temporary/" "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
   set_tests_properties(libf3d::${TName} PROPERTIES TIMEOUT 30)
   if (NOT F3D_TESTING_ENABLE_RENDERING_TESTS AND NOT ${TName} IN_LIST libf3dSDKTestsNoRender_list)
     set_tests_properties(libf3d::${TName} PROPERTIES DISABLED ON)

--- a/plugins/alembic/CMakeLists.txt
+++ b/plugins/alembic/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 
 project(f3d-plugin-alembic)
 
 include(GNUInstallDirs)
 
 # Check if the plugin is built externally
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
   find_package(f3d REQUIRED)
 else()
   include(f3dPlugin)

--- a/plugins/alembic/module/Testing/CMakeLists.txt
+++ b/plugins/alembic/module/Testing/CMakeLists.txt
@@ -9,5 +9,5 @@ endif()
 vtk_add_test_cxx(VTKExtensionsPluginAlembic tests
   NO_DATA NO_VALID NO_OUTPUT
   ${VTKExtensionsPluginAlembic_list}
-  ${CMAKE_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
+  ${F3D_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
 vtk_test_cxx_executable(VTKExtensionsPluginAlembic tests)

--- a/plugins/assimp/CMakeLists.txt
+++ b/plugins/assimp/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 
 project(f3d-plugin-assimp)
 
 include(GNUInstallDirs)
 
 # Check if the plugin is built externally
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
   find_package(f3d REQUIRED)
 else()
   include(f3dPlugin)

--- a/plugins/assimp/module/Testing/CMakeLists.txt
+++ b/plugins/assimp/module/Testing/CMakeLists.txt
@@ -10,5 +10,5 @@ endif()
 vtk_add_test_cxx(VTKExtensionsPluginAssimp tests
   NO_DATA NO_VALID NO_OUTPUT
   ${VTKExtensionsPluginAssimp_list}
-  ${CMAKE_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
+  ${F3D_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
 vtk_test_cxx_executable(VTKExtensionsPluginAssimp tests)

--- a/plugins/draco/CMakeLists.txt
+++ b/plugins/draco/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 
 project(f3d-plugin-draco)
 
 include(GNUInstallDirs)
 
 # Check if the plugin is built externally
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
   find_package(f3d REQUIRED)
 else()
   include(f3dPlugin)

--- a/plugins/draco/module/Testing/CMakeLists.txt
+++ b/plugins/draco/module/Testing/CMakeLists.txt
@@ -9,5 +9,5 @@ endif()
 vtk_add_test_cxx(VTKExtensionsPluginDraco tests
   NO_DATA NO_VALID NO_OUTPUT
   ${VTKExtensionsPluginDraco_list}
-  ${CMAKE_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
+  ${F3D_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
 vtk_test_cxx_executable(VTKExtensionsPluginDraco tests)

--- a/plugins/exodus/CMakeLists.txt
+++ b/plugins/exodus/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 
 project(f3d-plugin-exodus)
 
 include(GNUInstallDirs)
 
 # Check if the plugin is built externally
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
   find_package(f3d REQUIRED)
 else()
   include(f3dPlugin)

--- a/plugins/native/CMakeLists.txt
+++ b/plugins/native/CMakeLists.txt
@@ -1,5 +1,11 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(f3d-plugin-native)
+
+include(GNUInstallDirs)
+
 # Only internal build is supported for static plugins
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
   message(FATAL_ERROR "native plugin cannot be built externally")
 endif()
 

--- a/plugins/occt/CMakeLists.txt
+++ b/plugins/occt/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 
 project(f3d-plugin-occt)
 
 include(GNUInstallDirs)
 
 # Check if the plugin is built externally
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
   find_package(f3d REQUIRED)
 else()
   include(f3dPlugin)

--- a/plugins/occt/module/Testing/CMakeLists.txt
+++ b/plugins/occt/module/Testing/CMakeLists.txt
@@ -9,5 +9,5 @@ endif()
 vtk_add_test_cxx(VTKExtensionsPluginOCCT tests
   NO_DATA NO_VALID NO_OUTPUT
   ${VTKExtensionsPluginOCCT_list}
-  ${CMAKE_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
+  ${F3D_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
 vtk_test_cxx_executable(VTKExtensionsPluginOCCT tests)

--- a/python/testing/CMakeLists.txt
+++ b/python/testing/CMakeLists.txt
@@ -27,7 +27,7 @@ list(APPEND pyf3dTestsNoRender_list
 # Add all the ADD_TEST for each test
 foreach(test ${pyf3dTests_list})
   get_filename_component (TName ${test} NAME_WE)
-  add_test(NAME pyf3d::${TName} COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/${test} $<TARGET_FILE_DIR:VTK::CommonCore> ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+  add_test(NAME pyf3d::${TName} COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/${test} $<TARGET_FILE_DIR:VTK::CommonCore> ${F3D_SOURCE_DIR} ${CMAKE_BINARY_DIR})
   set_tests_properties(pyf3d::${TName} PROPERTIES
     ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:pyf3d>"
     FAIL_REGULAR_EXPRESSION "AssertionError")

--- a/testing/configs/hdri.json.in
+++ b/testing/configs/hdri.json.in
@@ -1,6 +1,6 @@
 {
   "global":
   {
-    "hdri": "${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr"
+    "hdri": "${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr"
   }
 }

--- a/testing/recordings/TestInteractionDropFiles.log.in
+++ b/testing/recordings/TestInteractionDropFiles.log.in
@@ -8,7 +8,7 @@ KeyPressEvent 677 699 0 0 1 Super_L 0
 CharEvent 677 699 0 0 1 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${CMAKE_SOURCE_DIR}/testing/data/cow.vtp
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${F3D_SOURCE_DIR}/testing/data/cow.vtp
 RenderEvent 781 494 0 0 0 Super_L 0
 MouseMoveEvent 781 498 0 0 0 Super_L 0
 LeaveEvent 751 614 0 0 0 Super_L 0
@@ -16,7 +16,7 @@ EnterEvent 700 570 0 0 0 Super_L 0
 MouseMoveEvent 700 570 0 0 0 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 2 ${CMAKE_SOURCE_DIR}/testing/data/dragon.vtu ${CMAKE_SOURCE_DIR}/testing/data/suzanne.stl
+DropFilesEvent 781 494 0 0 0 Super_L 1 2 ${F3D_SOURCE_DIR}/testing/data/dragon.vtu ${F3D_SOURCE_DIR}/testing/data/suzanne.stl
 RenderEvent 781 494 0 0 0 Super_L 0
 MouseMoveEvent 781 498 0 0 0 Super_L 0
 LeaveEvent 751 614 0 0 0 Super_L 0

--- a/testing/recordings/TestInteractionDropHDRI.log.in
+++ b/testing/recordings/TestInteractionDropHDRI.log.in
@@ -8,5 +8,5 @@ KeyPressEvent 677 699 0 0 1 Super_L 0
 CharEvent 677 699 0 0 1 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 2 ${CMAKE_SOURCE_DIR}/testing/data/dragon.vtu ${CMAKE_SOURCE_DIR}/testing/data/palermo_park_1k.hdr
+DropFilesEvent 781 494 0 0 0 Super_L 1 2 ${F3D_SOURCE_DIR}/testing/data/dragon.vtu ${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr
 RenderEvent 781 494 0 0 0 Super_L 0

--- a/testing/recordings/TestInteractionDropHDRIExr.log.in
+++ b/testing/recordings/TestInteractionDropHDRIExr.log.in
@@ -8,7 +8,7 @@ KeyPressEvent 677 699 0 0 1 Super_L 0
 CharEvent 677 699 0 0 1 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${CMAKE_SOURCE_DIR}/testing/data/kloofendal_43d_clear_1k.exr
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${F3D_SOURCE_DIR}/testing/data/kloofendal_43d_clear_1k.exr
 RenderEvent 781 494 0 0 0 Super_L 0
 MouseMoveEvent 781 498 0 0 0 Super_L 0
 LeaveEvent 751 614 0 0 0 Super_L 0
@@ -16,7 +16,7 @@ EnterEvent 700 570 0 0 0 Super_L 0
 MouseMoveEvent 700 570 0 0 0 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${CMAKE_SOURCE_DIR}/testing/data/dragon.vtu
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${F3D_SOURCE_DIR}/testing/data/dragon.vtu
 RenderEvent 781 494 0 0 0 Super_L 0
 MouseMoveEvent 781 498 0 0 0 Super_L 0
 LeaveEvent 751 614 0 0 0 Super_L 0

--- a/testing/recordings/TestInteractionDropSameFiles.log.in
+++ b/testing/recordings/TestInteractionDropSameFiles.log.in
@@ -5,7 +5,7 @@ KeyPressEvent 677 699 0 0 1 Super_L 0
 CharEvent 677 699 0 0 1 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${CMAKE_SOURCE_DIR}/testing/data/cow.vtp
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${F3D_SOURCE_DIR}/testing/data/cow.vtp
 RenderEvent 781 494 0 0 0 Super_L 0
 MouseMoveEvent 781 498 0 0 0 Super_L 0
 LeaveEvent 751 614 0 0 0 Super_L 0
@@ -13,7 +13,7 @@ EnterEvent 700 570 0 0 0 Super_L 0
 MouseMoveEvent 700 570 0 0 0 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${CMAKE_SOURCE_DIR}/testing/data/dragon.vtu
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${F3D_SOURCE_DIR}/testing/data/dragon.vtu
 RenderEvent 781 494 0 0 0 Super_L 0
 MouseMoveEvent 781 498 0 0 0 Super_L 0
 LeaveEvent 751 614 0 0 0 Super_L 0
@@ -21,6 +21,6 @@ EnterEvent 700 570 0 0 0 Super_L 0
 MouseMoveEvent 700 570 0 0 0 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${CMAKE_SOURCE_DIR}/testing/data/cow.vtp
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${F3D_SOURCE_DIR}/testing/data/cow.vtp
 RenderEvent 781 494 0 0 0 Super_L 0
 MouseMoveEvent 781 498 0 0 0 Super_L 0

--- a/testing/recordings/TestInteractionGroupGeometriesDrop.log.in
+++ b/testing/recordings/TestInteractionGroupGeometriesDrop.log.in
@@ -5,6 +5,6 @@ KeyPressEvent 677 699 0 0 1 Super_L 0
 CharEvent 677 699 0 0 1 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${CMAKE_SOURCE_DIR}/testing/data/mb/mb_2_0.vtp
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${F3D_SOURCE_DIR}/testing/data/mb/mb_2_0.vtp
 RenderEvent 781 494 0 0 0 Super_L 0
 MouseMoveEvent 781 498 0 0 0 Super_L 0

--- a/testing/recordings/TestSDKInteractorCallBack.log.in
+++ b/testing/recordings/TestSDKInteractorCallBack.log.in
@@ -5,7 +5,7 @@ KeyPressEvent 677 699 0 0 1 Super_L 0
 CharEvent 677 699 0 0 1 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${CMAKE_SOURCE_DIR}/testing/data/dragon.vtu
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${F3D_SOURCE_DIR}/testing/data/dragon.vtu
 RenderEvent 781 494 0 0 0 Super_L 0
 MouseMoveEvent 781 498 0 0 0 Super_L 0
 LeaveEvent 751 614 0 0 0 Super_L 0

--- a/testing/recordings/TestSDKInteractorDropFullScene.log.in
+++ b/testing/recordings/TestSDKInteractorDropFullScene.log.in
@@ -5,7 +5,7 @@ KeyPressEvent 677 699 0 0 1 Super_L 0
 CharEvent 677 699 0 0 1 Super_L 0
 UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
 EnterEvent 781 494 0 0 0 Super_L 0
-DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${CMAKE_SOURCE_DIR}/testing/data/world.obj
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${F3D_SOURCE_DIR}/testing/data/world.obj
 RenderEvent 781 494 0 0 0 Super_L 0
 MouseMoveEvent 781 498 0 0 0 Super_L 0
 LeaveEvent 751 614 0 0 0 Super_L 0

--- a/webassembly/CMakeLists.txt
+++ b/webassembly/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(f3djs PRIVATE libf3d)
 target_link_options(f3djs PRIVATE
   "--bind"
   "-O1"
-  "SHELL:--preload-file ${CMAKE_SOURCE_DIR}/testing/data@/"
+  "SHELL:--preload-file ${F3D_SOURCE_DIR}/testing/data@/"
   "SHELL:-sEXPORT_NAME=f3d"
   "SHELL:-sALLOW_MEMORY_GROWTH=1"
   "SHELL:-sDEMANGLE_SUPPORT=1"

--- a/winshellext/CMakeLists.txt
+++ b/winshellext/CMakeLists.txt
@@ -13,7 +13,7 @@ if (F3D_USE_EXTERNAL_NLOHMANN_JSON)
   target_link_libraries(F3DShellExtension PRIVATE nlohmann_json::nlohmann_json)
 else ()
   target_include_directories(F3DShellExtension PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/external/nlohmann_json>)
+    $<BUILD_INTERFACE:${F3D_SOURCE_DIR}/external/nlohmann_json>)
 endif ()
 
 target_link_libraries(F3DShellExtension PUBLIC libf3d PRIVATE pathcch shlwapi windowscodecs)


### PR DESCRIPTION
If F3D is added as a subproject using `add_subdirectory`, many things are not working because of the usage of `CMAKE_SOURCE_DIR` which refer to the top level directory. Let's use `F3D_SOURCE_DIR` instead.  
FYI the variable `F3D_SOURCE_DIR` is defined automatically when calling `project(F3D)`
Since CMake 3.21 there is a [PROJECT_IS_TOP_LEVEL](https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html). We can use that too for the plugins.