### PR TITLE
Add HDRI hide feature and improve HDRI performance

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -331,6 +331,7 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
     this->DeclareOption(grp2, "roughness", "", "Roughness coefficient (0.0-1.0)", options.getAsDoubleRef("model.material.roughness"), HasDefault::YES, MayHaveConfig::YES, "<roughness>");
     this->DeclareOption(grp2, "metallic", "", "Metallic coefficient (0.0-1.0)", options.getAsDoubleRef("model.material.metallic"), HasDefault::YES, MayHaveConfig::YES, "<metallic>");
     this->DeclareOption(grp2, "hdri", "", "Path to an image file that will be used as a light source", options.getAsStringRef("render.background.hdri"), LocalHasDefaultNo, MayHaveConfig::YES, "<file path>");
+    this->DeclareOption(grp2, "hdri-hide", "", "When using a HDRI, use it as a light source but hide the background skybox", options.getAsBoolRef("render.background.hdri.hide"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp2, "texture-matcap", "", "Path to a texture file containing a material capture", options.getAsStringRef("model.matcap.texture"), LocalHasDefaultNo, MayHaveConfig::YES, "<file path>");
     this->DeclareOption(grp2, "texture-base-color", "", "Path to a texture file that sets the color of the object", options.getAsStringRef("model.color.texture"), LocalHasDefaultNo, MayHaveConfig::YES, "<file path>");
     this->DeclareOption(grp2, "texture-material", "", "Path to a texture file that sets the Occlusion, Roughness and Metallic values of the object", options.getAsStringRef("model.material.texture"), LocalHasDefaultNo, MayHaveConfig::YES, "<file path>");

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -315,6 +315,7 @@ if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20221220)
   f3d_test(NAME TestHDRI8Bit DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/logo.tif HDRI)
   f3d_test(NAME TestHDRIOrient DATA suzanne.stl ARGS --up=+Z --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr HDRI)
   f3d_test(NAME TestHDRIToneMapping DATA suzanne.ply ARGS -t --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr HDRI)
+  f3d_test(NAME TestHDRIHide HDRI DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr --hdri-hide DEFAULT_LIGHTS)
   f3d_test(NAME TestInteractionHDRIMove DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr HDRI INTERACTION THRESHOLD 60) #Shift+MouseRight;
   f3d_test(NAME TestInteractionHDRIBlur DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr INTERACTION HDRI DEFAULT_LIGHTS) #U
   f3d_test(NAME TestInteractionHDRIReload DATA suzanne.ply ARGS --hdri=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr INTERACTION HDRI DEFAULT_LIGHTS) #Up

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 For F3D users:
  - Added bindings to move the camera to standard locations: `1`: Front, `3`: Right, `7`: Top, `9`: Isometric
+ - Added a `--hdri-hide` option to hide the HDRI skybox while using HDRI lighting
  - Fixed an issue with the binary release when opening draco files
  - Fixed an issue with matcap textures
  - Fixed cheatsheet menu rendering under 'Drop File Instructor'
  - Improved cheatsheet menu contrast for any background color
  - Improved overall text contrast for any background color
+ - Improved HDRI cache performance
 
 For libf3d users:
  - Reworked image API to support many file formats to read (EXR, HDR) and write (PNG, JPG, TIF, BMP)

--- a/doc/libf3d/OPTIONS.md
+++ b/doc/libf3d/OPTIONS.md
@@ -74,7 +74,8 @@ render.raytracing.samples|int<br>5<br>render|The number of *samples per pixel*.|
 render.raytracing.denoise|bool<br>false<br>render|*Denoise* the raytracing rendering.|\-\-denoise
 render.background.color|vector\<double\><br>0.2,0.2,0.2<br>render|Set the window *background color*.<br>Ignored if *hdri* is set.|\-\-bg-color
 render.background.hdri|string<br>-<br>render|Set the *HDRI* image used to create the environment.<br>The environment act as a light source and is reflected on the material.<br>Valid file format are hdr, exr, png, jpg, pnm, tiff, bmp. Override the color.|\-\-hdri
