### PR TITLE
Check and link with libatomic for `armel` architecture

### DIFF
--- a/doc/user/LIMITATIONS_AND_TROUBLESHOOTING.md
+++ b/doc/user/LIMITATIONS_AND_TROUBLESHOOTING.md
@@ -53,6 +53,10 @@ Your data probably contains some translucent data for some reason, turn on trans
 
 With some C++ STD library version, explicit linking to `stdc++fs` is not supported. We provide a CMake option `F3D_LINUX_APPLICATION_LINK_FILESYSTEM` that you can set to `OFF` to workaround this issue.
 
+> I have a link error related to undefined reference to symbol of `libatomic`.
+
+The GCC flag `-latomic` is not being added automatically with specific architectures, like `armel` and `RISCV64`. We provide a CMake option `F3D_LINUX_LIBRARY_LINK_ATOMIC` that you can set to `ON` to workaround this issue.
+
 > Thumbnails are not working in my file manager.
 
  * Check that your file manager supports the thumbnailer mechanism.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -191,6 +191,14 @@ if (APPLE OR UNIX)
   endif ()
 endif ()
 
+if(UNIX AND NOT APPLE)
+  option(F3D_LINUX_LIBRARY_LINK_ATOMIC "Link with libatomic" OFF)
+  mark_as_advanced(F3D_LINUX_LIBRARY_LINK_ATOMIC)
+  if(F3D_LINUX_LIBRARY_LINK_ATOMIC)
+    target_link_libraries(libf3d PRIVATE atomic)
+  endif()
+endif()
+
 # Testing
 if(BUILD_TESTING)
   add_subdirectory(testing)


### PR DESCRIPTION
Debian build of F3D v2.2.1 is failing for `armel` architecture (Buildlog: [f3d_2.2.1+dfsg-1_armel.log](https://github.com/f3d-app/f3d/files/12910154/f3d_2.2.1%2Bdfsg-1_armel.log)). The issue is that gcc does not automatically link with `libatomic` for some architectures  (gcc bug [here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81358)).

The issue have been reported many times to the CMake team ([here](https://gitlab.kitware.com/cmake/cmake/-/issues/23021), [here](https://gitlab.kitware.com/cmake/cmake/-/issues/21174) or [here](https://gitlab.kitware.com/cmake/cmake/-/issues/20895)), and the CMake team just suggests to check it explicitly with the `check_cxx_source_compiles` command. 

So I've pushed this quick patch (heavily inspired by the one from [libtorrent](https://github.com/arvidn/libtorrent/pull/5748/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR632)), which will be suitable for Debian package migration.
However, its uses `link_libraries` CMake command for simplicity and you may want to use `target_link_libraries` command at a better place than the top level CMakeLists.txt.

Feel free to suggest and edit !

Best,
François
