### PR TITLE
add dark title bar support on windows

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -111,6 +111,10 @@ else ()
     $<BUILD_INTERFACE:${F3D_SOURCE_DIR}/external/nlohmann_json>)
 endif ()
 
+if (WIN32)
+  target_link_libraries(libf3d PRIVATE Dwmapi)
+endif()
+
 set_target_properties(libf3d PROPERTIES
   CXX_STANDARD 17
   CXX_VISIBILITY_PRESET hidden

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -63,7 +63,9 @@ public:
   bool IsWindowsBuildNumberOrGreater(int buildNumber)
   {
     std::string value{};
-    bool result = vtksys::SystemTools::ReadRegistryValue("HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion;CurrentBuildNumber", value);
+    bool result = vtksys::SystemTools::ReadRegistryValue(
+      "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion;CurrentBuildNumber",
+      value);
 
     if (result == true)
     {
@@ -86,16 +88,18 @@ public:
 
   /**
    * Helper function to fetch a DWORD from windows registry.
-   * 
+   *
    * @param hKey A handle to an open registry key
    * @param subKey The path of registry key relative to 'hKey'
    * @param value The name of the registry value
    * @param dWord Variable to store the result in
    */
-  bool ReadRegistryDWord(HKEY hKey, const std::wstring& subKey, const std::wstring& value, DWORD& dWord)
+  bool ReadRegistryDWord(
+    HKEY hKey, const std::wstring& subKey, const std::wstring& value, DWORD& dWord)
   {
     DWORD dataSize = sizeof(DWORD);
-    LONG result = RegGetValueW(hKey, subKey.c_str(), value.c_str(), RRF_RT_REG_DWORD, nullptr, &dWord, &dataSize);
+    LONG result = RegGetValueW(
+      hKey, subKey.c_str(), value.c_str(), RRF_RT_REG_DWORD, nullptr, &dWord, &dataSize);
 
     return result == ERROR_SUCCESS;
   }
@@ -118,7 +122,7 @@ public:
     }
 
     result = ReadRegistryDWord(HKEY_CURRENT_USER, subKey, L"SystemUsesLightTheme", value);
-    
+
     if (result && value == 0)
     {
       return true;
@@ -301,11 +305,10 @@ void window_impl::Initialize(bool withColoring)
   this->Internals->Initialized = true;
 
 #ifdef _WIN32
-  HWND hwnd = static_cast<HWND>(this->Internals->RenWin->GetGenericWindowId());
-  BOOL useDarkMode = this->Internals->IsWindowsInDarkMode();
-
   if (this->Internals->IsWindowsBuildNumberOrGreater(IMMERSIVE_DARK_MODE_SUPPORTED_SINCE))
   {
+    HWND hwnd = static_cast<HWND>(this->Internals->RenWin->GetGenericWindowId());
+    BOOL useDarkMode = this->Internals->IsWindowsInDarkMode();
     DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDarkMode, sizeof(useDarkMode));
   }
 #endif

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -22,8 +22,6 @@
 #include <vtkWindowToImageFilter.h>
 #include <vtksys/SystemTools.hxx>
 
-#include <charconv>
-
 #if F3D_MODULE_EXTERNAL_RENDERING
 #include <vtkExternalOpenGLRenderWindow.h>
 #endif

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -62,7 +62,7 @@ public:
    * Helper function to detect if the
    * Windows Build Number is equal or greater to a number
    */
-  BOOL IsWindowsBuildNumberOrGreater(int buildNumber)
+  bool IsWindowsBuildNumberOrGreater(int buildNumber)
   {
     std::string value{};
     bool result = vtksys::SystemTools::ReadRegistryValue("HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion;CurrentBuildNumber", value);
@@ -89,7 +89,7 @@ public:
   /**
    * Helper function to detect user theme
    */
-  BOOL IsWindowsInDarkMode()
+  bool IsWindowsInDarkMode()
   {
     HKEY hKey;
     LONG result = RegOpenKeyExA(HKEY_CURRENT_USER,
@@ -308,7 +308,6 @@ void window_impl::Initialize(bool withColoring)
 
 #ifdef _WIN32
   HWND hwnd = static_cast<HWND>(this->Internals->RenWin->GetGenericWindowId());
-
   BOOL useDarkMode = this->Internals->IsWindowsInDarkMode();
 
   if (this->Internals->IsWindowsBuildNumberOrGreater(IMMERSIVE_DARK_MODE_SUPPORTED_SINCE))

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -34,7 +34,7 @@
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 #endif
 
-constexpr auto IMMERSIVE_DARK_MODE_SUPPORTED_SINCE = 22000;
+constexpr auto IMMERSIVE_DARK_MODE_SUPPORTED_SINCE = 19041;
 #endif
 
 namespace f3d::detail

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -75,7 +75,7 @@ public:
       }
       catch (const std::invalid_argument& e)
       {
-        f3d::log::debug("Error parsing CurrentBuildNumber");
+        f3d::log::debug("Error parsing CurrentBuildNumber", e.what());
       }
     }
     else
@@ -112,20 +112,15 @@ public:
     std::wstring subKey(L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize");
 
     DWORD value{};
-    bool result = false;
 
-    result = ReadRegistryDWord(HKEY_CURRENT_USER, subKey, L"AppsUseLightTheme", value);
-
-    if (result && value == 0)
+    if (ReadRegistryDWord(HKEY_CURRENT_USER, subKey, L"AppsUseLightTheme", value))
     {
-      return true;
+      return value == 0;
     }
 
-    result = ReadRegistryDWord(HKEY_CURRENT_USER, subKey, L"SystemUsesLightTheme", value);
-
-    if (result && value == 0)
+    if (ReadRegistryDWord(HKEY_CURRENT_USER, subKey, L"SystemUsesLightTheme", value))
     {
-      return true;
+      return value == 0;
     }
 
     return false;


### PR DESCRIPTION
Fix #895 

## Changes

Added some helper functions to fetch User theme from registry and also to query build numbers to check if a feature is supported.

Sets Immersive Dark Mode based on user theme.