### PR TITLE
Improve upon #858

### DIFF
--- a/.cppcheck.supp
+++ b/.cppcheck.supp
@@ -11,6 +11,7 @@ unusedFunction
 
 // specific checks
 knownConditionTrueFalse:library/testing/TestSDKImage.cxx
+knownConditionTrueFalse:library/testing/TestSDKImageDeprecated.cxx
 noExplicitConstructor:library/public/types.h
 preprocessorErrorDirective:library/src/engine.cxx
 preprocessorErrorDirective:plugins/draco/module/vtkF3DDracoReader.cxx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,15 +69,23 @@ jobs:
             os: macos
             vtk_version: commit
             raytracing_label: no-raytracing
+            exclude_deprecated_label: no-exclude-deprecated
             bundle_label: bundle
+            egl_label: no-egl
           - build_type: headless
             os: ubuntu
             vtk_version: commit
+            raytracing_label: raytracing
+            exclude_deprecated_label: no-exclude-deprecated
+            bundle_label: no-bundle
             egl_label: egl
           - build_type: exclude_deprecated
             os: ubuntu
             vtk_version: commit
+            raytracing_label: raytracing
             exclude_deprecated_label: exclude-deprecated
+            bundle_label: no-bundle
+            egl_label: no-egl
 
     runs-on: ${{matrix.os}}-latest
     container: ${{ matrix.os == 'ubuntu' && 'ghcr.io/f3d-app/f3d-ci' || null }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         build_type: [standard]
         include:
           - raytracing_label: raytracing
+          - exclude_deprecated_label: no-exclude-deprecated
           - bundle_label: no-bundle
           - egl_label: no-egl
           - vtk_version: v9.0.0
@@ -73,6 +74,10 @@ jobs:
             os: ubuntu
             vtk_version: commit
             egl_label: egl
+          - build_type: exclude_deprecated
+            os: ubuntu
+            vtk_version: commit
+            exclude_deprecated_label: exclude-deprecated
 
     runs-on: ${{matrix.os}}-latest
     container: ${{ matrix.os == 'ubuntu' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -163,6 +168,7 @@ jobs:
         -DCMAKE_PREFIX_PATH:PATH=$(pwd)/../dependencies/install/
         -DF3D_BINDINGS_JAVA=ON
         -DF3D_BINDINGS_PYTHON=ON
+        -DF3D_EXCLUDE_DEPRECATED=${{ matrix.exclude_deprecated_label == 'exclude-deprecated' && 'ON' || 'OFF' }}
         -DF3D_LINUX_GENERATE_MAN=ON
         -DF3D_LINUX_INSTALL_DEFAULT_CONFIGURATION_FILE_IN_PREFIX=ON
         -DF3D_MACOS_BUNDLE=${{ matrix.bundle_label == 'bundle' && 'ON' || 'OFF' }}
@@ -388,7 +394,6 @@ jobs:
         -DF3D_PLUGIN_BUILD_DRACO=ON
         -DF3D_PLUGIN_BUILD_OCCT=ON
         -DF3D_STRICT_BUILD=ON
-        -DF3D_EXCLUDE_DEPRECATED=ON
         -DF3D_TESTING_ENABLE_LONG_TIMEOUT_TESTS=ON
 
     - name: Build

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,7 +7,12 @@ For F3D users:
  - Fixed an issue with the binary release when opening draco files
  - Fixed an issue with matcap textures
 
+For libf3d users:
+ - Reworked image API to support many file formats to read (EXR, HDR) and write (PNG, JPG, TIF, BMP)
+ - Deprecated previous image API
+
 For developers:
+ - Added a deprecation framework
 
 For F3D packagers:
  - Fixed compatibility with FreeBSD

--- a/library/testing/CMakeLists.txt
+++ b/library/testing/CMakeLists.txt
@@ -22,6 +22,10 @@ if(VTK_VERSION VERSION_GREATER 9.0.1)
     TestSDKDynamicLightIntensity.cxx
     TestSDKDynamicProperties.cxx
     )
+  if(NOT F3D_EXCLUDE_DEPRECATED)
+    list(APPEND libf3dSDKTests_list
+         TestSDKImageDeprecated.cxx)
+  endif()
 endif()
 
 # Animation needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/7246

--- a/library/testing/TestSDKImageDeprecated.cxx
+++ b/library/testing/TestSDKImageDeprecated.cxx
@@ -1,0 +1,109 @@
+#include <image.h>
+
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include <random>
+
+int TestSDKImageDeprecated(int argc, char* argv[])
+{
+  constexpr unsigned int width = 64;
+  constexpr unsigned int height = 64;
+  constexpr unsigned int channels = 3;
+
+  std::vector<unsigned char> pixels(width * height * channels);
+
+  // fill with deterministic random values
+  // do not use std::uniform_int_distribution, it's not giving the same result on different
+  // platforms
+  std::mt19937 rand_generator;
+  std::generate(std::begin(pixels), std::end(pixels), [&]() { return rand_generator() % 256; });
+
+  f3d::image generated;
+  generated.setResolution(width, height).setChannelCount(channels).setData(pixels.data());
+  generated.save(std::string(argv[2]) + "TestSDKImageDeprecated.png");
+
+  // test exceptions
+  try
+  {
+    generated.save("/dummy/folder/img.png");
+
+    std::cerr << "An exception has not been thrown when saving to an incorrect path" << std::endl;
+    return EXIT_FAILURE;
+  }
+  catch (const f3d::image::write_exception&)
+  {
+  }
+
+  try
+  {
+    f3d::image img("/dummy/folder/img.png");
+
+    std::cerr << "An exception has not been thrown when reading an incorrect path" << std::endl;
+    return EXIT_FAILURE;
+  }
+  catch (const f3d::image::read_exception&)
+  {
+  }
+
+  f3d::image baseline(std::string(argv[1]) + "/baselines/TestSDKImage.png");
+
+  if (generated.getWidth() != width || generated.getHeight() != height)
+  {
+    std::cerr << "Image has wrong dimensions" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (generated.getChannelCount() != channels)
+  {
+    std::cerr << "Image has wrong number of channels" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (generated.getData() == nullptr)
+  {
+    std::cerr << "Image has no data" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (generated != baseline)
+  {
+    std::cerr << "Generated image is different from the baseline" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // test operators
+  f3d::image imgCopy = generated; // copy constructor
+
+  if (imgCopy != generated)
+  {
+    std::cerr << "Copy constructor failed" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  imgCopy = baseline; // copy assignment
+
+  if (imgCopy != baseline)
+  {
+    std::cerr << "Copy assignment failed" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  f3d::image imgMove = std::move(imgCopy); // move constructor
+
+  if (imgMove != baseline)
+  {
+    std::cerr << "Move constructor failed" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  imgCopy = std::move(imgMove); // move assignment
+
+  if (imgCopy != baseline)
+  {
+    std::cerr << "Move assignment failed" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -288,7 +288,7 @@ PYBIND11_MODULE(f3d, module)
     [=](const f3d::image& img)
     {
       PyErr_WarnEx(PyExc_DeprecationWarning, "getData is deprecated, use getContent instead.", 1);
-      getImageBytes(img);
+      return getImageBytes(img);
     });
 #pragma GCC diagnostic pop
 #endif

--- a/python/testing/CMakeLists.txt
+++ b/python/testing/CMakeLists.txt
@@ -5,6 +5,11 @@ list(APPEND pyf3dTests_list
      TestPythonUtils.py
     )
 
+if(NOT F3D_EXCLUDE_DEPRECATED)
+  list(APPEND pyf3dTests_list
+       TestPythonImageDataDeprecated.py)
+endif()
+
 if(NOT F3D_MACOS_BUNDLE)
   list(APPEND pyf3dTests_list
        TestPythonPlugins.py

--- a/python/testing/TestPythonImageData.py
+++ b/python/testing/TestPythonImageData.py
@@ -42,7 +42,7 @@ assert len(data) == depth * width * height
 
 '''set data back'''
 
-img.setData(data)
+img.setContent(data)
 assert img.getContent() == data
 
 '''check channel type and save image'''
@@ -57,7 +57,7 @@ assert os.path.isfile(sys.argv[3] + "/Testing/Temporary/TestPythonSaveFile.bmp")
 '''attempt to set partial data back'''
 
 try:
-    img.setData(data[:-1])
+    img.setContent(data[:-1])
     assert False, 'expected exception'
 except ValueError:
     assert True

--- a/python/testing/TestPythonImageDataDeprecated.py
+++ b/python/testing/TestPythonImageDataDeprecated.py
@@ -1,0 +1,55 @@
+import sys
+if sys.platform.startswith('win32'):
+  import os
+  os.add_dll_directory(sys.argv[1])
+
+import f3d
+
+engine = f3d.engine(f3d.window.NATIVE_OFFSCREEN)
+window = engine.getWindow()
+window.setSize(300, 200)
+
+
+'''with background -> RGB image'''
+
+img = window.renderToImage()
+width = img.getWidth()
+height = img.getHeight()
+depth = img.getChannelCount()
+data = img.getData()
+
+assert width == window.getWidth()
+assert height == window.getHeight()
+assert depth == 3
+assert isinstance(data, (bytes, bytearray))
+assert len(data) == depth * width * height
+
+
+'''without background -> RGBA image'''
+
+img = window.renderToImage(True)
+width = img.getWidth()
+height = img.getHeight()
+depth = img.getChannelCount()
+data = img.getData()
+
+assert width == window.getWidth()
+assert height == window.getHeight()
+assert depth == 4
+assert isinstance(data, (bytes, bytearray))
+assert len(data) == depth * width * height
+
+
+'''set data back'''
+
+img.setData(data)
+assert img.getData() == data
+
+
+'''attempt to set partial data back'''
+
+try:
+    img.setData(data[:-1])
+    assert False, 'expected exception'
+except ValueError:
+    assert True


### PR DESCRIPTION
 - Add changelog for #858 
 - Add a dedicated CI for exclude deprecated
 - Fix a deprecated usage in python testing
 - Add a test for testing deprecated image python API
 - Add a test for testing deprecated image SDK API
 - Fixes a small issue with cache logic in CI
 - Fixes an issue in deprecated code