### PR TITLE
Improve F3D logging system and add VTK output to --verbose

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -287,6 +287,7 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
   // Deprecated options that needs further processing
   std::string deprecatedHDRI;
   std::vector<std::string> deprecatedInputs;
+  bool deprecatedQuiet = false;
 #endif
 
   try
@@ -305,14 +306,16 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
     this->DeclareOption(grp0, "readers-list", "", "Print the list of readers");
     this->DeclareOption(grp0, "config", "", "Specify the configuration file to use. absolute/relative path or filename/filestem to search in configuration file locations.", appOptions.UserConfigFile,  LocalHasDefaultNo, MayHaveConfig::NO , "<filePath/filename/fileStem>");
     this->DeclareOption(grp0, "dry-run", "", "Do not read the configuration file", appOptions.DryRun,  HasDefault::YES, MayHaveConfig::NO );
-    this->DeclareOption(grp0, "no-render", "", "Verbose mode without any rendering, only for the first file", appOptions.NoRender,  HasDefault::YES, MayHaveConfig::YES );
+    this->DeclareOption(grp0, "no-render", "", "Do not render anything and quit right after loading the first file, use with --verbose to recover information about a file.", appOptions.NoRender,  HasDefault::YES, MayHaveConfig::YES );
     this->DeclareOption(grp0, "max-size", "", "Maximum size in Mib of a file to load, negative value means unlimited", appOptions.MaxSize,  HasDefault::YES, MayHaveConfig::YES, "<size in Mib>");
     this->DeclareOption(grp0, "load-plugins", "", "List of plugins to load separated with a comma", appOptions.Plugins, LocalHasDefaultNo, MayHaveConfig::YES, "<paths or names>");
     this->DeclareOption(grp0, "scan-plugins", "", "Scan some directories for plugins (result can be incomplete)");
 
     auto grp1 = cxxOptions.add_options("General");
-    this->DeclareOption(grp1, "verbose", "", "Enable verbose mode, providing more information about the loaded data in the console output", appOptions.Verbose,  HasDefault::YES, MayHaveConfig::YES );
-    this->DeclareOption(grp1, "quiet", "", "Enable quiet mode, which supersede any verbose options and prevent any console output to be generated at all", appOptions.Quiet,  HasDefault::YES, MayHaveConfig::YES );
+    this->DeclareOption(grp1, "verbose", "", "Set verbose level, providing more information about the loaded data in the console output", appOptions.VerboseLevel, HasDefault::YES, MayHaveConfig::YES, "{debug, info, warning, error, quiet}", HasImplicitValue::YES, "debug");
+#ifndef F3D_NO_DEPRECATED
+    this->DeclareOption(grp1, "quiet", "", "Enable quiet mode, which supersede any verbose options and prevent any console output to be generated at all (deprecated, using `--verbose=quiet` instead)", deprecatedQuiet,  HasDefault::YES, MayHaveConfig::YES );
+#endif
     this->DeclareOption(grp1, "progress", "", "Show progress bar", options.getAsBoolRef("ui.loader-progress"), HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp1, "geometry-only", "", "Do not read materials, cameras and lights from file", appOptions.GeometryOnly, HasDefault::YES, MayHaveConfig::YES);
     this->DeclareOption(grp1, "group-geometries", "", "When opening multiple files, show them all in the same scene. Force geometry-only. The configuration file for the first file will be loaded.", appOptions.GroupGeometries, HasDefault::YES, MayHaveConfig::NO);
@@ -466,6 +469,11 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
       }
 
 #ifndef F3D_NO_DEPRECATED
