### PR TITLE
OCCT fixes for edges and colors

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -571,6 +571,8 @@ if(F3D_PLUGIN_BUILD_OCCT)
   f3d_test(NAME TestInvalidBREP DATA invalid.brep ARGS --verbose --load-plugins=occt NO_BASELINE)
 
   if(F3D_PLUGIN_OCCT_COLORING_SUPPORT AND NOT F3D_MACOS_BUNDLE)
+    f3d_test(NAME TestXCAFColors DATA xcaf-colors.stp DEFAULT_LIGHTS ARGS --load-plugins=occt -csy --up=+Z --camera-direction=-1,-1,-1)
+
     file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
     f3d_test(NAME TestDefaultConfigFileOCCT DATA f3d.stp CONFIG config_build LONG_TIMEOUT DEFAULT_LIGHTS)
 

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -134,7 +134,7 @@ public:
           uvs->InsertNextTypedTuple(fn);
         }
 
-        std::vector<vtkIdType> polyline(nbV - 1);
+        std::vector<vtkIdType> polyline(nbV);
         std::iota(polyline.begin(), polyline.end(), shift);
         linesCells->InsertNextCell(polyline.size(), polyline.data());
 

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -143,7 +143,8 @@ public:
         {
           std::array<unsigned char, 3> rgb = { 0, 0, 0 };
           Quantity_Color aColor;
-          if (this->ColorTool->GetColor(edge, XCAFDoc_ColorCurv, aColor))
+          if (this->ColorTool->GetColor(edge, XCAFDoc_ColorCurv, aColor) ||
+            this->ColorTool->GetColor(shape, XCAFDoc_ColorCurv, aColor))
           {
             rgb[0] = static_cast<unsigned char>(255.0 * aColor.Red());
             rgb[1] = static_cast<unsigned char>(255.0 * aColor.Green());
@@ -249,7 +250,8 @@ public:
         {
           std::array<unsigned char, 3> rgb = { 255, 255, 255 };
           Quantity_Color aColor;
-          if (this->ColorTool->GetColor(face, XCAFDoc_ColorSurf, aColor))
+          if (this->ColorTool->GetColor(face, XCAFDoc_ColorSurf, aColor) ||
+            this->ColorTool->GetColor(shape, XCAFDoc_ColorSurf, aColor))
           {
             rgb[0] = static_cast<unsigned char>(255.0 * aColor.Red());
             rgb[1] = static_cast<unsigned char>(255.0 * aColor.Green());

--- a/testing/baselines/TestSTEP.png
+++ b/testing/baselines/TestSTEP.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1241ecbcf7e68a93bdb1d48d061113867bcb16123c4b5d105910cd3eb29d6f0d
-size 6224
+oid sha256:b13197ebdd899107995aa2244baa0c5c1f7ccbfbad0943a81bd48de7b75bf674
+size 7146

--- a/testing/baselines/TestXCAFColors.png
+++ b/testing/baselines/TestXCAFColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67fcc6a0e1ae0e2c80c38f981199a235c8250373f498872b6cdcfe889cdaa04d
+size 6940

--- a/testing/data/xcaf-colors.stp
+++ b/testing/data/xcaf-colors.stp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5babb12db25c99df13679b087b9ef29286a6972aefc147293c85402c263d00c
+size 154613


### PR DESCRIPTION
The color of a face/edge in a STEP file can be stored on the parent shape instead of the face/edge itself, so we need to check that as a fallback.

would fix #271, also fixes an off-by-one oversight on the edges.

Fixing the missing edges possibly makes everything look ugly now as the lines are drawn very thin :(
Not sure what the way forward is here? should the lines be hidden by default and toggled with the "show edges" features instead of it showing the underlying triangulation edges? 