### PR TITLE
Fix an issue with invalid option log not being shown on windows

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -438,6 +438,7 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
             f3d::log::error("Did you mean '--", name, "'?");
           }
         }
+        f3d::log::waitForUser();
         throw F3DExNoProcess("unknown options");
       }
 


### PR DESCRIPTION
Fix #1015 