### PR TITLE
Fix inexistent warning in GCC < 9

### DIFF
--- a/plugins/usd/module/vtkF3DUSDImporter.cxx
+++ b/plugins/usd/module/vtkF3DUSDImporter.cxx
@@ -37,8 +37,10 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
+#if __GNUC__ >= 9
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif
 #elif defined(_MSC_VER)
 #pragma warning(push, 0)
 #endif


### PR DESCRIPTION
`-Wdeprecated-copy` has been introduced in GCC 9