### PR TITLE
maintain config declaration order

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -205,7 +205,7 @@ private:
   std::string FilePathForConfigBlock;
 
   using DictionaryEntry = std::map<std::string, std::string>;
-  using Dictionary = std::map<std::string, DictionaryEntry>;
+  using Dictionary = std::vector<std::pair<std::string, DictionaryEntry> >;
   DictionaryEntry GlobalConfigDicEntry;
   Dictionary ConfigDic;
   std::string ExecutableName;
@@ -746,7 +746,7 @@ bool ConfigurationOptions::InitializeDictionaryFromConfigFile(const std::string&
       return false;
     }
 
-    nlohmann::json json;
+    nlohmann::ordered_json json;
     try
     {
       file >> json;
@@ -783,7 +783,7 @@ bool ConfigurationOptions::InitializeDictionaryFromConfigFile(const std::string&
       }
       else
       {
-        this->ConfigDic[regexpConfig.key()] = localDic;
+        this->ConfigDic.emplace_back(regexpConfig.key(), localDic);
       }
     }
   }

--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -68,8 +68,8 @@ protected:
     bool ret = false;
     if (this->FilePathForConfigBlock.empty())
     {
-      auto localIt = this->GlobalConfigDicEntry.find(option);
-      if (localIt != this->GlobalConfigDicEntry.end())
+      auto localIt = this->GlobalConfigEntry.find(option);
+      if (localIt != this->GlobalConfigEntry.end())
       {
         configValue = localIt->second;
         ret = true;
@@ -77,7 +77,7 @@ protected:
     }
     else
     {
-      for (auto const& it : this->ConfigDic)
+      for (auto const& it : this->RegexConfigEntries)
       {
         std::regex re(it.first, std::regex_constants::icase);
         std::smatch matches;
@@ -204,10 +204,10 @@ private:
 
   std::string FilePathForConfigBlock;
 
-  using DictionaryEntry = std::map<std::string, std::string>;
-  using Dictionary = std::vector<std::pair<std::string, DictionaryEntry> >;
-  DictionaryEntry GlobalConfigDicEntry;
-  Dictionary ConfigDic;
+  using ConfigEntry = std::map<std::string, std::string>;
+  using ConfigEntries = std::vector<std::pair<std::string, ConfigEntry> >;
+  ConfigEntry GlobalConfigEntry;
+  ConfigEntries RegexConfigEntries;
   std::string ExecutableName;
   std::vector<std::string> AllLongOptions;
 };
@@ -671,7 +671,7 @@ void ConfigurationOptions::PrintReadersList()
 //----------------------------------------------------------------------------
 bool ConfigurationOptions::InitializeDictionaryFromConfigFile(const std::string& config)
 {
-  this->ConfigDic.clear();
+  this->RegexConfigEntries.clear();
 
   std::string configSearch = "config";
   if (!config.empty())
@@ -779,11 +779,11 @@ bool ConfigurationOptions::InitializeDictionaryFromConfigFile(const std::string&
       }
       if (regexpConfig.key() == "global")
       {
-        this->GlobalConfigDicEntry = localDic;
+        this->GlobalConfigEntry = localDic;
       }
       else
       {
-        this->ConfigDic.emplace_back(regexpConfig.key(), localDic);
+        this->RegexConfigEntries.emplace_back(regexpConfig.key(), localDic);
       }
     }
   }

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -196,6 +196,7 @@ f3d_test(NAME TestInvalidUpDirection DATA suzanne.ply ARGS -g --up=W REGEXP "W i
 f3d_test(NAME TestUpDirectionNoSign DATA suzanne.ply ARGS --up=X DEFAULT_LIGHTS)
 f3d_test(NAME TestTextureMatCap DATA suzanne.ply ARGS --texture-matcap=${F3D_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
 f3d_test(NAME TestTextureMatCapWithTCoords DATA WaterBottle.glb ARGS --geometry-only --texture-matcap=${F3D_SOURCE_DIR}/testing/data/skin.png DEFAULT_LIGHTS)
+f3d_test(NAME TestConfigOrder DATA suzanne.ply ARGS CONFIG ${F3D_SOURCE_DIR}/testing/data/config-order.json DEFAULT_LIGHTS)
 
 # Needs SSBO: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10675
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20231108)

--- a/testing/baselines/TestConfigOrder.png
+++ b/testing/baselines/TestConfigOrder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da64ad8407e5b93ec5f2120dd1081bf646b03f44204fa4d45ee7ac9688cec029
+size 24535

--- a/testing/data/config-order.json
+++ b/testing/data/config-order.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0402c6dc8183ec7c46d4cb71bff46451f6ab0fa4294b9725657d3a3d8638f5d1
+size 269


### PR DESCRIPTION
The config blocks are currently matched by regex in alphabetical order which is counter-intuitive.

Technically it makes sense because JSON specifies dictionaries as unordered collections and F3D uses `std::map` for storage, but this feels like unspecified behavior left to the implementation :(

This PR uses `nlohmann::ordered_json` and `std::vector<std::pair<...>>` to maintain the top-down declaration order form the config file.