### PR TITLE
Improve logging

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -166,6 +166,8 @@ int F3DStarter::Start(int argc, char** argv)
   // Set verbosity level early from command line
   F3DInternals::SetVerboseLevel(this->Internals->AppOptions.VerboseLevel);
 
+  f3d::log::debug("========== Initializing ==========");
+
   // Load plugins from the app options
   this->Internals->Parser.LoadPlugins(this->Internals->AppOptions);
 
@@ -189,6 +191,8 @@ int F3DStarter::Start(int argc, char** argv)
   F3DNSDelegate::InitializeDelegate(this);
 #endif
 
+  f3d::log::debug("========== Configuring engine ==========");
+
   if (this->Internals->AppOptions.NoRender)
   {
     this->Internals->Engine = std::make_unique<f3d::engine>(f3d::window::Type::NONE);
@@ -209,6 +213,8 @@ int F3DStarter::Start(int argc, char** argv)
         {
           this->Internals->Engine->getInteractor().stopAnimation();
 
+          f3d::log::debug("========== Loading 3D file ==========");
+
           if (restoreCamera)
           {
             f3d::camera& cam = this->Internals->Engine->getWindow().getCamera();
@@ -220,6 +226,8 @@ int F3DStarter::Start(int argc, char** argv)
           {
             this->LoadFile(index, true);
           }
+
+          f3d::log::debug("========== Rendering ==========");
 
           this->Render();
           return true;
@@ -304,6 +312,9 @@ int F3DStarter::Start(int argc, char** argv)
     }
 #endif
   }
+  f3d::log::debug("Engine configured");
+
+  f3d::log::debug("========== Loading 3D file ==========");
 
   // Add all files
   for (auto& file : files)
@@ -313,6 +324,8 @@ int F3DStarter::Start(int argc, char** argv)
 
   // Load a file
   this->LoadFile();
+
+  f3d::log::debug("========== Rendering ==========");
 
   if (!this->Internals->AppOptions.NoRender)
   {
@@ -396,6 +409,12 @@ int F3DStarter::Start(int argc, char** argv)
       {
         f3d::log::info("Image comparison success with an error difference of: ", error);
       }
+
+      if (this->Internals->FilesList.size() > 1)
+      {
+        f3d::log::warn("Image comparison was performed using a single 3D file, other provided "
+                       "3D files were ignored.");
+      }
     }
     // Render to file if needed
     else if (!this->Internals->AppOptions.Output.empty())
@@ -408,14 +427,22 @@ int F3DStarter::Start(int argc, char** argv)
 
       f3d::image img = window.renderToImage(this->Internals->AppOptions.NoBackground);
       img.save(this->Internals->AppOptions.Output);
+      f3d::log::debug("Output image saved to ", this->Internals->AppOptions.Output);
+
+      if (this->Internals->FilesList.size() > 1)
+      {
+        f3d::log::warn("An output image was saved using a single 3D file, other provided 3D "
+                       "files were ignored.");
+      }
     }
     // Start interaction
     else
     {
 #ifdef F3D_HEADLESS_BUILD
       f3d::log::error("This is a headless build of F3D, interactive rendering is not supported");
+      return EXIT_FAILURE;
 #else
-      window.render();
+      this->Render();
       interactor.start();
 #endif
     }
@@ -590,6 +617,7 @@ void F3DStarter::LoadFile(int index, bool relativeIndex)
 void F3DStarter::Render()
 {
   this->Internals->Engine->getWindow().render();
+  f3d::log::debug("Render done");
 }
 
 //----------------------------------------------------------------------------