-render.background.blur|bool<br>false<br>render|Blur background when using a HDRI.|\-\-blur-background
+render.background.hdri.hide|bool<br>false<br>render|Hide background skybox when using a HDRI.|\-\-blur-background
+render.background.blur|bool<br>false<br>render|Blur background, useful with a HDRI.|\-\-blur-background
 render.background.blur.coc|double<br>20.0<br>render|Blur background circle of confusion radius.|\-\-blur-background-coc
 
 ## UI Options

--- a/doc/user/OPTIONS.md
+++ b/doc/user/OPTIONS.md
@@ -68,7 +68,9 @@ Options|Default|Description
 -z, \-\-fps||Display a *frame per second counter*.
 -n, \-\-filename||Display the *name of the file* on top of the window.
 -m, \-\-metadata||Display the *metadata*.<br>Empty without a default scene.
--u, \-\-blur-background||Blur background.<br>Requires an HDRi.
+-u, \-\-blur-background||Blur background.<br>Useful with a HDRI.
+\-\-blur-coc|20|Blur circle of confusion radius.
+\-\-hdri-hide|false|Hide the skybox background when using a HDRI.
 \-\-light-intensity|1.0|*Adjust the intensity* of every light in the scene.
 
 ## Scientific visualization options

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -648,7 +648,8 @@ void vtkF3DRenderer::ConfigureHDRI()
       hdriTexture->SetInputConnection(textureReader->GetOutputPort());
 
       // 8-bit textures are usually gamma-corrected
-      if (textureReader->GetOutput() && textureReader->GetOutput()->GetScalarType() == VTK_UNSIGNED_CHAR)
+      if (textureReader->GetOutput() &&
+        textureReader->GetOutput()->GetScalarType() == VTK_UNSIGNED_CHAR)
       {
         hdriTexture->UseSRGBColorSpaceOn();
       }

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -493,6 +493,21 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
 }
 
 //----------------------------------------------------------------------------
+void vtkF3DRenderer::ShowHDRISkybox(bool show)
+{
+  if (this->HDRISkyboxVisible != show)
+  {
+    this->HDRISkyboxVisible = show;
+
+    // TODO merely changing the Skybox visibility could be optimized
+    // instead of configuring the HDRI lighting again
+    this->HDRIConfigured = false;
+    this->TextActorsConfigured = false;
+    this->RenderPassesConfigured = false;
+  }
+}
+
+//----------------------------------------------------------------------------
 void vtkF3DRenderer::SetHDRIFile(const std::string& hdriFile)
 {
   // Check HDRI is different than current one
@@ -699,16 +714,23 @@ void vtkF3DRenderer::ConfigureHDRI()
     }
 #endif
 
-    // Setup the OpenGL Skybox
-    // TODO: Add support for visibility in vtkOpenGLSkybox
-    this->AddActor(this->Skybox);
-    this->Skybox->SetProjection(vtkSkybox::Sphere);
-    this->Skybox->SetTexture(hdriTexture);
+    if (this->HDRISkyboxVisible)
+    {
+      // Setup the OpenGL Skybox
+      // TODO: Add support for visibility in vtkOpenGLSkybox
+      this->AddActor(this->Skybox);
+      this->Skybox->SetProjection(vtkSkybox::Sphere);
+      this->Skybox->SetTexture(hdriTexture);
 
-    // First version of VTK including the version check (and the feature used)
+      // First version of VTK including the version check (and the feature used)
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 0, 20200527)
-    this->Skybox->GammaCorrectOn();
+      this->Skybox->GammaCorrectOn();
 #endif
