### PR TITLE
Partially revert a8fdf79e6e7b4006e71ae8a5db0592796a0a1477

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -177,17 +177,11 @@ if(F3D_STRICT_BUILD AND MSVC)
   target_compile_definitions(libf3d PRIVATE _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
 endif()
 
-if(APPLE)
-  set_target_properties(libf3d PROPERTIES INSTALL_RPATH "@loader_path")
-elseif(UNIX)
-  set_target_properties(libf3d PROPERTIES INSTALL_RPATH "$ORIGIN")
-endif()
-
 if (APPLE OR UNIX)
   # Make sure rpath is correctly set for libf3d
   get_target_property(target_type VTK::CommonCore TYPE)
   if (target_type STREQUAL SHARED_LIBRARY)
-    set_target_properties(libf3d PROPERTIES BUILD_RPATH "$<TARGET_FILE_DIR:VTK::CommonCore>")
+    set_target_properties(libf3d PROPERTIES INSTALL_RPATH "$<TARGET_FILE_DIR:VTK::CommonCore>")
   endif ()
 endif ()
 


### PR DESCRIPTION
Addresses https://github.com/NixOS/nixpkgs/issues/262328 by partially reverting a8fdf79e6e7b4006e71ae8a5db0592796a0a1477, found by bisecting between v2.1.0 and v2.2.0

I don't know what the issue was or how to properly fix it, as i don't speak cmake