### PR TITLE
Fixes for Android

### DIFF
--- a/java/Camera.java
+++ b/java/Camera.java
@@ -18,5 +18,7 @@ public class Camera {
     public native double[] getPosition();
     public native void setPosition(double[] pt);
 
+    public native void resetToBounds();
+
     private long mNativeAddress;
 }

--- a/java/Engine.java
+++ b/java/Engine.java
@@ -6,8 +6,8 @@ public class Engine implements AutoCloseable {
         System.loadLibrary("f3d-java");
     }
 
-    public Engine(Window.Type type) {
-        mNativeAddress = construct(type); // instantiate the native engine
+    public Engine() {
+        mNativeAddress = construct(); // instantiate the native engine
         mLoader = new Loader(mNativeAddress);
         mOptions = new Options(mNativeAddress);
         mWindow = new Window(mNativeAddress);
@@ -30,7 +30,7 @@ public class Engine implements AutoCloseable {
     public Options getOptions() { return mOptions; }
     public Window getWindow() { return mWindow; }
 
-    private native long construct(Window.Type type);
+    private native long construct();
     private native void destroy(long nativeAddress);
 
     private Loader mLoader;

--- a/java/F3DJavaBindings.cxx
+++ b/java/F3DJavaBindings.cxx
@@ -43,14 +43,10 @@ extern "C"
     env->ReleaseStringUTFChars(path, str);
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, construct)(JNIEnv* env, jobject self, jobject windowType)
+  JNIEXPORT jlong JAVA_BIND(Engine, construct)(JNIEnv*, jobject)
   {
-    // read cursor
-    jmethodID method =
-      env->GetMethodID(env->FindClass("app/f3d/F3D/Window$Type"), "ordinal", "()I");
-    jint itype = env->CallIntMethod(windowType, method);
-
-    return reinterpret_cast<jlong>(new f3d::engine(static_cast<f3d::window::Type>(itype)));
+    f3d::log::setVerboseLevel(f3d::log::VerboseLevel::DEBUG);
+    return reinterpret_cast<jlong>(new f3d::engine());
   }
 
   JNIEXPORT void JAVA_BIND(Engine, destroy)(JNIEnv*, jobject, jlong ptr)
@@ -196,5 +192,10 @@ extern "C"
     double* arr = env->GetDoubleArrayElements(pt, nullptr);
     GetEngine(env, self)->getWindow().getCamera().setPosition({ arr[0], arr[1], arr[2] });
     env->ReleaseDoubleArrayElements(pt, arr, 0);
+  }
+
+  JNIEXPORT void JAVA_BIND(Camera, resetToBounds)(JNIEnv* env, jobject self)
+  {
+    GetEngine(env, self)->getWindow().getCamera().resetToBounds();
   }
 }

--- a/java/Window.java
+++ b/java/Window.java
@@ -2,8 +2,6 @@ package app.f3d.F3D;
 
 public class Window {
 
-    public enum Type { NONE, NATIVE, NATIVE_OFFSCREEN, EXTERNAL }
-
     public Window(long nativeAddress) {
         mNativeAddress = nativeAddress;
         mCamera = new Camera(nativeAddress);

--- a/java/testing/TestJavaBindings.java
+++ b/java/testing/TestJavaBindings.java
@@ -17,7 +17,7 @@ public class TestJavaBindings {
     Engine.autoloadPlugins();
 
     // Always use try-with-resources idiom to ensure the native engine is released
-    try (Engine engine = new Engine(Window.Type.NATIVE_OFFSCREEN)) {
+    try (Engine engine = new Engine()) {
 
       Camera camera = engine.getWindow().getCamera();
 

--- a/library/src/camera_impl.cxx
+++ b/library/src/camera_impl.cxx
@@ -231,8 +231,7 @@ camera& camera_impl::resetToDefault()
 //----------------------------------------------------------------------------
 camera& camera_impl::resetToBounds([[maybe_unused]] double zoomFactor)
 {
-
-#if VTK_VERSION_NUMBER < VTK_VERSION_CHECK(9, 0, 20210331)
+#if __ANDROID__ || VTK_VERSION_NUMBER < VTK_VERSION_CHECK(9, 0, 20210331)
   this->Internals->VTKRenderer->ResetCamera();
 #else
   if (this->Internals->VTKRenderer->GetRenderWindow()->IsA("vtkExternalOpenGLRenderWindow"))


### PR DESCRIPTION
- Add `resetToBounds` binding
- Always build a NATIVE window (for some reason the enum is causing Java crash)
- Do not reset in screen space for Android (not working but not sure why yet)
- Always enable verbose mode