### PR TITLE
Reset the loader when loading an invalid file

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -570,6 +570,7 @@ f3d_test(NAME TestInteractionVolumeInverse DATA HeadMRVolume.mhd ARGS --camera-p
 f3d_test(NAME TestInteractionPointCloud DATA pointsCloud.vtp ARGS --point-size=20 INTERACTION DEFAULT_LIGHTS) #O
 f3d_test(NAME TestInteractionDirectory DATA mb INTERACTION ARGS --scalars DEFAULT_LIGHTS) #Right;Right;Right;Left;Up;
 f3d_test(NAME TestInteractionDirectoryLoop DATA mb INTERACTION ARGS --scalars DEFAULT_LIGHTS) #Left;Left;Left;
+f3d_test(NAME TestInteractionDirectoryEmpty DATA mb INTERACTION NO_DATA_FORCE_RENDER) #Right;Right;Right;
 f3d_test(NAME TestInteractionDirectoryEmptyVerbose DATA mb ARGS --verbose NO_BASELINE INTERACTION REGEXP "is not a file of a supported file format") #Right;Right;Right;HMCSY
 f3d_test(NAME TestInteractionAnimationNotStopped DATA InterpolationTest.glb NO_BASELINE INTERACTION)#Space;
 f3d_test(NAME TestInteractionResetCamera DATA dragon.vtu INTERACTION DEFAULT_LIGHTS)#MouseMovements;Return;

--- a/library/src/loader_impl.cxx
+++ b/library/src/loader_impl.cxx
@@ -107,18 +107,23 @@ public:
     log::debug(importer->GetOutputsDescription(), "\n");
   }
 
+  void Reset()
+  {
+    // Reset the generic importer
+    this->GenericImporter->RemoveInternalReaders();
+
+    // Remove the importer from the renderer
+    this->Window.SetImporterForColoring(nullptr);
+
+    // Window initialization is needed
+    this->Window.Initialize(true);
+  }
+
   void LoadGeometry(const std::string& name, vtkAlgorithm* source, bool reset)
   {
     if (!this->DefaultScene || reset)
     {
-      // Reset the generic importer
-      this->GenericImporter->RemoveInternalReaders();
-
-      // Remove the importer from the renderer
-      this->Window.SetImporterForColoring(nullptr);
-
-      // Window initialization is needed
-      this->Window.Initialize(true);
+      this->Reset();
     }
 
     // Manage progress bar
@@ -202,6 +207,7 @@ loader& loader_impl::loadGeometry(const std::string& filePath, bool reset)
     {
       log::debug("Provided geometry file path is empty\n");
     }
+    this->Internals->Reset();
     return *this;
   }
   if (!vtksys::SystemTools::FileExists(filePath, true))

--- a/testing/baselines/TestInteractionDirectoryEmpty.png
+++ b/testing/baselines/TestInteractionDirectoryEmpty.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6789c7fd477ee3e6ecb90900904afded1405e7c1d0c577d5ea29ce8831001d1
+size 6210

--- a/testing/recordings/TestInteractionDirectoryEmpty.log
+++ b/testing/recordings/TestInteractionDirectoryEmpty.log
@@ -1,0 +1,12 @@
+# StreamVersion 1.2
+ExposeEvent 0 299 0 0 0 0 0
+RenderEvent 0 299 0 0 0 0 0
+KeyPressEvent 345 -446 0 0 1 Right 0
+CharEvent 345 -446 0 0 1 Right 0
+KeyReleaseEvent 345 -446 0 0 1 Right 0
+KeyPressEvent 345 -446 0 0 1 Right 0
+CharEvent 345 -446 0 0 1 Right 0
+KeyReleaseEvent 345 -446 0 0 1 Right 0
+KeyPressEvent 345 -446 0 0 1 Right 0
+CharEvent 345 -446 0 0 1 Right 0
+KeyReleaseEvent 345 -446 0 0 1 Right 0


### PR DESCRIPTION
- Add a dedicated code path to reset the loader when loading an invalid file
- Adding a test
- Fix #1017 