### PR TITLE
Remove unsupported std::reduce

### DIFF
--- a/library/src/loader_impl.cxx
+++ b/library/src/loader_impl.cxx
@@ -335,7 +335,11 @@ loader& loader_impl::loadGeometry(const std::vector<float>& positions,
       std::to_string(positions.size()));
   }
 
-  unsigned int expectedSize = std::reduce(faceSizes.cbegin(), faceSizes.cend());
+  unsigned int expectedSize = 0;
+  for (unsigned int currentSize : faceSizes)
+  {
+    expectedSize += currentSize;
+  }
 
   if (faceIndices.size() != expectedSize)
   {


### PR DESCRIPTION
`std::reduce` is not supported on SB compiler