### PR TITLE
fix `grid-absolute` for off-center models

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -123,7 +123,7 @@ f3d_test(NAME TestGridX DATA suzanne.ply ARGS -g --up=+X DEFAULT_LIGHTS)
 f3d_test(NAME TestGridY DATA suzanne.ply ARGS -g --up=+Y DEFAULT_LIGHTS)
 f3d_test(NAME TestGridZ DATA suzanne.ply ARGS -g --up=+Z DEFAULT_LIGHTS)
 f3d_test(NAME TestGridOptions DATA suzanne.ply ARGS -g --camera-elevation-angle=45 --grid-unit=2 --grid-subdivisions=3 -t DEFAULT_LIGHTS)
-f3d_test(NAME TestGridAbsolute DATA suzanne.ply ARGS -g --camera-elevation-angle=45 --grid-absolute -t DEFAULT_LIGHTS)
+f3d_test(NAME TestGridAbsolute DATA f3d.vtp ARGS -g --up=-Y --camera-direction=-.5,+1,+1 --grid-absolute -t DEFAULT_LIGHTS)
 f3d_test(NAME TestAxis DATA suzanne.ply ARGS -x DEFAULT_LIGHTS)
 f3d_test(NAME TestPointCloud DATA pointsCloud.vtp ARGS -o --point-size=20 DEFAULT_LIGHTS) # Using default lights because of ResetCamera
 f3d_test(NAME TestPointCloudBar DATA pointsCloud.vtp ARGS -sob --point-size=20 DEFAULT_LIGHTS) # Using default lights because of ResetCamera

--- a/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.h
+++ b/library/VTKExtensions/Rendering/vtkF3DOpenGLGridMapper.h
@@ -18,6 +18,11 @@ public:
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /**
+   * Set the origin of the axes relative to the actor position
+   */
+  vtkSetVector3Macro(OriginOffset, double);
+
+  /**
    * Set the distance where the grid disappear.
    */
   vtkSetMacro(FadeDistance, double);
@@ -59,6 +64,7 @@ protected:
 
   bool GetNeedToRebuildShaders(vtkOpenGLHelper& cellBO, vtkRenderer* ren, vtkActor* act) override;
 
+  double OriginOffset[3] = { 0.0, 0.0, 0.0 };
   double FadeDistance = 10.0;
   double UnitSquare = 1.0;
   int Subdivisions = 10;

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -487,7 +487,14 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
       }
 
       double gridPos[3] = { 0, 0, 0 };
-      if (!this->GridAbsolute)
+      if (this->GridAbsolute)
+      {
+        for (int i = 0; i < 3; i++)
+        {
+          gridPos[i] = this->UpVector[i] ? 0 : 0.5 * (bounds[2 * i] + bounds[2 * i + 1]);
+        }
+      }
+      else
       {
         for (int i = 0; i < 3; i++)
         {
@@ -507,6 +514,8 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
       gridMapper->SetUnitSquare(tmpUnitSquare);
       gridMapper->SetSubdivisions(this->GridSubdivisions);
       gridMapper->SetUpIndex(this->UpIndex);
+      if (this->GridAbsolute)
+        gridMapper->SetOriginOffset(-gridPos[0], -gridPos[1], -gridPos[2]);
 
       this->GridActor->GetProperty()->SetColor(0.0, 0.0, 0.0);
       this->GridActor->ForceTranslucentOn();

--- a/testing/baselines/TestGridAbsolute.png
+++ b/testing/baselines/TestGridAbsolute.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec895bc50caac2deba0af9cc561a0db91d375014fa69b522bef610a3a3fc9ae5
-size 43811
+oid sha256:6b00dd4d9456d232b4b6d7238f4c08bbbe27251a29fb97d979a29f09b89cb653
+size 36347


### PR DESCRIPTION
`absolute-grid` option currently works as intended when models are off-center vertically (in the up direction) but not when they are off-center "sideways" (along the grid plane), see example below:

![absolute-grid-bug](https://github.com/f3d-app/f3d/assets/489715/eb7a46e3-c6f3-4233-b7c8-0910520aadd7)

This PR changes the behavior to the following:

![absolute-grid-fix](https://github.com/f3d-app/f3d/assets/489715/100fc1ed-939c-4eb1-8a7b-4ee79a4e4561)

axes are still in the same position at the origin, but the actor and fading radius of the grid are centered below the model.

There is still room for improvement, for example if the model is very far from the origin the axes may not be visible at all (outside of radius), solving that would require more involved framing/fading patterns of the grid plane.

This fix should at least make the feature not broken anymore.