### PR TITLE
Put F3D window on top of output window

### DIFF
--- a/library/VTKExtensions/Core/vtkF3DWin32OutputWindow.cxx
+++ b/library/VTKExtensions/Core/vtkF3DWin32OutputWindow.cxx
@@ -29,7 +29,7 @@ int vtkF3DWin32OutputWindow::Initialize()
 {
   int rc = this->Superclass::Initialize();
 
-  // retrieve window handle
+  // retrieve output window handle
   HWND hCurWnd = nullptr;
   do
   {
@@ -51,6 +51,25 @@ int vtkF3DWin32OutputWindow::Initialize()
 
   // find Edit control
   this->EditControlHandle = FindWindowExA(hCurWnd, nullptr, "Edit", nullptr);
+
+  // retrieve f3d window handle
+  HWND f3dCurWnd = nullptr;
+  do
+  {
+    f3dCurWnd = FindWindowExA(nullptr, f3dCurWnd, "vtkOpenGL", nullptr);
+    DWORD processID = 0;
+    GetWindowThreadProcessId(f3dCurWnd, &processID);
+    if (processID == GetCurrentProcessId())
+    {
+      break;
+    }
+  } while (f3dCurWnd != nullptr);
+
+  // Put f3d window on top of output window
+  if (f3dCurWnd)
+  {
+    BringWindowToTop(f3dCurWnd);
+  }
 
   return rc;
 }


### PR DESCRIPTION
Fix: https://github.com/f3d-app/f3d/issues/350

When initializing the output window (on the first show only), put the F3D window on top of the output window so it is less disruptive.