### PR TITLE
fix: print error when test record file doesn't exist

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -720,13 +720,6 @@ f3d_test(NAME TestOutputNoBackground DATA cow.vtp ARGS --no-background NO_BASELI
 # Test Non existent interaction record directory
 f3d_test(NAME TestInteractionNonExistentRecordDirectory ARGS --interaction-test-record=${CMAKE_BINARY_DIR}/Testing/NotExistentDirectory/interaction.log NO_BASELINE REGEXP "Interaction record directory does not exist")
 
-# Create a directory with no write permissions
-set(NON_WRITABLE_DIRECTORY ${CMAKE_BINARY_DIR}/Testing/Temporary/NonWritableDirectory)
-file(MAKE_DIRECTORY ${NON_WRITABLE_DIRECTORY})
-file(CHMOD ${NON_WRITABLE_DIRECTORY} PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
-
-f3d_test(NAME TestInteractionNonWritableRecordDirectory ARGS --interaction-test-record=${NON_WRITABLE_DIRECTORY}/interaction.log NO_BASELINE REGEXP "Don't have write permissions for")
-
 # Basic record and play test
 f3d_test(NAME TestInteractionRecord DATA cow.vtp ARGS --interaction-test-record=${CMAKE_BINARY_DIR}/Testing/Temporary/interaction.log NO_BASELINE)
 f3d_test(NAME TestInteractionPlay DATA cow.vtp ARGS --interaction-test-play=${CMAKE_BINARY_DIR}/Testing/Temporary/interaction.log DEPENDS TestInteractionRecord NO_BASELINE)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -717,8 +717,21 @@ f3d_test(NAME TestOutputOutput DATA cow.vtp ARGS --ref=${CMAKE_BINARY_DIR}/Testi
 f3d_test(NAME TestUnsupportedInputOutput DATA unsupportedFile.dummy REGEXP "No file loaded, no rendering performed" NO_BASELINE)
 f3d_test(NAME TestOutputNoBackground DATA cow.vtp ARGS --no-background NO_BASELINE)
 
-# Test Not existent interaction record directory
-f3d_test(NAME TestInteractionRecordNonExistentDirectory DATA cow.vtp ARGS --interaction-test-record=${CMAKE_BINARY_DIR}/Testing/Does/Not/Exist/interaction.log NO_BASELINE REGEXP_FAIL "Interaction log file directory does not exist")
+# Test Non existent interaction record directory
+f3d_test(NAME TestInteractionNonExistentRecordDirectory ARGS --interaction-test-record=${CMAKE_BINARY_DIR}/Testing/NotExistentDirectory/interaction.log NO_BASELINE REGEXP "Interaction record directory does not exist")
+
+# Create a directory with no write permissions
+set(NON_WRITABLE_DIRECTORY ${CMAKE_BINARY_DIR}/Testing/Temporary/NonWritableDirectory)
+file(MAKE_DIRECTORY ${NON_WRITABLE_DIRECTORY})
+
+# Set directory permissions to make it non-writable
+if (UNIX)
+    execute_process(COMMAND chmod -w "${NON_WRITABLE_DIRECTORY}")
+elseif (WIN32)
+    execute_process(COMMAND icacls "${NON_WRITABLE_DIRECTORY}" /deny Everyone:(W))
+endif()
+
+f3d_test(NAME TestInteractionNonWritableRecordDirectory ARGS --interaction-test-record=${NON_WRITABLE_DIRECTORY}/interaction.log NO_BASELINE REGEXP "Don't have write permissions for")
 
 # Basic record and play test
 f3d_test(NAME TestInteractionRecord DATA cow.vtp ARGS --interaction-test-record=${CMAKE_BINARY_DIR}/Testing/Temporary/interaction.log NO_BASELINE)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -717,6 +717,9 @@ f3d_test(NAME TestOutputOutput DATA cow.vtp ARGS --ref=${CMAKE_BINARY_DIR}/Testi
 f3d_test(NAME TestUnsupportedInputOutput DATA unsupportedFile.dummy REGEXP "No file loaded, no rendering performed" NO_BASELINE)
 f3d_test(NAME TestOutputNoBackground DATA cow.vtp ARGS --no-background NO_BASELINE)
 
+# Test Not existent interaction record directory
+f3d_test(NAME TestInteractionRecordNonExistentDirectory DATA cow.vtp ARGS --interaction-test-record=${CMAKE_BINARY_DIR}/Testing/Does/Not/Exist/interaction.log NO_BASELINE REGEXP_FAIL "Interaction log file directory does not exist")
+
 # Basic record and play test
 f3d_test(NAME TestInteractionRecord DATA cow.vtp ARGS --interaction-test-record=${CMAKE_BINARY_DIR}/Testing/Temporary/interaction.log NO_BASELINE)
 f3d_test(NAME TestInteractionPlay DATA cow.vtp ARGS --interaction-test-play=${CMAKE_BINARY_DIR}/Testing/Temporary/interaction.log DEPENDS TestInteractionRecord NO_BASELINE)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -723,13 +723,7 @@ f3d_test(NAME TestInteractionNonExistentRecordDirectory ARGS --interaction-test-
 # Create a directory with no write permissions
 set(NON_WRITABLE_DIRECTORY ${CMAKE_BINARY_DIR}/Testing/Temporary/NonWritableDirectory)
 file(MAKE_DIRECTORY ${NON_WRITABLE_DIRECTORY})
-
-# Set directory permissions to make it non-writable
-if (UNIX)
-    execute_process(COMMAND chmod -w "${NON_WRITABLE_DIRECTORY}")
-elseif (WIN32)
-    execute_process(COMMAND icacls "${NON_WRITABLE_DIRECTORY}" /deny Everyone:(W))
-endif()
+file(CHMOD ${NON_WRITABLE_DIRECTORY} PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
 
 f3d_test(NAME TestInteractionNonWritableRecordDirectory ARGS --interaction-test-record=${NON_WRITABLE_DIRECTORY}/interaction.log NO_BASELINE REGEXP "Don't have write permissions for")
 

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -683,7 +683,6 @@ bool interactor_impl::recordInteraction(const std::string& file)
 {
   if (file.empty())
   {
-    // TODO improve VTK to check file opening
     log::error("No interaction record file provided");
     return false;
   }

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -717,7 +717,6 @@ bool interactor_impl::recordInteraction(const std::string& file)
   this->Internals->Recorder->SetInteractor(this->Internals->VTKInteractor);
 #endif
 
-  std::string cleanFile = vtksys::SystemTools::CollapseFullPath(file);
   this->Internals->Recorder->SetFileName(cleanFile.c_str());
   this->Internals->Recorder->On();
   this->Internals->Recorder->Record();

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -695,14 +695,14 @@ bool interactor_impl::recordInteraction(const std::string& file)
   // Check if the parent directory exists
   if (!vtksys::SystemTools::FileExists(parentDirectory))
   {
-    log::error("Interaction log file directory does not exist ", parentDirectory);
+    log::error("Interaction record directory does not exist ", parentDirectory);
     return false;
   }
 
   // Check if we can write to the directory
   if (!vtksys::SystemTools::TestFileAccess(parentDirectory, vtksys::TEST_FILE_WRITE))
   {
-    log::error("Don't have permission to write to ", parentDirectory);
+    log::error("Don't have write permissions for ", parentDirectory);
     return false;
   }
 

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -688,6 +688,24 @@ bool interactor_impl::recordInteraction(const std::string& file)
     return false;
   }
 
+  std::string cleanFile = vtksys::SystemTools::CollapseFullPath(file);
+
+  std::string parentDirectory = vtksys::SystemTools::GetParentDirectory(cleanFile);
+
+  // Check if the parent directory exists
+  if (!vtksys::SystemTools::FileExists(parentDirectory))
+  {
+    log::error("Interaction log file directory does not exist ", parentDirectory);
+    return false;
+  }
+
+  // Check if we can write to the directory
+  if (!vtksys::SystemTools::TestFileAccess(parentDirectory, vtksys::TEST_FILE_WRITE))
+  {
+    log::error("Don't have permission to write to ", parentDirectory);
+    return false;
+  }
+
 // Clear needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9229
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 1, 20220601)
   // Make sure the recorder is off and streams are cleared


### PR DESCRIPTION
## Fixes

#1231 

## Changes

F3D now errors out when the record file doesn't exist.
