### PR TITLE
add javascript to insert download buttons

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,2 +1,2 @@
 <link rel="shortcut icon" href="https://raw.githubusercontent.com/f3d-app/f3d/master/resources/logo.ico" type="image/x-icon">
-<script type="application/javascript" src="{{ "/assets/main.js" | prepend:site.baseurl}}"></script>
+<script type="application/javascript" src="{{site.baseurl}}/assets/main.js"></script>

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,2 +1,2 @@
 <link rel="shortcut icon" href="https://raw.githubusercontent.com/f3d-app/f3d/master/resources/logo.ico" type="image/x-icon">
-<script type="application/javascript" src="{{ "/assets/main.js" | prepend:site.resource}}"></script>
+<script type="application/javascript" src="{{ "/assets/main.js" | prepend:site.baseurl}}"></script>

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,2 +1,2 @@
 <link rel="shortcut icon" href="https://raw.githubusercontent.com/f3d-app/f3d/master/resources/logo.ico" type="image/x-icon">
-<script type="application/javascript" src="/assets/main.js"></script>
+<script type="application/javascript" src="{{ "/assets/main.js" | prepend:site.resource}}"></script>

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,2 +1,2 @@
 <link rel="shortcut icon" href="https://raw.githubusercontent.com/f3d-app/f3d/master/resources/logo.ico" type="image/x-icon">
-<script type="application/javascript" src="{{site.baseurl}}/assets/main.js"></script>
+<script type="application/javascript" src="{{ site.baseurl }}/assets/main.js"></script>

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,1 +1,2 @@
 <link rel="shortcut icon" href="https://raw.githubusercontent.com/f3d-app/f3d/master/resources/logo.ico" type="image/x-icon">
+<script type="application/javascript" src="/assets/main.js"></script>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -36,3 +36,13 @@ kbd {
     // Transition is fun
     transition: all 0.1s;
 }
+
+div.install-buttons {
+    text-align: center;
+    display: block;
+    line-height: 1;
+
+    .btn {
+        margin: .5em;
+    }
+}

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,0 +1,90 @@
+function onload(event) {
+  if (window.location.pathname.endsWith("/INSTALLATION.html")) {
+    enhance_install_page();
+  }
+}
+
+function enhance_install_page() {
+  function retrieve_downloads(target_platform_re) {
+    var downloads = [];
+    for (const table of document.querySelectorAll("table")) {
+      const th = document.querySelector("th");
+      if (th) {
+        if (/Platform/i.test(th.innerText)) {
+          for (const table_row of table.querySelectorAll("tr")) {
+            const table_cols = table_row.querySelectorAll("td");
+            if (table_cols.length > 1) {
+              const link = table_cols[1].querySelector("a");
+              if (link) {
+                const platform = table_cols[0].innerText;
+                if (target_platform_re.test(platform))
+                  downloads.push([platform, link.innerText, link.href]);
+              }
+            }
+          }
+          break; // stop after first relevant table
+        }
+      }
+    }
+    return downloads;
+  }
+
+  /* check OS: first check for `?os=foo` in the URL, otherwise guess form user agent */
+  const params = new URLSearchParams(window.location.search);
+  const current_os = params.get("os") || guess_client_OS();
+
+  if (current_os == null) return;
+
+  /* find download links matching the OS */
+  const target_platform_re = RegExp(`(${current_os})`, "i");
+  const downloads = retrieve_downloads(target_platform_re);
+
+  if (downloads.length < 1) return;
+
+  /* create a box below the first header to insert buttons */
+  const header = document.querySelector("h1");
+  if (header == null) return;
+  const div = document.createElement("div");
+  div.setAttribute("class", "install-buttons");
+  header.parentNode.insertBefore(div, header.nextSibling);
+
+  /* create download button for each matching link */
+  var i = 0;
+  for ([platform, filename, url] of downloads) {
+    const bolded_platform = platform.replace(target_platform_re, "<b>$1</b>");
+    const link = document.createElement("a");
+    link.setAttribute("href", url);
+    link.setAttribute("class", i++ ? "btn" : "btn btn-primary");
+    link.innerHTML = `<div>Get <b>F3D</b> for ${bolded_platform}</div><small>${filename}</small>`;
+    div.append(link);
+  }
+  const note = document.createElement("div");
+  note.innerHTML = "<small>or see other available versions below</small>";
+  div.append(note);
+}
+
+function guess_client_OS() {
+  /* https://stackoverflow.com/a/38241481 */
+  const userAgent = window.navigator.userAgent;
+  const platform =
+    window.navigator?.userAgentData?.platform || window.navigator.platform;
+  const macosPlatforms = ["macOS", "Macintosh", "MacIntel", "MacPPC", "Mac68K"];
+  const windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"];
+  const iosPlatforms = ["iPhone", "iPad", "iPod"];
+
+  if (macosPlatforms.indexOf(platform) !== -1) {
+    return "MacOS";
+  } else if (iosPlatforms.indexOf(platform) !== -1) {
+    return "iOS";
+  } else if (windowsPlatforms.indexOf(platform) !== -1) {
+    return "Windows";
+  } else if (/Android/.test(userAgent)) {
+    return "Android";
+  } else if (/Linux/.test(platform)) {
+    return "Linux";
+  } else {
+    return null;
+  }
+}
+
+window.addEventListener("load", onload);

