### PR TITLE
Add missing header for GCC 14

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -12,6 +12,7 @@
 #include "options.h"
 #include "window.h"
 
+#include <algorithm>
 #include <cassert>
 #include <filesystem>
 #include <set>


### PR DESCRIPTION
Ref: https://gcc.gnu.org/gcc-14/porting_to.html