### PR TITLE
Enable multi-threading when reading EXR files

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@ For F3D users:
  - Changed `--verbose` into a string based option, eg: `--verbose=quiet` or `--verbose=debug`. `--verbose` is still supported.
  - Changed `--no-render` behavior so that it doesn't impact verbosity anymore
  - Deprecated `--quiet`, use `--verbose=quiet` instead.
+ - Reading EXR files is now multi-threaded and much faster.
 
 For libf3d users:
  - Added `scene.animation.autoplay` option.

--- a/library/VTKExtensions/Readers/vtkF3DEXRReader.cxx
+++ b/library/VTKExtensions/Readers/vtkF3DEXRReader.cxx
@@ -11,6 +11,7 @@
 #include <ImfRgbaFile.h>
 
 #include <sstream>
+#include <thread>
 
 vtkStandardNewMacro(vtkF3DEXRReader);
 
@@ -114,6 +115,7 @@ void vtkF3DEXRReader::ExecuteDataWithInformation(vtkDataObject* output, vtkInfor
   try
   {
     assert(this->InternalFileName);
+    Imf::setGlobalThreadCount(std::thread::hardware_concurrency());
     Imf::RgbaInputFile file(this->InternalFileName);
 
     Imf::Array2D<Imf::Rgba> pixels(this->GetHeight(), this->GetWidth());


### PR DESCRIPTION
Down from 12.3s to 3.4 seconds on my computer (24 threads)

Fix https://github.com/f3d-app/f3d/issues/887