+    }
+    else
+    {
+      this->RemoveActor(this->Skybox);
+    }
   }
   else
   {

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -80,12 +80,12 @@ std::string ComputeFileHash(const std::string& filepath)
   std::vector<char> buffer(length);
 
   vtksys::ifstream file;
-  file.open(filepath, std::ios_base::binary);
+  file.open(filepath.c_str(), std::ios_base::binary);
   file.read(buffer.data(), length);
 
   vtksysMD5* md5 = vtksysMD5_New();
   vtksysMD5_Initialize(md5);
-  vtksysMD5_Append(md5, reinterpret_cast<const unsigned char*>(buffer.data()), length);
+  vtksysMD5_Append(md5, reinterpret_cast<const unsigned char*>(buffer.data()), static_cast<int>(length));
   vtksysMD5_Finalize(md5, digest);
   vtksysMD5_DigestToHex(digest, md5Hash);
   vtksysMD5_Delete(md5);
@@ -660,9 +660,11 @@ void vtkF3DRenderer::ConfigureHDRI()
       vtkNew<vtkImageData> img;
       hdriTexture->SetInputData(img);
 
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 2, 20221220)
       // The MTime must be more recent than the image one
       // Otherwise VTK triggers a new SH computation
       this->SphericalHarmonics->Modified();
+#endif
     }
     this->SetEnvironmentTexture(hdriTexture);
 

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -42,6 +42,7 @@
 #include <vtkXMLMultiBlockDataWriter.h>
 #include <vtkXMLTableReader.h>
 #include <vtkXMLTableWriter.h>
+#include <vtksys/FStream.hxx>
 #include <vtksys/MD5.h>
 #include <vtksys/SystemTools.hxx>
 
@@ -68,22 +69,24 @@ namespace
 {
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 2, 20221220)
 //----------------------------------------------------------------------------
-// Compute the MD5 hash of the scalar field of an image data
-std::string ComputeImageHash(vtkImageData* image)
+// Compute the MD5 hash of an existing file on disk
+std::string ComputeFileHash(const std::string& filepath)
 {
   unsigned char digest[16];
   char md5Hash[33];
   md5Hash[32] = '\0';
 
-  unsigned char* content = reinterpret_cast<unsigned char*>(image->GetScalarPointer());
-  int* dims = image->GetDimensions();
-  int nbComp = image->GetNumberOfScalarComponents();
-  int scalarSize = image->GetScalarSize();
-  int size = nbComp * scalarSize * dims[0] * dims[1] * dims[2];
+
+  std::size_t length = vtksys::SystemTools::FileLength(filepath);
+  std::vector<char> buffer(length);
+
+  vtksys::ifstream file;
+  file.open(filepath, std::ios_base::binary);
+  file.read(buffer.data(), length);
 
   vtksysMD5* md5 = vtksysMD5_New();
   vtksysMD5_Initialize(md5);
-  vtksysMD5_Append(md5, content, size);
+  vtksysMD5_Append(md5, reinterpret_cast<const unsigned char*>(buffer.data()), length);
   vtksysMD5_Finalize(md5, digest);
   vtksysMD5_DigestToHex(digest, md5Hash);
   vtksysMD5_Delete(md5);
@@ -602,7 +605,7 @@ void vtkF3DRenderer::ConfigureHDRI()
     }
 
     // Compute HDRI MD5
-    std::string hash = ::ComputeImageHash(hdriTexture->GetInput());
+    std::string hash = ::ComputeFileHash(this->HDRIFile);
 
     // Cache folder for this HDRI
     std::string currentCachePath = this->CachePath + "/" + hash;

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -85,7 +85,8 @@ std::string ComputeFileHash(const std::string& filepath)
 
   vtksysMD5* md5 = vtksysMD5_New();
   vtksysMD5_Initialize(md5);
-  vtksysMD5_Append(md5, reinterpret_cast<const unsigned char*>(buffer.data()), static_cast<int>(length));
+  vtksysMD5_Append(
+    md5, reinterpret_cast<const unsigned char*>(buffer.data()), static_cast<int>(length));
   vtksysMD5_Finalize(md5, digest);
   vtksysMD5_DigestToHex(digest, md5Hash);
   vtksysMD5_Delete(md5);

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -76,7 +76,6 @@ std::string ComputeFileHash(const std::string& filepath)
   char md5Hash[33];
   md5Hash[32] = '\0';
 
-
   std::size_t length = vtksys::SystemTools::FileLength(filepath);
   std::vector<char> buffer(length);
 