--- a/doc/user/INSTALLATION.md
+++ b/doc/user/INSTALLATION.md
@@ -4,12 +4,12 @@
 
 | Platform | Files |
 | -------- | ----- |
-| Windows Installer | [F3D-2.3.0-Windows.exe](https://github.com/f3d-app/f3d/releases/download/v2.3.0/F3D-2.3.0-Windows-x86_64-raytracing.exe) |
-| Windows (Portable) | [F3D-2.3.0-Windows.zip](https://github.com/f3d-app/f3d/releases/download/v2.3.0/F3D-2.3.0-Windows-x86_64-raytracing.zip) |
+| Windows (installer) | [F3D-2.3.0-Windows.exe](https://github.com/f3d-app/f3d/releases/download/v2.3.0/F3D-2.3.0-Windows-x86_64-raytracing.exe) |
+| Windows (portable) | [F3D-2.3.0-Windows.zip](https://github.com/f3d-app/f3d/releases/download/v2.3.0/F3D-2.3.0-Windows-x86_64-raytracing.zip) |
 | MacOS (Intel) | [F3D-2.3.0-macOS-x86_64.dmg](https://github.com/f3d-app/f3d/releases/download/v2.3.0/F3D-2.3.0-macOS-x86_64-raytracing.dmg) |
 | MacOS (Silicon) | [F3D-2.3.0-macOS-arm64.dmg](https://github.com/f3d-app/f3d/releases/download/v2.3.0/F3D-2.3.0-macOS-arm64.dmg) |
-| Debian-based Package | [F3D-2.3.0-Linux.deb](https://github.com/f3d-app/f3d/releases/download/v2.3.0/F3D-2.3.0-Linux-x86_64-raytracing.deb) |
-| Linux (Portable) | [F3D-2.3.0-Linux.tar.xz](https://github.com/f3d-app/f3d/releases/download/v2.3.0/F3D-2.3.0-Linux-x86_64-raytracing.tar.xz) |
+| Linux (Debian package) | [F3D-2.3.0-Linux.deb](https://github.com/f3d-app/f3d/releases/download/v2.3.0/F3D-2.3.0-Linux-x86_64-raytracing.deb) |
+| Linux (portable) | [F3D-2.3.0-Linux.tar.xz](https://github.com/f3d-app/f3d/releases/download/v2.3.0/F3D-2.3.0-Linux-x86_64-raytracing.tar.xz) |
 
 Note: MacOS package is not signed, see the [troubleshooting](LIMITATIONS_AND_TROUBLESHOOTING.md) section for a workaround if needed.
 


### PR DESCRIPTION
in order to have big "get F3D button" for the current OS above the release table:

Include a script in the header, the script is loaded on every page but will perform different actions depending on which page it's in. 
The idea is that the javascript only enhances the existing html, while being totally optional. We don't want to start adding <script> tags in the markdown documents.

In the case of the install page, the script retrieves the download links from the table in the page (html generated from the markdown file) and adds buttons for the ones where the "Platform" column matches the guessed client OS

edit: temporarily deployed at https://snoyer.github.io/f3d/doc/user/INSTALLATION.html
should look something like:
![screenshot](https://github.com/f3d-app/f3d/assets/489715/4ab689c0-b425-4970-99d7-3ccf04dcb78a)
