### PR TITLE
fix: terminate f3d process spawned by F3DShellExtension if its still active after timeout

### DIFF
--- a/winshellext/F3DThumbnailProvider.cxx
+++ b/winshellext/F3DThumbnailProvider.cxx
@@ -188,6 +188,13 @@ IFACEMETHODIMP F3DThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
   // Clean up
   DWORD exitCode = EXIT_SUCCESS;
   GetExitCodeProcess(pi.hProcess, &exitCode);
+  
+  // Terminate the process if it is still active
+  if (exitCode == STILL_ACTIVE)
+  {
+    TerminateProcess(pi.hProcess, EXIT_FAILURE);
+    GetExitCodeProcess(pi.hProcess, &exitCode);
+  }
 
   CloseHandle(pi.hThread);
   CloseHandle(pi.hProcess);


### PR DESCRIPTION
**Previous Behaviour**

If you previewed a thumbnail that took longer than 8 sec, the thumbnail would return in `E_FAIL` but wouldn't properly terminate the process associated with it. And continue running in the background.

**Current Behaviour**

The spawned process is properly terminated.