### PR TITLE
Disable VTK 9.0 and 9.1 on Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vtk_version: [commit, v9.3.0, v9.2.6, v9.1.0, v9.0.0]
+        vtk_version: [commit, v9.3.0, v9.2.6]
         include:
           - raytracing_label: raytracing
           - vtk_version: v9.0.0
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vtk_version: [commit, v9.3.0, v9.2.6, v9.1.0, v9.0.0]
+        vtk_version: [commit, v9.3.0, v9.2.6]
         cpu: [x86_64, arm64]
         bundle_label: [no-bundle]
         include:


### PR DESCRIPTION
Windows and macOS CI is slow, let's keep 9.0 and 9.1 on Linux only.