+      if (deprecatedQuiet)
+      {
+        appOptions.VerboseLevel = "quiet";
+      }
+
       if (!deprecatedHDRI.empty())
       {
         options.set("render.hdri.file", deprecatedHDRI);

--- a/application/F3DOptionsParser.h
+++ b/application/F3DOptionsParser.h
@@ -34,8 +34,7 @@ struct F3DAppOptions
 
   std::vector<int> Resolution{ 1000, 600 };
   std::vector<int> Position{ 0 };
-  bool Quiet = false;
-  bool Verbose = false;
+  std::string VerboseLevel = "info";
   double CameraAzimuthAngle = 0.0;
   double CameraElevationAngle = 0.0;
   std::vector<double> CameraFocalPoint = { 0 };

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -101,6 +101,36 @@ public:
     return false;
   }
 
+  static void SetVerboseLevel(const std::string& level)
+  {
+    // A switch/case over verbose level
+    if (level == "quiet")
+    {
+      f3d::log::setVerboseLevel(f3d::log::VerboseLevel::QUIET);
+    }
+    else if (level == "error")
+    {
+      f3d::log::setVerboseLevel(f3d::log::VerboseLevel::ERROR);
+    }
+    else if (level == "warning")
+    {
+      f3d::log::setVerboseLevel(f3d::log::VerboseLevel::WARN);
+    }
+    else if (level == "info")
+    {
+      f3d::log::setVerboseLevel(f3d::log::VerboseLevel::INFO);
+    }
+    else if (level == "debug")
+    {
+      f3d::log::setVerboseLevel(f3d::log::VerboseLevel::DEBUG);
+    }
+    else
+    {
+      f3d::log::warn("Unrecognized verbose level: ", level,
+        ", Ignoring. Possible values are quiet, error, warning, info, debug");
+    }
+  }
+
   F3DOptionsParser Parser;
   F3DAppOptions AppOptions;
   f3d::options DynamicOptions;
@@ -134,14 +164,7 @@ int F3DStarter::Start(int argc, char** argv)
     this->Internals->AppOptions, this->Internals->DynamicOptions, files);
 
   // Set verbosity level early from command line
-  if (this->Internals->AppOptions.Quiet)
-  {
-    f3d::log::setVerboseLevel(f3d::log::VerboseLevel::QUIET);
-  }
-  else if (this->Internals->AppOptions.Verbose || this->Internals->AppOptions.NoRender)
-  {
-    f3d::log::setVerboseLevel(f3d::log::VerboseLevel::DEBUG);
-  }
+  F3DInternals::SetVerboseLevel(this->Internals->AppOptions.VerboseLevel);
 
   // Load plugins from the app options
   this->Internals->Parser.LoadPlugins(this->Internals->AppOptions);
@@ -158,14 +181,7 @@ int F3DStarter::Start(int argc, char** argv)
       this->Internals->AppOptions, this->Internals->DynamicOptions, files);
 
     // Set verbosity level again if it was defined in the configuration file global block
-    if (this->Internals->AppOptions.Quiet)
-    {
-      f3d::log::setVerboseLevel(f3d::log::VerboseLevel::QUIET);
-    }
-    else if (this->Internals->AppOptions.Verbose || this->Internals->AppOptions.NoRender)
-    {
-      f3d::log::setVerboseLevel(f3d::log::VerboseLevel::DEBUG);
-    }
+    F3DInternals::SetVerboseLevel(this->Internals->AppOptions.VerboseLevel);
   }
 
 #if __APPLE__

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -28,7 +28,7 @@ function(f3d_test)
   endif()
 
   if(F3D_TEST_NO_RENDER)
-    list(APPEND F3D_TEST_ARGS "--no-render")
+    list(APPEND F3D_TEST_ARGS "--no-render" "--verbose=debug")
   else()
     if(F3D_TEST_RESOLUTION)
       list(APPEND F3D_TEST_ARGS "--resolution=${F3D_TEST_RESOLUTION}")
