### PR TITLE
Minor picking fixes

### DIFF
--- a/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
+++ b/library/VTKExtensions/Rendering/vtkF3DRenderer.cxx
@@ -525,6 +525,7 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
       this->GridActor->SetPosition(gridPos);
       this->GridActor->SetMapper(gridMapper);
       this->GridActor->UseBoundsOff();
+      this->GridActor->PickableOff();
       this->GridConfigured = true;
     }
   }

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -418,20 +418,15 @@ public:
 
       bool pickSuccessful = false;
       double picked[3];
-      self->CellPicker->Pick(x, y, 0, renderer);
-      if (self->CellPicker->GetActors()->GetNumberOfItems() > 0)
+      if (self->CellPicker->Pick(x, y, 0, renderer))
       {
         self->CellPicker->GetPickPosition(picked);
         pickSuccessful = true;
       }
-      else
+      else if (self->PointPicker->Pick(x, y, 0, renderer))
       {
-        self->PointPicker->Pick(x, y, 0, renderer);
-        if (self->PointPicker->GetActors()->GetNumberOfItems() > 0)
-        {
-          self->PointPicker->GetPickPosition(picked);
-          pickSuccessful = true;
-        }
+        self->PointPicker->GetPickPosition(picked);
+        pickSuccessful = true;
       }
 
       if (pickSuccessful)


### PR DESCRIPTION
Focal point picking with `--grid` and `--verbose` logs this message (still works fine, though):
```
ERROR: In vtkExecutive.cxx, line 344
vtkCompositeDataPipeline (0x563398629000): Attempt to get input information vector from input port index 0 for algorithm vtkF3DOpenGLGridMapper (0x5633987555e0), which has 0 input ports.
```
I don't know whether we never checked with both these options or if this only started showing up with recent VTK logging changes.

Making the grid not pickable makes the message go away.
I also simplified some conditional logic for the picking (amazing what reading the docs can do!)