### PR TITLE
Documentation : Updated system dependencies

### DIFF
--- a/doc/dev/GETTING_STARTED.md
+++ b/doc/dev/GETTING_STARTED.md
@@ -19,7 +19,7 @@ should work for other OSes as stated, as long as listed packages are available.
 ### Install dependencies
 
 First make sure your system is up-to-date,
-then install the required dependencies using the terminal.
+then install the required dependencies (nlohmann-json, hdf5, netcdf, ospray, fmt and verdict) using the terminal.
 
 #### Debian/Ubuntu/Mint
 

--- a/doc/dev/GETTING_STARTED.md
+++ b/doc/dev/GETTING_STARTED.md
@@ -13,30 +13,36 @@ Optional dependencies or covered in the build guide.
 
 ## Linux
 
-Note: The following steps were tested with Ubuntu 22 and ArchLinux but
+Note: The following steps were tested with Ubuntu 23 and ArchLinux but
 should work for other OSes as stated, as long as listed packages are available.
 
 ### Install dependencies
 
 First make sure your system is up-to-date,
-then install the required dependencies (nlohmann-json, hdf5, netcdf, ospray, fmt and verdict) using the terminal.
+then install the required dependencies using the terminal.
 
 #### Debian/Ubuntu/Mint
 
 ```
+sudo apt update
+sudo apt upgrade
 sudo apt install build-essential git git-lfs cmake libvtk9-dev
 ```
 
 #### Fedora/Centos/RedHat
 
 ```
+sudo yum update
 sudo yum install make automake gcc gcc-c++ kernel-devel git git-lfs cmake vtk
+
 ```
 
 #### Arch Linux
 
 ```
-sudo pacman -S base-devel git git-lfs cmake vtk
+sudo pacman -Syu
+sudo pacman -S base-devel git git-lfs cmake vtk nlohmann-json hdf5 netcdf fmt verdict
+
 ```
 
 ### Compile F3D

--- a/doc/dev/GETTING_STARTED.md
+++ b/doc/dev/GETTING_STARTED.md
@@ -34,15 +34,13 @@ sudo apt install build-essential git git-lfs cmake libvtk9-dev
 ```
 sudo yum update
 sudo yum install make automake gcc gcc-c++ kernel-devel git git-lfs cmake vtk
-
 ```
 
 #### Arch Linux
 
 ```
 sudo pacman -Syu
-sudo pacman -S base-devel git git-lfs cmake vtk nlohmann-json hdf5 netcdf fmt verdict
-
+sudo pacman -S base-devel git git-lfs cmake vtk nlohmann-json hdf5 netcdf fmt verdict openmpi glew ospray boost libxcursor
 ```
 
 ### Compile F3D


### PR DESCRIPTION
Without installing the system dependencies, cmake will issue warnings and make will fail with a linker error