@@ -657,7 +657,19 @@ f3d_test(NAME TestInteractionPlay DATA cow.vtp ARGS --interaction-test-play=${CM
 f3d_test(NAME TestPosition DATA dragon.vtu ARGS --position=100,100 NO_BASELINE)
 
 # Simple verbosity test
-f3d_test(NAME TestVerbose DATA dragon.vtu ARGS --verbose REGEXP "Number of points: 13268\nNumber of cells: 26532" NO_RENDER)
+f3d_test(NAME TestVerbose DATA dragon.vtu ARGS --verbose REGEXP "Number of points: 13268\nNumber of cells: 26532" NO_BASELINE)
+
+# Test verbose quiet
+f3d_test(NAME TestVerboseQuiet DATA mb.vtm ARGS --verbose=quiet REGEXP_FAIL "A non data set block was ignored while reading a multiblock." NO_BASELINE)
+
+# Test verbose error
+f3d_test(NAME TestVerboseError DATA mb.vtm ARGS --verbose=error REGEXP_FAIL "A non data set block was ignored while reading a multiblock." NO_BASELINE)
+
+# Test verbose warning, rely on the log::info about image comparison
+f3d_test(NAME TestVerboseWarning DATA cow.vtp ARGS --verbose=warning REGEXP_FAIL "Image comparison success with an error difference of" DEFAULT_LIGHTS)
+
+# Test verbose debug
+f3d_test(NAME TestVerboseDebug DATA dragon.vtu ARGS --verbose REGEXP "Number of points: 13268\nNumber of cells: 26532" NO_BASELINE)
 
 # Test verbose invalid verbose value
 f3d_test(NAME TestVerboseInvalid DATA dragon.vtu ARGS --verbose=invalid REGEXP "Unrecognized verbose level" NO_BASELINE)
@@ -703,13 +715,13 @@ f3d_test(NAME TestVerboseVolumeNoArray DATA cow.vtp ARGS -v REGEXP "Cannot use v
 f3d_test(NAME TestVerboseNoArray DATA cow.vtp ARGS -s REGEXP "No array to color with" NO_BASELINE)
 
 # Test non existent file, do not create nonExistentFile.vtp
-f3d_test(NAME TestVerboseNonExistentFile DATA nonExistentFile.vtp ARGS --filename --verbose REGEXP "File \".*nonExistentFile.vtp\" does not exist" NO_RENDER)
+f3d_test(NAME TestVerboseNonExistentFile DATA nonExistentFile.vtp REGEXP "File \".*nonExistentFile.vtp\" does not exist" NO_RENDER)
 
 # Test non existent font file, do not create nonExistentFile.ttf
 f3d_test(NAME TestVerboseNonExistentFont DATA suzanne.ply ARGS -n --font-file=${F3D_SOURCE_DIR}/testing/data/nonExistentFile.ttf REGEXP "Cannot find \".*nonExistentFile.ttf\" font file" NO_BASELINE)
 
-# Test non existent file, do not create nonExistentFile.vtp
-f3d_test(NAME TestQuietNonExistentFile DATA nonExistentFile.vtp ARGS --filename --verbose --quiet REGEXP_FAIL "File \".*nonExistentFile.vtp\" does not exist" NO_RENDER)
+# Test quiet with a non existent file
+f3d_test(NAME TestQuietNonExistentFile DATA nonExistentFile.vtp ARGS --verbose=quiet --no-render REGEXP_FAIL "File \".*nonExistentFile.vtp\" does not exist")
 
 # Test non supported file, do not add support for .dummy file.
 f3d_test(NAME TestUnsupportedFileText DATA unsupportedFile.dummy ARGS --filename REGEXP ".*unsupportedFile.dummy\" is not a file of a supported file format" NO_RENDER)
@@ -745,7 +757,7 @@ f3d_test(NAME TestNonExistentConfigFileStem DATA cow.vtp CONFIG "dummy" REGEXP "
 f3d_test(NAME TestInvalidConfigFile DATA cow.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/invalid.json REGEXP "Unable to parse the configuration file" NO_BASELINE)
 
 # Test quiet in config file
-f3d_test(NAME TestConfigFileQuiet DATA nonExistentFile.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/quiet.json REGEXP_FAIL "File .*/testing/data/nonExistentFile.vtp does not exist" NO_RENDER)
+f3d_test(NAME TestConfigFileQuiet DATA nonExistentFile.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/quiet.json REGEXP_FAIL "File .*/testing/data/nonExistentFile.vtp does not exist" NO_BASELINE)
 
 # Test no file with config file
 f3d_test(NAME TestNoFileConfigFile CONFIG ${F3D_SOURCE_DIR}/testing/configs/verbose.json ARGS --verbose REGEXP "No file to load provided." NO_BASELINE)
@@ -754,8 +766,9 @@ f3d_test(NAME TestNoFileConfigFile CONFIG ${F3D_SOURCE_DIR}/testing/configs/verb
 f3d_test(NAME TestHelp ARGS --help REGEXP "Usage:")
 f3d_test(NAME TestHelpPositional ARGS --help REGEXP "file1 file2 \.\.\.")
 if (NOT F3D_EXCLUDE_DEPRECATED)
-  f3d_test(NAME TestHelpInput ARGS --help REGEXP "--input")
+  f3d_test(NAME TestDeprecatedHelpInput ARGS --help REGEXP "--input")
   f3d_test(NAME TestDeprecatedInput ARGS --input a.b REGEXP "--input option is deprecated")
+  f3d_test(NAME TestDeprecatedQuietNonExistentFile DATA nonExistentFile.vtp ARGS --filename --verbose --quiet --no-render REGEXP_FAIL "File \".*nonExistentFile.vtp\" does not exist" NO_BASELINE)
 endif()
 
 # Test version display

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -659,6 +659,9 @@ f3d_test(NAME TestPosition DATA dragon.vtu ARGS --position=100,100 NO_BASELINE)
 # Simple verbosity test
 f3d_test(NAME TestVerbose DATA dragon.vtu ARGS --verbose REGEXP "Number of points: 13268\nNumber of cells: 26532" NO_RENDER)
 
+# Test verbose invalid verbose value
+f3d_test(NAME TestVerboseInvalid DATA dragon.vtu ARGS --verbose=invalid REGEXP "Unrecognized verbose level" NO_BASELINE)
+
 # Unknown scalar array verbosity test
 f3d_test(NAME TestVerboseWrongArray DATA dragon.vtu ARGS --scalars=dummy --verbose REGEXP "Unknown scalar array: dummy" NO_BASELINE)
 

--- a/cmake/plugin.thumbnailer.in
+++ b/cmake/plugin.thumbnailer.in
@@ -2,5 +2,5 @@
 Type=X-Thumbnailer
 Name=f3d Thumbnailer (${F3D_PLUGIN_NAME} plugin)
 TryExec=f3d
-Exec=f3d --config=thumbnail --load-plugins=${F3D_PLUGIN_NAME} --quiet --output=%o --resolution=%s,%s %i
+Exec=f3d --config=thumbnail --load-plugins=${F3D_PLUGIN_NAME} --verbose=quiet --output=%o --resolution=%s,%s %i
 MimeType=${F3D_PLUGIN_MIMETYPES_THUMB}

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Ongoing development
 For F3D users:
  - Added `--animation-autoplay` option (libf3d: `scene.animation.autoplay`) to automatically start animation on file load.
+ - Changed `--verbose` into a string based option, eg: `--verbose=quiet` or `--verbose=debug`. `--verbose` is still supported.
+ - Changed `--no-render` behavior so that it doesn't impact verbosity anymore
+ - Deprecated `--quiet`, use `--verbose=quiet` instead.
 
 For libf3d users:
  - Added `scene.animation.autoplay` option.

--- a/doc/user/CONFIGURATION_FILE.md
+++ b/doc/user/CONFIGURATION_FILE.md
@@ -60,7 +60,7 @@ The following command-line options <b> cannot </b> be set via config file:
 `help`, `version`, `readers-list`, `config`, `dry-run`.
 
 The following command-line options <b>can only</b> be set in the global block of the config file:
-`no-render`, `inputs`, `output`, `quiet`, `verbose`, `resolution`, `position` and all testing options.
+`no-render`, `inputs`, `output`, `verbose`, `resolution`, `position` and all testing options.
 
 Boolean options that have been turned on in the configuration file can be turned
 off on the command line if needed, eg: `--point-sprites=false`.

--- a/doc/user/OPTIONS.md
+++ b/doc/user/OPTIONS.md
@@ -6,7 +6,6 @@ F3D behavior can be fully controlled from the command line using the following o
 
 Options|Default|Description
 ------|------|------
-\-\-input=\<file\>||The *input* file or files to read, can also be provided as a positional argument.
 \-\-output=\<png file\>||Instead of showing a render view and render into it, *render directly into a png file*. When used with \-\-ref option, only outputs on failure.
 \-\-no-background||Use with \-\-output to output a png file with a transparent background.
 -h, \-\-help||Print *help* and exit. Ignore `--verbose`.
@@ -23,7 +22,6 @@ Options|Default|Description
 Options|Default|Description
 ------|------|------
 \-\-verbose=\<[debug\|info\|warning\|error\|quiet]\>|info| Set *verbose* level, in order to provide more information about the loaded data in the console output. If no level is providen, assume `debug`.
-\-\-quiet||Enable quiet mode, which supersede any verbose options. No console output will be generated at all.
 \-\-progress||Show a *progress bar* when loading the file.
 \-\-geometry-only||For certain **full scene** file formats (gltf/glb and obj),<br>reads *only the geometry* from the file and use default scene construction instead.
 \-\-group-geometries||When opening multiple files, show them all in the same scene.<br>Force geometry-only. The configuration file for the first file will be loaded.

--- a/doc/user/OPTIONS.md
+++ b/doc/user/OPTIONS.md
@@ -9,12 +9,12 @@ Options|Default|Description
 \-\-input=\<file\>||The *input* file or files to read, can also be provided as a positional argument.
 \-\-output=\<png file\>||Instead of showing a render view and render into it, *render directly into a png file*. When used with \-\-ref option, only outputs on failure.
 \-\-no-background||Use with \-\-output to output a png file with a transparent background.
--h, \-\-help||Print *help* and exit.
-\-\-version||Show *version* information and exit.
-\-\-readers-list||List available *readers* and exit.
+-h, \-\-help||Print *help* and exit. Ignore `--verbose`.
+\-\-version||Show *version* information and exit. Ignore `--verbose`.
+\-\-readers-list||List available *readers* and exit. Ignore `--verbose`.
 \-\-config=\<config file path/name/stem\>|config|Specify the [configuration file](CONFIGURATION_FILE.md) to use. Supports absolute/relative path but also filename/filestem to search for in standard configuration file locations.
 \-\-dry-run||Do not read any configuration file and consider only the command line options.
-\-\-no-render||Print information about the first provided file (as with \-\-verbose) and exit, without rendering anything, useful to recover information about a file.
+\-\-no-render||Do not render anything and quit just after loading the first file, use with \-\-verbose to recover information about a file.
 \-\-max-size=\<size in MiB\>|-1|Prevent F3D to load a file bigger than the provided size in Mib, negative value means unlimited, useful for thumbnails.
 \-\-load-plugins=\<paths or names\>||List of plugins to load separated with a comma. Official plugins are `alembic`, `assimp`, `draco`, `exodus`, `occt`, `usd`. See [usage](USAGE.md) for more info.
 
@@ -22,7 +22,7 @@ Options|Default|Description
 
 Options|Default|Description
 ------|------|------
-\-\-verbose||Enable *verbose* mode, providing more information about the loaded data in the console output.
+\-\-verbose=\<[debug\|info\|warning\|error\|quiet]\>|info| Set *verbose* level, in order to provide more information about the loaded data in the console output. If no level is providen, assume `debug`.
 \-\-quiet||Enable quiet mode, which supersede any verbose options. No console output will be generated at all.
 \-\-progress||Show a *progress bar* when loading the file.
 \-\-geometry-only||For certain **full scene** file formats (gltf/glb and obj),<br>reads *only the geometry* from the file and use default scene construction instead.

--- a/examples/plugins/example-plugin/CMakeLists.txt
+++ b/examples/plugins/example-plugin/CMakeLists.txt
@@ -31,6 +31,7 @@ if(BUILD_TESTING)
           COMMAND "$<TARGET_FILE:f3d::f3d>"
                   "--dry-run"
                   "--no-render"
+                  "--verbose"
                   "--load-plugins=$<TARGET_FILE:f3d-plugin-example>"
                   "${CMAKE_CURRENT_SOURCE_DIR}/data.expl"
   )

--- a/library/public/log.h
+++ b/library/public/log.h
@@ -24,7 +24,7 @@ public:
   /**
    * Enumeration of verbose levels
    * =============================
-   * DEBUG: All logs are displayed.
+   * DEBUG: All logs are displayed, including from third parties.
    * INFO: Standard logging level, the default.
    * WARN: Only warnings and errors are displayed.
    * ERROR: Only errors are displayed.

--- a/library/src/init.cxx
+++ b/library/src/init.cxx
@@ -32,9 +32,8 @@ void init::initialize()
 //----------------------------------------------------------------------------
 init::init()
 {
-#if NDEBUG
+  // Can be overridden by calling log::setVerboseLevel
   vtkObject::GlobalWarningDisplayOff();
-#endif
 
   // Disable vtkLogger in case VTK was built with log support
   vtkLogger::SetStderrVerbosity(vtkLogger::VERBOSITY_OFF);

--- a/library/src/log.cxx
+++ b/library/src/log.cxx
@@ -4,9 +4,10 @@
 
 #include "F3DLog.h"
 
+#include <vtkObject.h>
+
 namespace f3d
 {
-
 //----------------------------------------------------------------------------
 void log::printInternal(log::VerboseLevel level, const std::string& str)
 {
@@ -90,6 +91,9 @@ void log::setVerboseLevel(log::VerboseLevel level)
     default:
       break;
   }
+
+  // Display third parties log on Debug level
+  vtkObject::SetGlobalWarningDisplay(level == log::VerboseLevel::DEBUG);
 }
 
 //----------------------------------------------------------------------------

--- a/testing/baselines/TestVerboseWarning.png
+++ b/testing/baselines/TestVerboseWarning.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eb525fd45911d5d4f1919a6e50a6133a61c4362e23378fca6b8735fa511cbfa
+size 18653

--- a/testing/configs/quiet.json
+++ b/testing/configs/quiet.json
@@ -1,6 +1,7 @@
 {
   "global":
   {
-    "quiet": true
+    "verbose": "quiet",
+    "no-render": true
   }
 }

--- a/winshellext/F3DThumbnailProvider.cxx
+++ b/winshellext/F3DThumbnailProvider.cxx
@@ -165,7 +165,7 @@ IFACEMETHODIMP F3DThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
   // Create command to run
   wchar_t command[MAX_PATH * 3 + 20];
   swprintf_s(command, MAX_PATH * 3 + 20,
-    L"\"%s\" --input \"%s\" --output \"%s\" --config=thumbnail --quiet --resolution "
+    L"\"%s\" --input \"%s\" --output \"%s\" --config=thumbnail --verbose=quiet --resolution "
     L"%d,%d\"",
     m_f3dPath, m_filePath, image_filename, cx, cx);
 


### PR DESCRIPTION
fix https://github.com/f3d-app/f3d/issues/966

 - Transform --verbose into a string based option to select different level of verbosity
 - Deprecate --quiet
 - Change --no-render behavior by stopping having an effect on verbosity effect
 - Show VTK log when using debug verbosity