### PR TITLE
Fix animation with many bones

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -194,12 +194,13 @@ f3d_test(NAME TestUpDirectionNoSign DATA suzanne.ply ARGS --up=X DEFAULT_LIGHTS)
 f3d_test(NAME TestTextureMatCap DATA suzanne.ply ARGS --texture-matcap=${F3D_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
 f3d_test(NAME TestTextureMatCapWithTCoords DATA WaterBottle.glb ARGS --geometry-only --texture-matcap=${F3D_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
 
+# Needs SSBO: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10675
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20231108)
   f3d_test(NAME TestSkinningManyBones DATA tube_254bones.glb DEFAULT_LIGHTS)
 else()
   # No animation before https://gitlab.kitware.com/vtk/vtk/-/merge_requests/7246
   if(VTK_VERSION VERSION_GREATER_EQUAL 9.0.20201015)
-    f3d_test(NAME TestSkinningManyBonesWarning DATA tube_254bones.glb ARGS -v REGEXP "with 254 bones" NO_BASELINE)
+    f3d_test(NAME TestSkinningManyBonesWarning DATA tube_254bones.glb ARGS -v REGEXP "with more than 250 bones \\\(254\\\)" NO_BASELINE)
   endif()
 endif()
 

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -194,6 +194,15 @@ f3d_test(NAME TestUpDirectionNoSign DATA suzanne.ply ARGS --up=X DEFAULT_LIGHTS)
 f3d_test(NAME TestTextureMatCap DATA suzanne.ply ARGS --texture-matcap=${F3D_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
 f3d_test(NAME TestTextureMatCapWithTCoords DATA WaterBottle.glb ARGS --geometry-only --texture-matcap=${F3D_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
 
+if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20231108)
+  f3d_test(NAME TestSkinningManyBones DATA tube_254bones.glb DEFAULT_LIGHTS)
+else()
+  # No animation before https://gitlab.kitware.com/vtk/vtk/-/merge_requests/7246
+  if(VTK_VERSION VERSION_GREATER_EQUAL 9.0.20201015)
+    f3d_test(NAME TestSkinningManyBonesWarning DATA tube_254bones.glb ARGS -v REGEXP "with 254 bones" NO_BASELINE)
+  endif()
+endif()
+
 if (NOT APPLE)
   # This test is broken on apple because of #792
   f3d_test(NAME TestScalarsCell DATA f3d.vtp ARGS --scalars --cells --comp=-2 --up=+Z DEFAULT_LIGHTS)

--- a/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
@@ -1,5 +1,7 @@
 #include "vtkF3DPolyDataMapper.h"
 
+#include "F3DLog.h"
+
 #include <vtkActor.h>
 #include <vtkDoubleArray.h>
 #include <vtkMatrix4x4.h>
@@ -130,25 +132,64 @@ void vtkF3DPolyDataMapper::ReplaceShaderValues(
   type = uniforms->GetUniformTupleType("jointMatrices");
   if (type != vtkUniforms::TupleTypeInvalid)
   {
-    customDecl += "in vec4 joints;\n"
-                  "in vec4 weights;\n";
+    int nbJoints = uniforms->GetUniformNumberOfTuples("jointMatrices");
 
-    // compute skinning matrix with current uniform weights
-    beginImpl += "  mat4 skinMat = weights.x * jointMatrices[int(joints.x)]\n"
-                 "               + weights.y * jointMatrices[int(joints.y)]\n"
-                 "               + weights.z * jointMatrices[int(joints.z)]\n"
-                 "               + weights.w * jointMatrices[int(joints.w)];\n";
+    bool skinningSupported = true;
 
-    posImpl += "  posMC = skinMat * posMC;\n";
-
-    // apply the matrix to normals and tangents
-    if (hasNormals)
+    // The number of uniform values required by OpenGL is 4096
+    // Since a mat4 is 16 values, it means we can only support 256 bones
+    // However, there are other uniform values used in practice for other
+    // things like materials and we've seen issues starting at 253 bones
+    // let's be conservative here and trigger SSBO at 250 bones
+    if (nbJoints > 250)
     {
-      normalImpl += "  normalVCVSOutput = mat3(skinMat) * normalVCVSOutput;\n";
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 20231108)
+      std::vector<float> buffer(16 * sizeof(float) * nbJoints);
+      uniforms->GetUniformMatrix4x4v("jointMatrices", buffer);
+
+      this->JointMatrices->Upload(buffer, vtkOpenGLBufferObject::ArrayBuffer);
+      this->JointMatrices->BindShaderStorage(0);
+
+      uniforms->RemoveUniform("jointMatrices");
+
+      customDecl += "layout(std430, binding = 0) readonly buffer JointsData\n"
+                    "{\n"
+                    "  mat4 jointMatrices[];\n"
+                    "};\n";
+
+      // 4.3 is required for SSBO
+      vtkShaderProgram::Substitute(VSSource, "//VTK::System::Dec", "#version 430");
+#else
+      std::string msg = "A mesh is associated with " + std::to_string(nbJoints) +
+        " bones, which is not supported by VTK <= 9.3";
+      F3DLog::Print(F3DLog::Severity::Warning, msg);
+
+      skinningSupported = false;
+#endif
     }
-    if (hasTangents)
+
+    if (skinningSupported)
     {
-      normalImpl += "  tangentVCVSOutput = mat3(skinMat) * tangentVCVSOutput;\n";
+      customDecl += "in vec4 joints;\n"
+                    "in vec4 weights;\n";
+
+      // compute skinning matrix with current uniform weights
+      beginImpl += "  mat4 skinMat = weights.x * jointMatrices[int(joints.x)]\n"
+                   "               + weights.y * jointMatrices[int(joints.y)]\n"
+                   "               + weights.z * jointMatrices[int(joints.z)]\n"
+                   "               + weights.w * jointMatrices[int(joints.w)];\n";
+
+      posImpl += "  posMC = skinMat * posMC;\n";
+
+      // apply the matrix to normals and tangents
+      if (hasNormals)
+      {
+        normalImpl += "  normalVCVSOutput = mat3(skinMat) * normalVCVSOutput;\n";
+      }
+      if (hasTangents)
+      {
+        normalImpl += "  tangentVCVSOutput = mat3(skinMat) * tangentVCVSOutput;\n";
+      }
     }
   }
 

--- a/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
@@ -160,8 +160,8 @@ void vtkF3DPolyDataMapper::ReplaceShaderValues(
       // 4.3 is required for SSBO
       vtkShaderProgram::Substitute(VSSource, "//VTK::System::Dec", "#version 430");
 #else
-      std::string msg = "A mesh is associated with " + std::to_string(nbJoints) +
-        " bones, which is not supported by VTK <= 9.3";
+      std::string msg = "A mesh is associated with more than 250 bones (" +
+        std::to_string(nbJoints) + "), which is not supported by VTK <= 9.3";
       F3DLog::Print(F3DLog::Severity::Warning, msg);
 
       skinningSupported = false;

--- a/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.cxx
@@ -161,7 +161,7 @@ void vtkF3DPolyDataMapper::ReplaceShaderValues(
       vtkShaderProgram::Substitute(VSSource, "//VTK::System::Dec", "#version 430");
 #else
       std::string msg = "A mesh is associated with more than 250 bones (" +
-        std::to_string(nbJoints) + "), which is not supported by VTK <= 9.3";
+        std::to_string(nbJoints) + "), which is not supported by VTK < 9.3.20231108";
       F3DLog::Print(F3DLog::Severity::Warning, msg);
 
       skinningSupported = false;

--- a/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.h
+++ b/library/VTKExtensions/Rendering/vtkF3DPolyDataMapper.h
@@ -57,6 +57,11 @@ private:
   vtkMTimeType EnvTextureTime = 0;
   vtkTexture* EnvTexture = nullptr;
 #endif
+
+// SSBO support: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10675
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 20231108)
+  vtkNew<vtkOpenGLBufferObject> JointMatrices;
+#endif
 };
 
 #endif

--- a/testing/baselines/TestSkinningManyBones.png
+++ b/testing/baselines/TestSkinningManyBones.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e4e810c8c033cc3a751c04bfece2e4cdee254bc1a9a11ebe8c16e6d49edd60a
+size 4239

--- a/testing/data/tube_254bones.glb
+++ b/testing/data/tube_254bones.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e83f32920c9ab13a228d089d8af50fadeb4590745764dfbf051aaca4f98c5e2d
+size 521904


### PR DESCRIPTION
Fix https://github.com/f3d-app/f3d/issues/1050  

When there are many bones, the uniform used to store the bone matrices is converted to a SSBO which is much less restrictive, but may be a bit slower to access. If there are less than 250 bones, we keep using an uniform for best performance.