@@ -546,7 +545,7 @@ void vtkF3DRenderer::ConfigureHDRI()
 {
   // Read HDRI when needed
   vtkNew<vtkTexture> hdriTexture;
-  vtkSmartPointer<vtkImageReader2> reader;
+  vtkSmartPointer<vtkImageReader2> textureReader;
   this->HasHDRILighting = false;
   if (!this->HDRIFile.empty())
   {
@@ -557,9 +556,9 @@ void vtkF3DRenderer::ConfigureHDRI()
     }
     else
     {
-      reader = vtkSmartPointer<vtkImageReader2>::Take(
+      textureReader = vtkSmartPointer<vtkImageReader2>::Take(
         vtkImageReader2Factory::CreateImageReader2(this->HDRIFile.c_str()));
-      if (reader)
+      if (textureReader)
       {
         this->HasHDRILighting = true;
       }
@@ -640,16 +639,16 @@ void vtkF3DRenderer::ConfigureHDRI()
     if (needHDRIComputation || this->HDRISkyboxVisible)
     {
       // The actual env texture is needed, read it
-      reader->SetFileName(this->HDRIFile.c_str());
-      reader->Update();
+      textureReader->SetFileName(this->HDRIFile.c_str());
+      textureReader->Update();
 
       hdriTexture->SetColorModeToDirectScalars();
       hdriTexture->MipmapOn();
       hdriTexture->InterpolateOn();
-      hdriTexture->SetInputConnection(reader->GetOutputPort());
+      hdriTexture->SetInputConnection(textureReader->GetOutputPort());
 
       // 8-bit textures are usually gamma-corrected
-      if (reader->GetOutput() && reader->GetOutput()->GetScalarType() == VTK_UNSIGNED_CHAR)
+      if (textureReader->GetOutput() && textureReader->GetOutput()->GetScalarType() == VTK_UNSIGNED_CHAR)
       {
         hdriTexture->UseSRGBColorSpaceOn();
       }

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.h
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.h
@@ -40,6 +40,7 @@ public:
   void ShowFilename(bool show);
   void ShowCheatSheet(bool show);
   void ShowDropZone(bool show);
+  void ShowHDRISkybox(bool show);
   ///@}
 
   using vtkOpenGLRenderer::SetBackground;
@@ -235,6 +236,7 @@ protected:
   bool MetaDataVisible = false;
   bool CheatSheetVisible = false;
   bool DropZoneVisible = false;
+  bool HDRISkyboxVisible = true;
   bool UseRaytracing = false;
   bool UseRaytracingDenoiser = false;
   bool UseDepthPeelingPass = false;

--- a/library/src/options.cxx
+++ b/library/src/options.cxx
@@ -140,6 +140,7 @@ options::options()
   this->Internals->init("render.background.color", std::vector<double>{ 0.2, 0.2, 0.2 });
   this->Internals->init(
     "render.background.hdri", std::string()); // XXX This overrides background.color
+  this->Internals->init("render.background.hdri.hide", false);
   this->Internals->init("render.background.blur", false);
   this->Internals->init("render.background.blur.coc", 20.0);
   this->Internals->init("render.light.intensity", 1.);

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -309,6 +309,8 @@ void window_impl::UpdateDynamicOptions()
     this->Internals->Options.getAsDouble("render.background.blur.coc"));
   this->Internals->Renderer->SetHDRIFile(
     this->Internals->Options.getAsString("render.background.hdri"));
+  this->Internals->Renderer->ShowHDRISkybox(
+    !this->Internals->Options.getAsBool("render.background.hdri.hide"));
   this->Internals->Renderer->SetLightIntensity(
     this->Internals->Options.getAsDouble("render.light.intensity"));
 

--- a/testing/baselines/TestHDRIHide.png
+++ b/testing/baselines/TestHDRIHide.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cb2ae9fa4b3ac88ec62ace0b0a1f4f9d273a5ce3ac65f5eaefeb259062ac10f
+size 22653


### PR DESCRIPTION
- Add a `--hdri-hide` option to hide the HDRI skybox while using a HDRI
- Add a test
- Improve HDRI computation to rely on cache only when possible
- Improve HDRI cache performance by computing hashsum on file instead of content