### PR TITLE
Fix USD up axis

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -558,7 +558,7 @@ if(F3D_PLUGIN_BUILD_OCCT)
 endif()
 
 if(F3D_PLUGIN_BUILD_USD)
-  f3d_test(NAME TestUSD DATA suzanne.usd ARGS --load-plugins=usd --up=+Z DEFAULT_LIGHTS)
+  f3d_test(NAME TestUSD DATA suzanne.usd ARGS --load-plugins=usd DEFAULT_LIGHTS)
   f3d_test(NAME TestUSDAPrimitives DATA primitives.usda ARGS --load-plugins=usd DEFAULT_LIGHTS)
   f3d_test(NAME TestUSDAPrimitivesZAxis DATA primitivesZ.usda ARGS --load-plugins=usd DEFAULT_LIGHTS)
   f3d_test(NAME TestUSDAInstancing DATA instancing.usda ARGS --load-plugins=usd DEFAULT_LIGHTS)

--- a/testing/baselines/TestDefaultConfigFileUSD.png
+++ b/testing/baselines/TestDefaultConfigFileUSD.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b51d45b08b8df3b33d2c103f5d8ea190e1e76ca42d9d41dac259cab4d9ff070
-size 37698
+oid sha256:e2bd72e8a3b8c705c03ccbaedb3d540186013f4b7eb04d8cb2682ef976acc41d
+size 44054

--- a/testing/baselines/TestThumbnailConfigFileUSD.png
+++ b/testing/baselines/TestThumbnailConfigFileUSD.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ab41687a07f115ed652677b3144e3ee0702d6e13fb8e7e15e377d4c2b09c81bc
-size 10142
+oid sha256:f786ad1235197d91a99e54e92d95b7d59a4661931be0efc5aede04459d9ead50
+size 15325


### PR DESCRIPTION
Make all USD files +Y up by applying a rotation to the root.  
`suzanne.usd` is defined as +Z so this dataset is used to test the fix instead of specifying +Z explicitly in f3d.