### PR TITLE
OCCT speedups and fixes

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -585,7 +585,7 @@ if(F3D_PLUGIN_BUILD_OCCT)
   f3d_test(NAME TestInvalidBREP DATA invalid.brep ARGS --verbose --load-plugins=occt NO_BASELINE)
 
   if(F3D_PLUGIN_OCCT_COLORING_SUPPORT AND NOT F3D_MACOS_BUNDLE)
-    f3d_test(NAME TestXCAFColors DATA xcaf-colors.stp DEFAULT_LIGHTS ARGS --load-plugins=occt -csy --up=+Z --camera-direction=-1,-1,-1)
+    f3d_test(NAME TestXCAFColors DATA xcaf-colors.stp DEFAULT_LIGHTS ARGS --load-plugins=occt -csy --up=+Z --line-width=3 --camera-direction=-1,-1,-1)
 
     file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
     f3d_test(NAME TestDefaultConfigFileOCCT DATA f3d.stp CONFIG config_build LONG_TIMEOUT DEFAULT_LIGHTS)

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -244,23 +244,26 @@ public:
           std::swap(cell[0], cell[2]);
         }
         trianglesCells->InsertNextCell(3, cell);
+      }
 
 #if F3D_PLUGIN_OCCT_XCAF
-        if (this->ColorTool)
+      if (this->ColorTool)
+      {
+        std::array<unsigned char, 3> rgb = { 255, 255, 255 };
+        Quantity_Color aColor;
+        if (this->ColorTool->GetColor(face, XCAFDoc_ColorSurf, aColor) ||
+          this->ColorTool->GetColor(shape, XCAFDoc_ColorSurf, aColor))
         {
-          std::array<unsigned char, 3> rgb = { 255, 255, 255 };
-          Quantity_Color aColor;
-          if (this->ColorTool->GetColor(face, XCAFDoc_ColorSurf, aColor) ||
-            this->ColorTool->GetColor(shape, XCAFDoc_ColorSurf, aColor))
-          {
-            rgb[0] = static_cast<unsigned char>(255.0 * aColor.Red());
-            rgb[1] = static_cast<unsigned char>(255.0 * aColor.Green());
-            rgb[2] = static_cast<unsigned char>(255.0 * aColor.Blue());
-          }
+          rgb[0] = static_cast<unsigned char>(255.0 * aColor.Red());
+          rgb[1] = static_cast<unsigned char>(255.0 * aColor.Green());
+          rgb[2] = static_cast<unsigned char>(255.0 * aColor.Blue());
+        }
+        for (int i = 1; i <= nbT; i++)
+        {
           colors->InsertNextTypedTuple(rgb.data());
         }
-#endif
       }