--- a/application/F3DStarter.h
+++ b/application/F3DStarter.h
@@ -22,6 +22,7 @@ public:
 
   /**
    * Add a file or directory to the list of paths
+   * Returns the index of the added file
    */
   int AddFile(const std::filesystem::path& path, bool quiet = false);
 

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -700,6 +700,12 @@ f3d_test(NAME TestIncorrectColormap DATA IM-0001-1983.dcm ARGS --scalars --rough
 # Test opening a directory
 f3d_test(NAME TestVerboseDirectory DATA mb REGEXP "Loading 3D geometry: .*mb_._0.vt." NO_RENDER)
 
+# Test opening multiple file and rendering only one
+f3d_test(NAME TestVerboseMultiFileRender DATA mb REGEXP "An output image was saved using a single 3D file, other provided 3D files were ignored." NO_BASELINE)
+if (NOT F3D_TESTING_DISABLE_DEFAULT_LIGHTS_TESTS_COMPARISON) # DEFAULT_LIGHTS cannot be used here because the regexp text would not be reached
+  f3d_test(NAME TestVerboseMultiFileCompare DATA mb REGEXP "Image comparison was performed using a single 3D file, other provided 3D files were ignored.")
+endif ()
+
 # Test Animation invalid code paths
 f3d_test(NAME TestVerboseAnimationIndexError2 DATA cow.vtp ARGS --animation-index=1 --verbose REGEXP "An animation index has been specified but there are no animation available." NO_BASELINE)
 f3d_test(NAME TestVerboseAnimationNoAnimationTime DATA cow.vtp ARGS --animation-time=2 --verbose REGEXP "No animation available, cannot load a specific animation time" NO_BASELINE)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -698,7 +698,7 @@ f3d_test(NAME TestIncorrectComponent DATA dragon.vtu ARGS -s --comp=4 REGEXP "In
 f3d_test(NAME TestIncorrectColormap DATA IM-0001-1983.dcm ARGS --scalars --roughness=1 --colormap=0,1,0,0,1,0,1 REGEXP "Specified color map list count is not a multiple of 4, ignoring it." NO_BASELINE)
 
 # Test opening a directory
-f3d_test(NAME TestVerboseDirectory DATA mb REGEXP "Loading: .*mb_._0.vt." NO_RENDER)
+f3d_test(NAME TestVerboseDirectory DATA mb REGEXP "Loading 3D geometry: .*mb_._0.vt." NO_RENDER)
 
 # Test Animation invalid code paths
 f3d_test(NAME TestVerboseAnimationIndexError2 DATA cow.vtp ARGS --animation-index=1 --verbose REGEXP "An animation index has been specified but there are no animation available." NO_BASELINE)
@@ -744,7 +744,7 @@ f3d_test(NAME TestNonExistentTexture DATA cow.vtp ARGS --texture-material=${F3D_
 f3d_test(NAME TestInvalidGeometry DATA invalid.vtp REGEXP "A reader did not produce any output" NO_BASELINE)
 
 # Test invalid full scene file XXX should be improved
-f3d_test(NAME TestInvalidFullScene DATA invalid.gltf ARGS --verbose REGEXP "Loading full scene" NO_BASELINE)
+f3d_test(NAME TestInvalidFullScene DATA invalid.gltf ARGS --verbose REGEXP "Loading 3D scene" NO_BASELINE)
 
 # Test invalid texture
 f3d_test(NAME TestInvalidTexture DATA cow.vtp ARGS --texture-material=${F3D_SOURCE_DIR}/testing/data/invalid.png REGEXP "Cannot open texture file" NO_BASELINE)

--- a/library/src/loader_impl.cxx
+++ b/library/src/loader_impl.cxx
@@ -218,17 +218,18 @@ loader& loader_impl::loadGeometry(const std::string& filePath, bool reset)
   f3d::reader* reader = f3d::factory::instance()->getReader(filePath);
   if (!reader)
   {
-    throw loader::load_failure_exception(filePath + " is not a file of a supported file format");
+    throw loader::load_failure_exception(
+      filePath + " is not a file of a supported 3D geometry file format");
   }
   auto vtkReader = reader->createGeometryReader(filePath);
   if (!vtkReader)
   {
     throw loader::load_failure_exception(
-      filePath + " is not a file of a supported file format for default scene");
+      filePath + " is not a file of a supported 3D geometry file format for default scene");
   }
 
   // Read the file
-  log::debug("Loading: ", filePath, "\n");
+  log::debug("Loading 3D geometry: ", filePath, "\n");
 
   this->Internals->LoadGeometry(vtksys::SystemTools::GetFilenameName(filePath), vtkReader, reset);
 
@@ -253,13 +254,14 @@ loader& loader_impl::loadScene(const std::string& filePath)
   f3d::reader* reader = f3d::factory::instance()->getReader(filePath);
   if (!reader)
   {
-    throw loader::load_failure_exception(filePath + " is not a file of a supported file format");
+    throw loader::load_failure_exception(
+      filePath + " is not a file of a supported 3D scene file format");
   }
   this->Internals->CurrentFullSceneImporter = reader->createSceneReader(filePath);
   if (!this->Internals->CurrentFullSceneImporter)
   {
     throw loader::load_failure_exception(
-      filePath + " is not a file of a supported file format for full scene");
+      filePath + " is not a file of a supported 3D scene file format for full scene");
   }
 
   this->Internals->Window.Initialize(false);
@@ -281,7 +283,7 @@ loader& loader_impl::loadScene(const std::string& filePath)
   }
 #endif
 
-  log::debug("Loading full scene: ", filePath, "\n");
+  log::debug("Loading 3D scene: ", filePath, "\n");
 
   // Manage progress bar
   vtkNew<vtkProgressBarWidget> progressWidget;

--- a/testing/baselines/TestVerboseMultiFileCompare.png
+++ b/testing/baselines/TestVerboseMultiFileCompare.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1047c674b65aeeb536680937ccacf08c2bc592644212fe350e933a850c455c51
+size 14018


### PR DESCRIPTION
 - Fix https://github.com/f3d-app/f3d/issues/1103
 - Improve logging in libf3d::loader
 - Improve exit logic in F3DStarter with headless
 - Improve logging F3DStarter::Start
 - Add tests

Example output:

```
[glow@frollo ~/dev/f3d/f3d/build]$ ./bin/f3d ../src/testing/data/cow.vtp  --verbose 
========== Initializing ==========
Loading plugin "exodus"
  Version: 1.0
  Description: VTK Exodus support
  Readers:
    Exodus II
Loading plugin "native"
  Version: 1.0
  Description: Native VTK I/O support
  Readers:
    Autodesk 3D Studio
    CityGML
    DICOM
    GL Transmission Format
    MetaImage
    Nearly Raw Raster Data
    Wavefront OBJ
    Polygon
    Point Cloud
    Standard Triangle Language
    TIFF
    VRML
    VTK Legacy
    VTK XML UnstructuredGrid
    VTK XML PolyData
    VTK XML ImageData
    VTK XML RectangularGrid
    VTK XML StructuredGrid
    VTK XML MultiBlock
No configuration file for "config" found
========== Configuring engine ==========
Engine configured
========== Loading 3D file ==========
Loading 3D geometry: /home/glow/dev/f3d/f3d/build/../src/testing/data/cow.vtp

No animations available in this file

Animation(s) time range is: [inf, -inf].
=== cow.vtp ===
Number of points: 2903
Number of polygons: 3263
Number of lines: 0
Number of vertices: 0
0 point data array(s):
0 cell data array(s):


Not coloring

Scene bounding box: -4.44584,5.99809,-3.63704,2.75972,-1.70141,1.70141

Camera position: 0.776126,-0.438658,24.556
Camera focal point: 0.776126,-0.438658,0
Camera view up: 0,1,0
Camera view angle: 30


========== Rendering ==========
Render done

```