### PR TITLE
OCC BRep format

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -522,6 +522,8 @@ if(F3D_PLUGIN_BUILD_OCCT)
   f3d_test(NAME TestBREP DATA f3d.brep DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
   f3d_test(NAME TestBinaryBREP DATA f3d.bin.brep DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
 
+  f3d_test(NAME TestInvalidBREP DATA invalid.brep ARGS --verbose --load-plugins=occt REGEXP "Failed opening file" NO_BASELINE)
+
   if(F3D_PLUGIN_OCCT_COLORING_SUPPORT AND NOT F3D_MACOS_BUNDLE)
     file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
     f3d_test(NAME TestDefaultConfigFileOCCT DATA f3d.stp CONFIG config_build DEFAULT_LIGHTS)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -522,7 +522,7 @@ if(F3D_PLUGIN_BUILD_OCCT)
   f3d_test(NAME TestBREP DATA f3d.brep DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
   f3d_test(NAME TestBinaryBREP DATA f3d.bin.brep DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
 
-  f3d_test(NAME TestInvalidBREP DATA invalid.brep ARGS --verbose --load-plugins=occt REGEXP "Failed opening file" NO_BASELINE)
+  f3d_test(NAME TestInvalidBREP DATA invalid.brep ARGS --verbose --load-plugins=occt NO_BASELINE)
 
   if(F3D_PLUGIN_OCCT_COLORING_SUPPORT AND NOT F3D_MACOS_BUNDLE)
     file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -520,6 +520,7 @@ if(F3D_PLUGIN_BUILD_OCCT)
   f3d_test(NAME TestSTEP DATA f3d.stp DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
   f3d_test(NAME TestIGES DATA f3d.igs DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
   f3d_test(NAME TestBREP DATA f3d.brep DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
+  f3d_test(NAME TestBinaryBREP DATA f3d.bin.brep DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
 
   if(F3D_PLUGIN_OCCT_COLORING_SUPPORT AND NOT F3D_MACOS_BUNDLE)
     file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -519,6 +519,7 @@ endif()
 if(F3D_PLUGIN_BUILD_OCCT)
   f3d_test(NAME TestSTEP DATA f3d.stp DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
   f3d_test(NAME TestIGES DATA f3d.igs DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
+  f3d_test(NAME TestBREP DATA f3d.brep DEFAULT_LIGHTS ARGS --load-plugins=occt --up=+Z)
 
   if(F3D_PLUGIN_OCCT_COLORING_SUPPORT AND NOT F3D_MACOS_BUNDLE)
     file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@ For F3D users:
  - Added new options `hdri-file`, `hdri-ambient`, `hdri-skybox` to have more control on the HDRI behavior
  - Added bindings to toggle HDRI ambient lighting (`F`) and HDRI skybox (`J`)
  - Added bindings to move the camera to standard locations: `1`: Front, `3`: Right, `7`: Top, `9`: Isometric
+ - Added [Open CASCADE BRep format](https://dev.opencascade.org/doc/overview/html/specification__brep_format.html) to the OCCT plugin.
  - Fixed an issue with the binary release when opening draco files
  - Fixed an issue with matcap textures
  - Fixed an issue with HDRI lighting

--- a/doc/user/USAGE.md
+++ b/doc/user/USAGE.md
@@ -24,6 +24,7 @@ Here is the list of supported file formats:
 * **.pts** : Point Cloud file format
 * **.step/.stp** : CAD STEP exchange ISO format
 * **.iges/.igs** : CAD Initial Graphics Exchange Specification format
+* **.brep** : Open CASCADE BRep format
 * **.abc** : Alembic format
 * **.obj** : Wavefront OBJ file format (full scene and default scene)
 * **.gltf/.glb** : GL Transmission Format (full scene and default scene)

--- a/plugins/occt/CMakeLists.txt
+++ b/plugins/occt/CMakeLists.txt
@@ -52,6 +52,15 @@ f3d_plugin_declare_reader(
   CUSTOM_CODE "${CMAKE_CURRENT_SOURCE_DIR}/iges.inl"
 )
 
+f3d_plugin_declare_reader(
+  NAME BREP
+  EXTENSIONS brep occ
+  MIMETYPES model/brep model/occ
+  VTK_READER vtkF3DOCCTReader
+  FORMAT_DESCRIPTION "Open CASCADE BRep"
+  CUSTOM_CODE "${CMAKE_CURRENT_SOURCE_DIR}/brep.inl"
+)
+
 set(rpaths "")
 get_target_property(target_type TKernel TYPE)
 if (target_type STREQUAL SHARED_LIBRARY)

--- a/plugins/occt/CMakeLists.txt
+++ b/plugins/occt/CMakeLists.txt
@@ -54,8 +54,8 @@ f3d_plugin_declare_reader(
 
 f3d_plugin_declare_reader(
   NAME BREP
-  EXTENSIONS brep occ
-  MIMETYPES model/brep model/occ
+  EXTENSIONS brep
+  MIMETYPES application/vnd.brep
   VTK_READER vtkF3DOCCTReader
   FORMAT_DESCRIPTION "Open CASCADE BRep"
   CUSTOM_CODE "${CMAKE_CURRENT_SOURCE_DIR}/brep.inl"

--- a/plugins/occt/brep.inl
+++ b/plugins/occt/brep.inl
@@ -1,0 +1,10 @@
+void applyCustomReader(vtkAlgorithm* algo, const std::string& vtkNotUsed(fileName)) const override
+{
+  vtkF3DOCCTReader* occtReader = vtkF3DOCCTReader::SafeDownCast(algo);
+
+  occtReader->RelativeDeflectionOn();
+  occtReader->SetLinearDeflection(0.1);
+  occtReader->SetAngularDeflection(0.5);
+  occtReader->ReadWireOn();
+  occtReader->SetFileFormat(vtkF3DOCCTReader::FILE_FORMAT::BREP);
+}

--- a/plugins/occt/module/Testing/TestF3DOCCTReader.cxx
+++ b/plugins/occt/module/Testing/TestF3DOCCTReader.cxx
@@ -1,3 +1,5 @@
+#include <cassert>
+
 #include <vtkMultiBlockDataSet.h>
 #include <vtkNew.h>
 #include <vtkTestUtilities.h>
@@ -8,14 +10,23 @@
 
 int TestF3DOCCTReader(int vtkNotUsed(argc), char* argv[])
 {
-  std::string filename = std::string(argv[1]) + "data/f3d.stp";
-  vtkNew<vtkF3DOCCTReader> reader;
-  reader->RelativeDeflectionOn();
-  reader->SetLinearDeflection(0.1);
-  reader->SetAngularDeflection(0.5);
-  reader->ReadWireOn();
-  reader->SetFileName(filename);
-  reader->Update();
-  reader->Print(cout);
-  return reader->GetOutput()->GetNumberOfBlocks() > 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+  for (const auto file : {
+         "data/f3d.stp",
+         "data/f3d.igs",
+         "data/f3d.brep",
+       })
+  {
+    std::string filename = std::string(argv[1]) + file;
+    vtkNew<vtkF3DOCCTReader> reader;
+    reader->RelativeDeflectionOn();
+    reader->SetLinearDeflection(0.1);
+    reader->SetAngularDeflection(0.5);
+    reader->ReadWireOn();
+    reader->SetFileName(filename);
+    reader->Update();
+    reader->Print(cout);
+    assert(reader->GetOutput()->GetNumberOfBlocks() > 0);
+  }
+
+  return EXIT_SUCCESS;
 }

--- a/plugins/occt/module/Testing/TestF3DOCCTReader.cxx
+++ b/plugins/occt/module/Testing/TestF3DOCCTReader.cxx
@@ -4,10 +4,9 @@
 
 #include "vtkF3DOCCTReader.h"
 
-#include <cassert>
 #include <iostream>
 
-void testReader(const std::string& filename, const vtkF3DOCCTReader::FILE_FORMAT& format)
+bool testReader(const std::string& filename, const vtkF3DOCCTReader::FILE_FORMAT& format)
 {
   vtkNew<vtkF3DOCCTReader> reader;
   reader->RelativeDeflectionOn();
@@ -18,13 +17,14 @@ void testReader(const std::string& filename, const vtkF3DOCCTReader::FILE_FORMAT
   reader->SetFileFormat(format);
   reader->Update();
   reader->Print(cout);
-  assert(reader->GetOutput()->GetNumberOfBlocks() > 0);
+  return reader->GetOutput()->GetNumberOfBlocks() > 0;
 }
 
 int TestF3DOCCTReader(int vtkNotUsed(argc), char* argv[])
 {
-  testReader(std::string(argv[1]) + "data/f3d.stp", vtkF3DOCCTReader::FILE_FORMAT::STEP);
-  testReader(std::string(argv[1]) + "data/f3d.igs", vtkF3DOCCTReader::FILE_FORMAT::IGES);
-  testReader(std::string(argv[1]) + "data/f3d.brep", vtkF3DOCCTReader::FILE_FORMAT::BREP);
-  return EXIT_SUCCESS;
+  return (testReader(std::string(argv[1]) + "data/f3d.stp", vtkF3DOCCTReader::FILE_FORMAT::STEP) &&
+           testReader(std::string(argv[1]) + "data/f3d.igs", vtkF3DOCCTReader::FILE_FORMAT::IGES) &&
+           testReader(std::string(argv[1]) + "data/f3d.brep", vtkF3DOCCTReader::FILE_FORMAT::BREP))
+    ? EXIT_SUCCESS
+    : EXIT_FAILURE;
 }

--- a/plugins/occt/module/Testing/TestF3DOCCTReader.cxx
+++ b/plugins/occt/module/Testing/TestF3DOCCTReader.cxx
@@ -4,19 +4,27 @@
 
 #include "vtkF3DOCCTReader.h"
 
+#include <cassert>
 #include <iostream>
 
-int TestF3DOCCTReader(int vtkNotUsed(argc), char* argv[])
+void testReader(const std::string& filename, const vtkF3DOCCTReader::FILE_FORMAT& format)
 {
-  std::string filename = std::string(argv[1]) + "data/f3d.stp";
   vtkNew<vtkF3DOCCTReader> reader;
   reader->RelativeDeflectionOn();
   reader->SetLinearDeflection(0.1);
   reader->SetAngularDeflection(0.5);
   reader->ReadWireOn();
   reader->SetFileName(filename);
-  reader->SetFileFormat(vtkF3DOCCTReader::FILE_FORMAT::STEP);
+  reader->SetFileFormat(format);
   reader->Update();
   reader->Print(cout);
-  return reader->GetOutput()->GetNumberOfBlocks() > 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+  assert(reader->GetOutput()->GetNumberOfBlocks() > 0);
+}
+
+int TestF3DOCCTReader(int vtkNotUsed(argc), char* argv[])
+{
+  testReader(std::string(argv[1]) + "data/f3d.stp", vtkF3DOCCTReader::FILE_FORMAT::STEP);
+  testReader(std::string(argv[1]) + "data/f3d.igs", vtkF3DOCCTReader::FILE_FORMAT::IGES);
+  testReader(std::string(argv[1]) + "data/f3d.brep", vtkF3DOCCTReader::FILE_FORMAT::BREP);
+  return EXIT_SUCCESS;
 }

--- a/plugins/occt/module/Testing/TestF3DOCCTReader.cxx
+++ b/plugins/occt/module/Testing/TestF3DOCCTReader.cxx
@@ -1,5 +1,3 @@
-#include <cassert>
-
 #include <vtkMultiBlockDataSet.h>
 #include <vtkNew.h>
 #include <vtkTestUtilities.h>
@@ -10,23 +8,15 @@
 
 int TestF3DOCCTReader(int vtkNotUsed(argc), char* argv[])
 {
-  for (const auto file : {
-         "data/f3d.stp",
-         "data/f3d.igs",
-         "data/f3d.brep",
-       })
-  {
-    std::string filename = std::string(argv[1]) + file;
-    vtkNew<vtkF3DOCCTReader> reader;
-    reader->RelativeDeflectionOn();
-    reader->SetLinearDeflection(0.1);
-    reader->SetAngularDeflection(0.5);
-    reader->ReadWireOn();
-    reader->SetFileName(filename);
-    reader->Update();
-    reader->Print(cout);
-    assert(reader->GetOutput()->GetNumberOfBlocks() > 0);
-  }
-
-  return EXIT_SUCCESS;
+  std::string filename = std::string(argv[1]) + "data/f3d.stp";
+  vtkNew<vtkF3DOCCTReader> reader;
+  reader->RelativeDeflectionOn();
+  reader->SetLinearDeflection(0.1);
+  reader->SetAngularDeflection(0.5);
+  reader->ReadWireOn();
+  reader->SetFileName(filename);
+  reader->SetFileFormat(vtkF3DOCCTReader::FILE_FORMAT::STEP);
+  reader->Update();
+  reader->Print(cout);
+  return reader->GetOutput()->GetNumberOfBlocks() > 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -270,6 +270,7 @@ public:
     polydata->SetLines(linesCells);
 
 #if F3D_PLUGIN_OCCT_XCAF
+    /* colors may be left empty if this->ColorTool has not been initialized */
     if (colors->GetSize() > 0)
     {
       polydata->GetCellData()->SetScalars(colors);

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -136,15 +136,18 @@ public:
         linesCells->InsertNextCell(polyline.size(), polyline.data());
 
 #if F3D_PLUGIN_OCCT_XCAF
-        std::array<unsigned char, 3> rgb = { 0, 0, 0 };
-        Quantity_Color aColor;
-        if (this->ColorTool && this->ColorTool->GetColor(edge, XCAFDoc_ColorCurv, aColor))
+        if (this->ColorTool)
         {
-          rgb[0] = static_cast<unsigned char>(255.0 * aColor.Red());
-          rgb[1] = static_cast<unsigned char>(255.0 * aColor.Green());
-          rgb[2] = static_cast<unsigned char>(255.0 * aColor.Blue());
+          std::array<unsigned char, 3> rgb = { 0, 0, 0 };
+          Quantity_Color aColor;
+          if (this->ColorTool->GetColor(edge, XCAFDoc_ColorCurv, aColor))
+          {
+            rgb[0] = static_cast<unsigned char>(255.0 * aColor.Red());
+            rgb[1] = static_cast<unsigned char>(255.0 * aColor.Green());
+            rgb[2] = static_cast<unsigned char>(255.0 * aColor.Blue());
+          }
+          colors->InsertNextTypedTuple(rgb.data());
         }
-        colors->InsertNextTypedTuple(rgb.data());
 #endif
 
         shift += nbV;
@@ -239,15 +242,18 @@ public:
         trianglesCells->InsertNextCell(3, cell);
 
 #if F3D_PLUGIN_OCCT_XCAF
-        std::array<unsigned char, 3> rgb = { 255, 255, 255 };
-        Quantity_Color aColor;
-        if (this->ColorTool && this->ColorTool->GetColor(face, XCAFDoc_ColorSurf, aColor))
+        if (this->ColorTool)
         {
-          rgb[0] = static_cast<unsigned char>(255.0 * aColor.Red());
-          rgb[1] = static_cast<unsigned char>(255.0 * aColor.Green());
-          rgb[2] = static_cast<unsigned char>(255.0 * aColor.Blue());
+          std::array<unsigned char, 3> rgb = { 255, 255, 255 };
+          Quantity_Color aColor;
+          if (this->ColorTool->GetColor(face, XCAFDoc_ColorSurf, aColor))
+          {
+            rgb[0] = static_cast<unsigned char>(255.0 * aColor.Red());
+            rgb[1] = static_cast<unsigned char>(255.0 * aColor.Green());
+            rgb[2] = static_cast<unsigned char>(255.0 * aColor.Blue());
+          }
+          colors->InsertNextTypedTuple(rgb.data());
         }
-        colors->InsertNextTypedTuple(rgb.data());
 #endif
       }
 
@@ -262,7 +268,10 @@ public:
     polydata->SetLines(linesCells);
 
 #if F3D_PLUGIN_OCCT_XCAF
-    polydata->GetCellData()->SetScalars(colors);
+    if (colors->GetSize() > 0)
+    {
+      polydata->GetCellData()->SetScalars(colors);
+    }
 #endif
 
     polydata->Squeeze();

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -596,9 +596,12 @@ void vtkF3DOCCTReader::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "AngularDeflection: " << this->AngularDeflection << "\n";
   os << indent << "RelativeDeflection: " << (this->RelativeDeflection ? "true" : "false") << "\n";
   os << indent << "ReadWire: " << (this->ReadWire ? "true" : "false") << "\n";
-  os << indent << "FileFormat: "
-     << (this->FileFormat == FILE_FORMAT::BREP      ? "BREP"
-            : this->FileFormat == FILE_FORMAT::STEP ? "STEP"
-                                                    : "IGES")
-     << "\n";
+  // clang-format off
+  switch (this->FileFormat)
+  {
+    case FILE_FORMAT::BREP: os << "FileFormat: BREP" << "\n"; break;
+    case FILE_FORMAT::STEP: os << "FileFormat: STEP" << "\n"; break;
+    case FILE_FORMAT::IGES: os << "FileFormat: IGES" << "\n"; break;
+  }
+  // clang-format
 }

--- a/plugins/occt/module/vtkF3DOCCTReader.h
+++ b/plugins/occt/module/vtkF3DOCCTReader.h
@@ -30,6 +30,7 @@ public:
 
   enum FILE_FORMAT : unsigned char
   {
+    BREP,
     STEP,
     IGES
   };
@@ -37,7 +38,7 @@ public:
   ///@{
   /**
    * Set the file format to read.
-   * It can be either STEP or IGES.
+   * It can be either BREP, STEP or IGES.
    * Default is FILE_FORMAT::STEP
    */
   vtkSetMacro(FileFormat, FILE_FORMAT);

--- a/testing/baselines/TestBREP.png
+++ b/testing/baselines/TestBREP.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5699c4c1226b091fc7683b9688080489037501b9aace647c1657058cb4e81c6
+size 6265

--- a/testing/baselines/TestBinaryBREP.png
+++ b/testing/baselines/TestBinaryBREP.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5699c4c1226b091fc7683b9688080489037501b9aace647c1657058cb4e81c6
+size 6265

--- a/testing/data/f3d.bin.brep
+++ b/testing/data/f3d.bin.brep
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa79264dd9a9e09e9b88aafd73be3b1d78c3fb4137b1e1695545c1fc65f1eacb
+size 16773

--- a/testing/data/f3d.bin.brep
+++ b/testing/data/f3d.bin.brep
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa79264dd9a9e09e9b88aafd73be3b1d78c3fb4137b1e1695545c1fc65f1eacb
-size 16773
+oid sha256:6608dcfa0607a5b89d5f207afd588e09ed509821bd94ba29f4f2a705e7ec258c
+size 12808

--- a/testing/data/f3d.brep
+++ b/testing/data/f3d.brep
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b67cdf98cc84a3e27872dfa0d1ecedfbb8abfb9c1a1a9a8f036e0f0c57539377
+size 16773


### PR DESCRIPTION
> [Open Cascade BRep format](https://dev.opencascade.org/doc/overview/html/specification__brep_format.html) could be useful for CAD users working with OCC-based procedural generation (eg. [`cadquery`](https://github.com/CadQuery/cadquery), [`build123d`](https://github.com/gumyr/build123d)) to F3D pipelines.
> 
> example file here: https://github.com/tpaviot/pythonocc-demos/blob/master/assets/models/Motor-c.brep

I'm not sure I'm doing it right but I copy-pasted my way through to loading a `.brep` file.
![Motor-c brep](https://github.com/f3d-app/f3d/assets/489715/660c3267-5231-405f-be64-55307b3946ec)

The tests don't pass on my machine (including the existing `.stp` file, even though the test files load and are visually correct in the app) but they look like they should so here we go anyway :)