+#endif
 
       shift += nbV;
     }

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -74,7 +74,7 @@
 class vtkF3DOCCTReader::vtkInternals
 {
 #if F3D_PLUGIN_OCCT_XCAF
-  typedef XCAFPrs_IndexedDataMapOfShapeStyle StyleMap;
+  using StyleMap = XCAFPrs_IndexedDataMapOfShapeStyle;
 #endif
 
 public:
@@ -379,7 +379,7 @@ public:
     /* pass down default style (if any) to all leaves */
     try
     {
-      const XCAFPrs_Style defaultStyle = collectedStyles.FindFromKey(rootShape);
+      const XCAFPrs_Style& defaultStyle = collectedStyles.FindFromKey(rootShape);
       for (StyleMap::Iterator iter(inheritedStyles); iter.More(); iter.Next())
       {
         XCAFPrs_Style style = iter.Value();

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -313,18 +313,18 @@ public:
   }
 
 #if F3D_PLUGIN_OCCT_XCAF
-  StyleMap CollectInheritedStyles(const TDF_Label& label, const TopoDS_Shape& shape)
+  StyleMap CollectInheritedStyles(const TDF_Label& rootLabel, const TopoDS_Shape& rootShape)
   {
     StyleMap inheritedStyles;
 
-    if (label.IsNull())
+    if (rootLabel.IsNull())
     {
       return inheritedStyles;
     }
 
     /* collect styled shapes from the document */
     StyleMap collectedStyles;
-    XCAFPrs::CollectStyleSettings(label, TopLoc_Location(), collectedStyles);
+    XCAFPrs::CollectStyleSettings(rootLabel, TopLoc_Location(), collectedStyles);
 
     /* iterate styled shapes and assign style if leaf, otherwise collect if parent node */
     const TopAbs_ShapeEnum leafType = this->Parent->GetReadWire() ? TopAbs_EDGE : TopAbs_FACE;
@@ -377,7 +377,7 @@ public:
     /* pass down default style (if any) to all leaves */
     try
     {
-      const XCAFPrs_Style defaultStyle = collectedStyles.FindFromKey(shape);
+      const XCAFPrs_Style defaultStyle = collectedStyles.FindFromKey(rootShape);
       for (StyleMap::Iterator iter(inheritedStyles); iter.More(); iter.Next())
       {
         XCAFPrs_Style style = iter.Value();

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -73,7 +73,9 @@
 
 class vtkF3DOCCTReader::vtkInternals
 {
+#if F3D_PLUGIN_OCCT_XCAF
   typedef XCAFPrs_IndexedDataMapOfShapeStyle StyleMap;
+#endif
 
 public:
   //----------------------------------------------------------------------------

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -167,7 +167,7 @@ public:
         std::array<unsigned char, 3> rgb = { 0, 0, 0 };
         try
         {
-          const auto style = inheritedStyles.FindFromKey(edge);
+          const auto& style = inheritedStyles.FindFromKey(edge);
           if (style.IsSetColorCurv())
           {
             Quantity_Color color = style.GetColorCurv();
@@ -272,7 +272,7 @@ public:
       std::array<unsigned char, 3> rgb = { 255, 255, 255 };
       try
       {
-        const auto style = inheritedStyles.FindFromKey(face);
+        const auto& style = inheritedStyles.FindFromKey(face);
         if (style.IsSetColorSurf())
         {
           Quantity_Color color = style.GetColorSurf();
@@ -333,14 +333,14 @@ public:
     std::vector<std::pair<TopoDS_Shape, XCAFPrs_Style> > parents;
     for (StyleMap::Iterator iter(collectedStyles); iter.More(); iter.Next())
     {
-      const TopoDS_Shape shape = iter.Key();
+      const TopoDS_Shape& shape = iter.Key();
       if (shape.ShapeType() == leafType)
       {
         inheritedStyles.Add(shape, iter.Value());
       }
       else if (shape.ShapeType() < leafType)
       {
-        parents.push_back(std::make_pair(shape, iter.Value()));
+        parents.emplace_back(std::make_pair(shape, iter.Value()));
       }
     }
 

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -120,7 +120,7 @@ public:
       }
 
       // Add all edges to polydata
-      for (const TopoDS_Edge edge : edges)
+      for (const TopoDS_Edge& edge : edges)
       {
         TopLoc_Location location;
         const auto& poly = BRep_Tool::Polygon3D(edge, location);

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -334,11 +334,7 @@ public:
     for (StyleMap::Iterator iter(collectedStyles); iter.More(); iter.Next())
     {
       const TopoDS_Shape& shape = iter.Key();
-      if (shape.ShapeType() == leafType)
-      {
-        inheritedStyles.Add(shape, iter.Value());
-      }
-      else if (shape.ShapeType() < leafType)
+      if (shape.ShapeType() <= leafType)
       {
         parents.emplace_back(std::make_pair(shape, iter.Value()));
       }

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -178,7 +178,7 @@ public:
         }
         catch (Standard_NoSuchObject&)
         {
-          /* ignore */
+          /* edge has no style, safe to ignore */
         }
 
         colors->InsertNextTypedTuple(rgb.data());
@@ -283,7 +283,7 @@ public:
       }
       catch (Standard_NoSuchObject&)
       {
-        /* ignore */
+        /* face has no style, safe to ignore */
       }
 
       for (int i = 1; i <= nbT; i++)
@@ -388,7 +388,7 @@ public:
     }
     catch (Standard_NoSuchObject&)
     {
-      /* ignore */
+      /* root shape has no style, safe to ignore */
     }
 
     return inheritedStyles;

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -550,7 +550,7 @@ int vtkF3DOCCTReader::RequestData(
     this->Internals->ShapeMap[this->Internals->GetHash(label)] =
       this->Internals->CreateShape(shape);
 
-    double progress = 0.5 + static_cast<double>(iLabel) / topLevelShapes.Length();
+    double progress = 0.5 + (static_cast<double>(iLabel) / topLevelShapes.Length()) / 2;
     this->InvokeEvent(vtkCommand::ProgressEvent, &progress);
   }
 

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -98,9 +98,11 @@ public:
     vtkNew<vtkFloatArray> uvs;
     uvs->SetNumberOfComponents(2);
     uvs->SetName("UV");
+#if F3D_PLUGIN_OCCT_XCAF
     vtkNew<vtkUnsignedCharArray> colors;
     colors->SetNumberOfComponents(3);
     colors->SetName("Colors");
+#endif
     vtkNew<vtkCellArray> trianglesCells;
     vtkNew<vtkCellArray> linesCells;
 
@@ -303,11 +305,7 @@ public:
     polydata->SetLines(linesCells);
 
 #if F3D_PLUGIN_OCCT_XCAF
-    /* colors may be left empty ? */
-    if (colors->GetSize() > 0)
-    {
-      polydata->GetCellData()->SetScalars(colors);
-    }
+    polydata->GetCellData()->SetScalars(colors);
 #endif
 
     polydata->Squeeze();

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -96,6 +96,10 @@ public:
 
     Standard_Integer shift = 0;
 
+    /* Mesh the whole shape. This only affect faces, edges have to be handled separately. */
+    BRepMesh_IncrementalMesh(shape, this->Parent->GetLinearDeflection(),
+      this->Parent->GetRelativeDeflection(), this->Parent->GetAngularDeflection(), Standard_True);
+
     if (this->Parent->GetReadWire())
     {
       // Add all edges to polydata
@@ -165,14 +169,6 @@ public:
 
       TopLoc_Location location;
       const auto& poly = BRep_Tool::Triangulation(face, location);
-
-      if (poly.IsNull() || poly->NbTriangles() <= 0)
-      {
-        // meshing
-        BRepMesh_IncrementalMesh(face, this->Parent->GetLinearDeflection(),
-          this->Parent->GetRelativeDeflection(), this->Parent->GetAngularDeflection(),
-          Standard_True);
-      }
 
       if (poly.IsNull())
       {

--- a/testing/baselines/TestIGES.png
+++ b/testing/baselines/TestIGES.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1241ecbcf7e68a93bdb1d48d061113867bcb16123c4b5d105910cd3eb29d6f0d
-size 6224
+oid sha256:b13197ebdd899107995aa2244baa0c5c1f7ccbfbad0943a81bd48de7b75bf674
+size 7146

--- a/testing/baselines/TestXCAFColors.png
+++ b/testing/baselines/TestXCAFColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67fcc6a0e1ae0e2c80c38f981199a235c8250373f498872b6cdcfe889cdaa04d
-size 6940
+oid sha256:f20aaf2d20a1718085a3c8033f294884247a0c02c593fee23092b4bbe11ec0a3
+size 12501

--- a/testing/data/xcaf-colors.stp
+++ b/testing/data/xcaf-colors.stp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5babb12db25c99df13679b087b9ef29286a6972aefc147293c85402c263d00c
-size 154613
+oid sha256:ae335c39ea7dfaeb905639aa3cbaecc2f1895990d4e1a0bedd66d827c6cd2985
+size 1166830


### PR DESCRIPTION
Performance improvements for the OCCT reader:
- color lookups turn out to add up a lot when they're done for every triangle of a re-meshed face.
- re-meshing can be batched instead of done for each face/edge individually.
- color lookups with `XCAFDoc_ColorTool` were also wrong in addition to being slow, using `XCAFPrs` to walk down the attribute tree and collect inherited style properties is more correct and faster

all in all the 18MB step file from https://www.printables.com/model/612925-creality-k1-corexy-motion-assembly-cad/files now opens in about ~~40sec~~ 15sec instead of almost 5min

before and after:

![f3d-k1-before](https://github.com/f3d-app/f3d/assets/489715/95b1db39-11cc-44d9-86e7-067d7d6396e6)

![f3d-k1-after](https://github.com/f3d-app/f3d/assets/489715/6a41618f-f567-4fad-ad90-ece5c7e69df3)

also fixes a minor bug where progress was reported up to 150%, meaning the progress bar would look full before the actual processing was finished.
