### PR TITLE
Enable depth peeling in default config

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -224,6 +224,7 @@ if(NOT F3D_MACOS_BUNDLE)
   f3d_test(NAME TestDefaultConfigFileTIFF DATA logo.tif CONFIG config_build LONG_TIMEOUT DEFAULT_LIGHTS)
   f3d_test(NAME TestDefaultConfigFilePLY DATA suzanneRGBA.ply CONFIG config_build LONG_TIMEOUT DEFAULT_LIGHTS THRESHOLD 100)
   f3d_test(NAME TestDefaultConfigFileAndCommand DATA suzanne.stl ARGS --up=-Y --camera-direction=-1,0.5,-1 CONFIG config_build LONG_TIMEOUT DEFAULT_LIGHTS)
+  f3d_test(NAME TestDefaultConfigTranslucent DATA red_translucent_monkey.gltf CONFIG config_build LONG_TIMEOUT DEFAULT_LIGHTS)
 
   # no-background test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8501
   if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,8 @@ For F3D users:
  - Changed `--no-render` behavior so that it doesn't impact verbosity anymore
  - Deprecated `--quiet`, use `--verbose=quiet` instead.
  - Reading EXR files is now multi-threaded and much faster.
+ - Translucency support is now enabled by default.
+ - A small margin is added between the model and the grid to avoid potential z-fighting.
 
 For libf3d users:
  - Added `scene.animation.autoplay` option.

--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -498,7 +498,10 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
       {
         for (int i = 0; i < 3; i++)
         {
-          double size = bounds[2 * i + 1] - bounds[2 * i];
+          // a small margin is added to the size to avoid z-fighting if large translucent
+          // triangles are exactly aligned with the grid bounds
+          constexpr double margin = 1.0001;
+          double size = margin * (bounds[2 * i + 1] - bounds[2 * i]);
           gridPos[i] = 0.5 * (bounds[2 * i] + bounds[2 * i + 1] - this->UpVector[i] * size);
         }
       }

--- a/resources/configs/config.d/10_global.json
+++ b/resources/configs/config.d/10_global.json
@@ -9,6 +9,7 @@
     "filename": true,
     "scalars": "",
     "camera-direction": "-1,-0.5,-1",
-    "hdri-ambient": true
+    "hdri-ambient": true,
+    "translucency-support": true
   }
 }

--- a/resources/configs/thumbnail.d/10_global.json
+++ b/resources/configs/thumbnail.d/10_global.json
@@ -8,6 +8,7 @@
     "no-background": true,
     "quiet": true,
     "scalars": "",
-    "tone-mapping": true
+    "tone-mapping": true,
+    "translucency-support": true
   }
 }

--- a/testing/baselines/TestDefaultConfigFileAssimpFBX.png
+++ b/testing/baselines/TestDefaultConfigFileAssimpFBX.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e14d6cb31b7d120405621c3d0ff46bbd2e90a29227b85a131367400e50ef80dd
-size 41754
+oid sha256:48569f03d182bcee3d4346db2a0bef5bddcefe548c37069bdf7e6648dcaeda42
+size 42857

--- a/testing/baselines/TestDefaultConfigTranslucent.png
+++ b/testing/baselines/TestDefaultConfigTranslucent.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81ecdd10b12d826c7cec3799827944f33bc23cb986f8cba1e92fefa363f3903e
+size 40125

--- a/testing/baselines/TestThumbnailConfigFileAssimpFBX.png
+++ b/testing/baselines/TestThumbnailConfigFileAssimpFBX.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c8e4bb5589999e087e424df8f72f0149a85f5bdbf31aa549b8c3eea100d4c9a
-size 2488
+oid sha256:eb54cd5d9d874380feabf7f704869aacb2239621a31db0ece74a3543f78d710b
+size 2520

--- a/testing/data/red_translucent_monkey.bin
+++ b/testing/data/red_translucent_monkey.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fcaf25b1759576258bafee8765fa290e6451c95a2d5c12874ee38d2bc92e896
+size 68720

--- a/testing/data/red_translucent_monkey.gltf
+++ b/testing/data/red_translucent_monkey.gltf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f00fbdebd0f71e08983114318866c15b167a9d0c72bf8903d5a9644ec0102f6
+size 1651


### PR DESCRIPTION
Fix https://github.com/f3d-app/f3d/issues/1046

Additionally, a small margin is added to the size to avoid z-fighting if large translucent triangles are exactly aligned with the grid bounds