### PR TITLE
Cleanup Static Build

### DIFF
--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Label to control egl'
     required: false
     default: 'no-egl'
+  static_label:
+    description: 'Label to control static build'
+    required: false
+    default: 'no-static'
   cpu:
     description: 'CPU architecture to build for'
     required: false
@@ -136,6 +140,7 @@ runs:
         -Werror=dev
         -Werror=deprecated
         --warn-uninitialized
+        -DBUILD_SHARED_LIBS=${{ inputs.static_label == 'static' && 'OFF' || 'ON' }}
         -DBUILD_TESTING=ON
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX:PATH=../install
@@ -227,7 +232,9 @@ runs:
         cmake --install . --component configuration
 
     - name: Build and configure python externally
-      if: inputs.optional_deps_label == 'optional-deps'
+      if: |
+        inputs.optional_deps_label == 'optional-deps' &&
+        inputs.static_label == 'no-static'
       shell: bash
       working-directory: ${{github.workspace}}
       run: |
@@ -235,6 +242,7 @@ runs:
         cmake --build build_python --config Release
 
     - name: Build and configure libf3d examples
+      if: inputs.static_label == 'no-static'
       shell: bash
       working-directory: ${{github.workspace}}
       run: |
@@ -244,14 +252,17 @@ runs:
     - name: Install Mesa Windows examples
       if: |
         runner.os == 'Windows' &&
-        inputs.vtk_version != 'v9.0.0' && inputs.vtk_version != 'v9.1.0'
+        inputs.vtk_version != 'v9.0.0' && inputs.vtk_version != 'v9.1.0' &&
+        inputs.static_label == 'no-static'
       uses: ./source/.github/actions/mesa-install-bin
       with:
         path: ${{github.workspace}}\build_examples\*\Release
 
     # older VTK version create different renderings so they are not tested
     - name: Test libf3d examples
-      if: inputs.vtk_version != 'v9.0.0' && inputs.vtk_version != 'v9.1.0'
+      if: |
+        inputs.vtk_version != 'v9.0.0' && inputs.vtk_version != 'v9.1.0' &&
+        inputs.static_label == 'no-static'
       shell: bash
       working-directory: ${{github.workspace}}
       run: ctest --test-dir build_examples -C Release -VV
@@ -264,6 +275,7 @@ runs:
       # CMAKE_MODULE_PATH is required because of
       # https://github.com/AcademySoftwareFoundation/openvdb/issues/1160
     - name: Build plugin examples
+      if: inputs.static_label == 'no-static'
       shell: bash
       working-directory: ${{github.workspace}}
       run: |
@@ -271,6 +283,7 @@ runs:
         cmake --build build_plugins --config Release
 
     - name: Test plugin examples
+      if: inputs.static_label == 'no-static'
       shell: bash
       working-directory: ${{github.workspace}}
       run: ctest --test-dir build_plugins -C Release -VV
@@ -308,7 +321,10 @@ runs:
     # Grid rendering has artifacts in macOS arm64 CI
     # https://github.com/f3d-app/f3d/issues/1276
     - name: Check F3D_PLUGINS_PATH using plugin example
-      if: inputs.vtk_version != 'v9.0.0' && inputs.vtk_version != 'v9.1.0' && inputs.vtk_version != 'v9.2.6' && inputs.cpu != 'arm64'
+      if: |
+        inputs.vtk_version != 'v9.0.0' && inputs.vtk_version != 'v9.1.0' && inputs.vtk_version != 'v9.2.6' && 
+        inputs.cpu != 'arm64' &&
+        inputs.static_label == 'no-static'
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: F3D_PLUGINS_PATH=$(pwd)/../build_plugins/example-plugin${{ runner.os == 'Windows' && '/Release' || null }} ${{ env.F3D_BIN_PATH }} ../source/examples/plugins/example-plugin/data.expl --load-plugins=example --output=../install_example_plugin_output.png --ref=../source/.github/baselines/install_example_plugin_output.png --resolution=300,300 --verbose

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -330,6 +330,7 @@ runs:
       run: F3D_PLUGINS_PATH=$(pwd)/../build_plugins/example-plugin${{ runner.os == 'Windows' && '/Release' || null }} ${{ env.F3D_BIN_PATH }} ../source/examples/plugins/example-plugin/data.expl --load-plugins=example --output=../install_example_plugin_output.png --ref=../source/.github/baselines/install_example_plugin_output.png --resolution=300,300 --verbose
 
     - name: Install plugin examples
+      if: inputs.static_label == 'no-static'
       shell: bash
       working-directory: ${{github.workspace}}
       run: |

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -133,6 +133,7 @@ runs:
       # CMAKE_MODULE_PATH is required because of
       # https://github.com/AcademySoftwareFoundation/openvdb/issues/1160
       # OCCT plugin causes issues with static build because it exports symbols with the executable for some reasons
+      # https://github.com/f3d-app/f3d/issues/1322
     - name: Configure
       shell: bash
       working-directory: ${{github.workspace}}/build

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -132,6 +132,7 @@ runs:
       # Exodus not supported on Apple Silicon because of #976
       # CMAKE_MODULE_PATH is required because of
       # https://github.com/AcademySoftwareFoundation/openvdb/issues/1160
+      # OCCT plugin causes issues with static build because it exports symbols with the executable for some reasons
     - name: Configure
       shell: bash
       working-directory: ${{github.workspace}}/build
@@ -162,7 +163,7 @@ runs:
         -DF3D_PLUGIN_BUILD_ASSIMP=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
         -DF3D_PLUGIN_BUILD_DRACO=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
         -DF3D_PLUGIN_BUILD_EXODUS=${{ inputs.cpu == 'x86_64' && inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_BUILD_OCCT=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_BUILD_OCCT=${{ inputs.optional_deps_label == 'optional-deps' && inputs.static_label == 'no-static' && 'ON' || 'OFF' }}
         -DF3D_PLUGIN_BUILD_USD=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
         -DF3D_PLUGIN_OCCT_COLORING_SUPPORT=${{ runner.os == 'macOS' && 'OFF' || 'ON' }}
         -DF3D_PLUGIN_BUILD_VDB=${{ matrix.vtk_version != 'v9.0.0' && matrix.vtk_version != 'v9.1.0' && matrix.vtk_version != 'v9.2.6' && inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -322,7 +322,7 @@ runs:
     # https://github.com/f3d-app/f3d/issues/1276
     - name: Check F3D_PLUGINS_PATH using plugin example
       if: |
-        inputs.vtk_version != 'v9.0.0' && inputs.vtk_version != 'v9.1.0' && inputs.vtk_version != 'v9.2.6' && 
+        inputs.vtk_version != 'v9.0.0' && inputs.vtk_version != 'v9.1.0' && inputs.vtk_version != 'v9.2.6' &&
         inputs.cpu != 'arm64' &&
         inputs.static_label == 'no-static'
       shell: bash
@@ -345,6 +345,15 @@ runs:
       working-directory: ${{github.workspace}}/install
       run: |
         ${{ env.F3D_BIN_PATH }} ../source/testing/data/suzanne.obj --output=output/install_output.png --ref=../source/.github/baselines/install_output.png --resolution=300,300 --verbose
+
+    - name: Check Install plugins
+      if: |
+        inputs.vtk_version != 'v9.0.0' && inputs.vtk_version != 'v9.1.0' && inputs.vtk_version != 'v9.2.6'
+        && inputs.cpu != 'arm64'
+        && inputs.static_label == 'no-static'
+      shell: bash
+      working-directory: ${{github.workspace}}/install
+      run: |
         ${{ env.F3D_BIN_PATH }} ../source/examples/plugins/example-plugin/data.expl --output=../install_example_plugin_output.png --ref=../source/.github/baselines/install_example_plugin_output.png  --resolution=300,300 --verbose
 
     - name: Upload Tests Install Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
       fail-fast: false
       matrix:
         vtk_version: [commit, v9.3.0, v9.2.6]
+        static_label: [no-static]
+        include:
+          - vtk_version: commit
+            static_label: static
 
     runs-on: windows-latest
 
@@ -69,6 +73,7 @@ jobs:
       with:
         vtk_version: ${{matrix.vtk_version}}
         raytracing_label: raytracing
+        static_label: ${{matrix.static_label}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
 
 #----------------------------------------------------------------------------
@@ -88,6 +93,7 @@ jobs:
           - exclude_deprecated_label: no-exclude-deprecated
           - optional_deps_label: optional-deps
           - egl_label: no-egl
+          - static_label: no-static
           - vtk_version: v9.0.0
             raytracing_label: no-raytracing
           - build_type: headless
@@ -96,18 +102,28 @@ jobs:
             optional_deps_label: optional-deps
             exclude_deprecated_label: no-exclude-deprecated
             egl_label: egl
+            static_label: no-static
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
             optional_deps_label: optional-deps
             exclude_deprecated_label: exclude-deprecated
             egl_label: no-egl
+            static_label: no-static
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
             optional_deps_label: no-optional-deps
             exclude_deprecated_label: no-exclude-deprecated
             egl_label: no-egl
+            static_label: no-static
+          - build_type: static_libs
+            vtk_version: commit
+            raytracing_label: no-raytracing
+            optional_deps_label: optional-deps
+            exclude_deprecated_label: no-exclude-deprecated
+            egl_label: no-egl
+            static_label: static
 
     runs-on: ubuntu-latest
     container: ghcr.io/f3d-app/f3d-ci
@@ -132,6 +148,7 @@ jobs:
         optional_deps_label: ${{matrix.optional_deps_label}}
         exclude_deprecated_label: ${{matrix.exclude_deprecated_label}}
         egl_label: ${{matrix.egl_label}}
+        static_label: ${{matrix.static_label}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
 
 #----------------------------------------------------------------------------
@@ -144,10 +161,6 @@ jobs:
       fail-fast: false
       matrix:
         vtk_version: [commit, v9.3.0, v9.2.6]
-        bundle_label: [no-bundle]
-        include:
-          - vtk_version: commit
-            bundle_label: bundle
 
     runs-on: macos-latest
 
@@ -163,12 +176,11 @@ jobs:
       uses: ./source/.github/actions/generic-ci
       with:
         vtk_version: ${{matrix.vtk_version}}
-        bundle_label: ${{matrix.bundle_label}}
         cpu: x86_64
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
 
 #----------------------------------------------------------------------------
-# MacOS ARM CI: Build and test, cross-vtk build matrix
+# MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
 #----------------------------------------------------------------------------
   macos_arm:
     if: github.event.pull_request.draft == false
@@ -182,6 +194,9 @@ jobs:
         include:
           - vtk_version: commit
             bundle_label: bundle
+        include:
+          - vtk_version: commit
+            static_label: static
 
     runs-on: macos-14
 
@@ -198,6 +213,7 @@ jobs:
       with:
         vtk_version: ${{matrix.vtk_version}}
         bundle_label: ${{matrix.bundle_label}}
+        static_label: ${{matrix.static_label}}
         cpu: arm64
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,6 @@ jobs:
       fail-fast: false
       matrix:
         vtk_version: [commit, v9.3.0, v9.2.6]
-        static_label: [no-static]
-        include:
-          - vtk_version: commit
-            static_label: static
 
     runs-on: windows-latest
 
@@ -73,7 +69,6 @@ jobs:
       with:
         vtk_version: ${{matrix.vtk_version}}
         raytracing_label: raytracing
-        static_label: ${{matrix.static_label}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
 
 #----------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
       fail-fast: false
       matrix:
         vtk_version: [commit, v9.3.0, v9.2.6]
+        static_label: [no-static]
+        include:
+          - vtk_version: commit
+            static_label: static
 
     runs-on: windows-latest
 
@@ -69,6 +73,7 @@ jobs:
       with:
         vtk_version: ${{matrix.vtk_version}}
         raytracing_label: raytracing
+        static_label: ${{matrix.static_label}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
 
 #----------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,10 +186,10 @@ jobs:
       matrix:
         vtk_version: [commit, v9.3.0, v9.2.6]
         bundle_label: [no-bundle]
+        static_label: [no-static]
         include:
           - vtk_version: commit
             bundle_label: bundle
-        include:
           - vtk_version: commit
             static_label: static
 

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -236,7 +236,10 @@ if(WIN32)
 else()
   set(_dirname "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 endif()
-f3d_test(NAME TestPluginNoInit ARGS --verbose --load-plugins=${_dirname}/${CMAKE_SHARED_LIBRARY_PREFIX}f3d${CMAKE_SHARED_LIBRARY_SUFFIX} NO_BASELINE REGEXP "Cannot find init_plugin symbol in library")
+
+if(BUILD_SHARED_LIBS)
+  f3d_test(NAME TestPluginNoInit ARGS --verbose --load-plugins=${_dirname}/${CMAKE_SHARED_LIBRARY_PREFIX}f3d${CMAKE_SHARED_LIBRARY_SUFFIX} NO_BASELINE REGEXP "Cannot find init_plugin symbol in library")
+endif()
 
 if(NOT F3D_MACOS_BUNDLE)
   # On linux, we can easily test the config file search from the binary code by positioning a config file in the binary dir
@@ -574,7 +577,7 @@ if(F3D_PLUGIN_BUILD_EXODUS)
     endif()
   endif()
 
-  if (NOT F3D_PLUGINS_STATIC_BUILD)
+  if (NOT F3D_PLUGINS_STATIC_BUILD AND BUILD_SHARED_LIBS)
 
     # Test --load-plugins with the name of a dynamic plugin
     f3d_test(NAME TestPluginName DATA disk_out_ref.ex2 ARGS --load-plugins=exodus --verbose NO_BASELINE REGEXP "Loaded plugin exodus from")

--- a/cmake/f3dPlugin.cmake
+++ b/cmake/f3dPlugin.cmake
@@ -175,7 +175,12 @@ macro(f3d_plugin_build)
                CommonCore CommonExecutionModel IOImport
                ${F3D_PLUGIN_VTK_MODULES})
 
-  if(F3D_PLUGIN_FORCE_STATIC OR F3D_PLUGINS_STATIC_BUILD OR NOT BUILD_SHARED_LIBS)
+  set(_force_static FALSE)
+  if(DEFINED BUILD_SHARED_LIBS AND NOT BUILD_SHARED_LIBS)
+    set(_force_static TRUE)
+  endif()
+
+  if(F3D_PLUGIN_FORCE_STATIC OR F3D_PLUGINS_STATIC_BUILD OR _force_static)
     set(F3D_PLUGIN_TYPE "STATIC")
     set(F3D_PLUGIN_IS_STATIC ON)
     set_property(GLOBAL APPEND PROPERTY F3D_STATIC_PLUGINS ${F3D_PLUGIN_NAME})

--- a/cmake/f3dPlugin.cmake
+++ b/cmake/f3dPlugin.cmake
@@ -175,7 +175,7 @@ macro(f3d_plugin_build)
                CommonCore CommonExecutionModel IOImport
                ${F3D_PLUGIN_VTK_MODULES})
 
-  if(F3D_PLUGIN_FORCE_STATIC OR F3D_PLUGINS_STATIC_BUILD)
+  if(F3D_PLUGIN_FORCE_STATIC OR F3D_PLUGINS_STATIC_BUILD OR NOT BUILD_SHARED_LIBS)
     set(F3D_PLUGIN_TYPE "STATIC")
     set(F3D_PLUGIN_IS_STATIC ON)
     set_property(GLOBAL APPEND PROPERTY F3D_STATIC_PLUGINS ${F3D_PLUGIN_NAME})
@@ -201,12 +201,6 @@ macro(f3d_plugin_build)
   list(APPEND f3d_plugin_link_options "${f3d_coverage_link_options}")
   list(APPEND f3d_plugin_link_options "${f3d_sanitizer_link_options}")
 
-  # if libf3d is built as a static library, VTK extension static libraries
-  # must be exported as well for proper linkage
-  set(export_name "")
-  if(NOT BUILD_SHARED_LIBS AND F3D_PLUGIN_IS_STATIC)
-    set(export_name "f3dTargets")
-  endif()
 
   vtk_module_find_modules(vtk_module_files "${CMAKE_CURRENT_SOURCE_DIR}")
 
@@ -220,11 +214,8 @@ macro(f3d_plugin_build)
 
     vtk_module_build(
       MODULES ${modules}
-      INSTALL_EXPORT ${export_name}
       INSTALL_HEADERS OFF
-      HEADERS_COMPONENT vtkext
-      TARGETS_COMPONENT vtkext
-      PACKAGE "f3d-plugin-${F3D_PLUGIN_NAME}")
+      PACKAGE "f3d_${F3D_PLUGIN_NAME}_vtkext_private")
 
     foreach (module IN LISTS modules)
       if(NOT "${f3d_plugin_compile_options}" STREQUAL "")
@@ -294,7 +285,7 @@ macro(f3d_plugin_build)
     ${F3D_PLUGIN_VTK_MODULES}
     ${modules})
 
-  if(NOT F3D_PLUGIN_IS_STATIC OR NOT BUILD_SHARED_LIBS)
+  if(NOT F3D_PLUGIN_IS_STATIC)
     install(TARGETS f3d-plugin-${F3D_PLUGIN_NAME}
       EXPORT ${export_name}
       ARCHIVE DESTINATION ${_f3d_plugins_install_dir} COMPONENT plugin

--- a/cmake/f3dPlugin.cmake
+++ b/cmake/f3dPlugin.cmake
@@ -292,7 +292,7 @@ macro(f3d_plugin_build)
 
   if(NOT F3D_PLUGIN_IS_STATIC)
     install(TARGETS f3d-plugin-${F3D_PLUGIN_NAME}
-       EXPORT f3dTargets
+      EXPORT f3dTargets
       ARCHIVE DESTINATION ${_f3d_plugins_install_dir} COMPONENT plugin
       LIBRARY DESTINATION ${_f3d_plugins_install_dir} COMPONENT plugin)
   endif()

--- a/cmake/f3dPlugin.cmake
+++ b/cmake/f3dPlugin.cmake
@@ -287,7 +287,7 @@ macro(f3d_plugin_build)
 
   if(NOT F3D_PLUGIN_IS_STATIC)
     install(TARGETS f3d-plugin-${F3D_PLUGIN_NAME}
-      EXPORT ${export_name}
+       EXPORT f3dTargets
       ARCHIVE DESTINATION ${_f3d_plugins_install_dir} COMPONENT plugin
       LIBRARY DESTINATION ${_f3d_plugins_install_dir} COMPONENT plugin)
   endif()

--- a/doc/dev/BUILD.md
+++ b/doc/dev/BUILD.md
@@ -36,6 +36,7 @@ Here is some CMake options of interest:
 * `F3D_WINDOWS_GUI`: On Windows, build a Win32 application (without console).
 * `F3D_WINDOWS_BUILD_SHELL_THUMBNAILS_EXTENSION`: On Windows, build the shell thumbnails extension.
 * `F3D_PLUGINS_STATIC_BUILD`: Build all plugins as static library (embedded into `libf3d`) and automatically loaded by the application. Incompatible with `F3D_MACOS_BUNDLE`.
+* `BUILD_SHARED_LIBS`: Build the libf3d and all plugins as static library (embedded into `f3d` executable). The `library` and `plugin_sdk` component will not be installed.
 
 Some modules, plugins and bindings depending on external libraries can be optionally enabled with the following CMake variables:
 

--- a/doc/libf3d/OVERVIEW.md
+++ b/doc/libf3d/OVERVIEW.md
@@ -125,7 +125,7 @@ For the complete documentation, please consult the [libf3d doxygen documentation
 
 ## Building against the libf3d
 
-Please follow instructions in the [F3D build guide](../dev/BUILD.md), and make sure to install the `sdk` component then use CMake to find the libf3d
+Please follow instructions in the [F3D build guide](../dev/BUILD.md), make sure to build with `BUILD_SHARED_LIBS=ON` and to install the `sdk` component then use CMake to find the libf3d
 and link against it like this in your CMakeLists.txt:
 
 ```cmake

--- a/doc/libf3d/PLUGINS.md
+++ b/doc/libf3d/PLUGINS.md
@@ -1,6 +1,7 @@
 # Plugin SDK
 
-When calling `find_package(f3d REQUIRED COMPONENTS pluginsdk)` in CMake, a few macros are made available to you to generate a plugin which allow you to extend libf3d to support your own file format. Access to a f3d::vtkext VTK module is also provided if needed.
+Please follow instructions in the [F3D build guide](../dev/BUILD.md), make sure to build with `BUILD_SHARED_LIBS=ON` and to install the `plugin_sdk` component.
+You will then be able to call `find_package(f3d REQUIRED COMPONENTS pluginsdk)` in your plugin CMakeLists.txt, a few macros are made available to you to generate a plugin which allow you to extend libf3d to support your own file format. Access to a f3d::vtkext VTK module is also provided if needed.
 > Please consider [contributing](../../CONTRIBUTING.md) your plugin in [F3D directly](https://github.com/f3d-app/f3d/tree/master/plugins) if you think it can be useful to the community.
 > You can also consider contributing directly [in VTK](https://gitlab.kitware.com/vtk/vtk/blob/master/Documentation/dev/git/develop.md).
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -195,7 +195,30 @@ if(BUILD_TESTING)
 endif()
 
 # Installing
+
+## Install f3dConfig.cmake and f3dVersion.cmake so the f3d::f3d target can be found
+## Even without BUILD_SHARED_LIBS
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${F3D_SOURCE_DIR}/cmake/f3dConfig.cmake.in" "${CMAKE_BINARY_DIR}/cmake/f3dConfig.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/f3d")
+write_basic_package_version_file(
+  "${CMAKE_BINARY_DIR}/cmake/f3dConfigVersion.cmake"
+  VERSION "${F3D_VERSION}"
+  COMPATIBILITY SameMajorVersion)
+install(
+  FILES
+    "${CMAKE_BINARY_DIR}/cmake/f3dConfig.cmake"
+    "${CMAKE_BINARY_DIR}/cmake/f3dConfigVersion.cmake"
+  DESTINATION
+    "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
+  COMPONENT sdk
+  EXCLUDE_FROM_ALL)
+
+## Install the rest of the libraries and SDK parts
 if(BUILD_SHARED_LIBS)
+
+  # Install the libf3d
   install(TARGETS libf3d
     EXPORT f3dLibraryTargets
     RUNTIME_DEPENDENCY_SET libf3dDeps
@@ -212,31 +235,22 @@ if(BUILD_SHARED_LIBS)
     POST_EXCLUDE_REGEXES ".*system32/.*" "^/usr/lib.*" "^/lib.*" "^/var/lib.*"
     DIRECTORIES "${F3D_DEPENDENCIES_DIR}")
 
+  # Install the public headers
   install(FILES ${F3D_PUBLIC_HEADERS}
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/f3d"
     COMPONENT sdk
     EXCLUDE_FROM_ALL)
 
+  # Install the library exported targets
   install(EXPORT f3dLibraryTargets
     NAMESPACE f3d::
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
     COMPONENT sdk
     EXCLUDE_FROM_ALL)
 
-  include(CMakePackageConfigHelpers)
-  configure_package_config_file(
-    "${F3D_SOURCE_DIR}/cmake/f3dConfig.cmake.in" "${CMAKE_BINARY_DIR}/cmake/f3dConfig.cmake"
-    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/f3d")
-
-  write_basic_package_version_file(
-    "${CMAKE_BINARY_DIR}/cmake/f3dConfigVersion.cmake"
-    VERSION "${F3D_VERSION}"
-    COMPATIBILITY SameMajorVersion)
-
+  # Install library cmake files
   install(
     FILES
-      "${CMAKE_BINARY_DIR}/cmake/f3dConfig.cmake"
-      "${CMAKE_BINARY_DIR}/cmake/f3dConfigVersion.cmake"
       "${F3D_SOURCE_DIR}/cmake/library-config.cmake"
       "${F3D_SOURCE_DIR}/cmake/f3dEmbed.cmake"
     DESTINATION
@@ -244,11 +258,13 @@ if(BUILD_SHARED_LIBS)
     COMPONENT sdk
     EXCLUDE_FROM_ALL)
 
+  # Install plugin headers
   install(FILES ${F3D_PLUGIN_HEADERS}
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/f3d"
     COMPONENT plugin_sdk
     EXCLUDE_FROM_ALL)
 
+  # Install pluginsdk cmake and source files
   install(
     FILES
       "${F3D_SOURCE_DIR}/cmake/pluginsdk-config.cmake"

--- a/vtkext/private/CMakeLists.txt
+++ b/vtkext/private/CMakeLists.txt
@@ -6,26 +6,9 @@ vtk_module_scan(
   WANT_BY_DEFAULT   ON
   ENABLE_TESTS      ${BUILD_TESTING})
 
-# if libf3d is built as a static library, VTK extension static libraries
-# must be exported as well for proper linkage
-set(export_name "")
-set(f3d_vtk_no_install "")
-if(NOT BUILD_SHARED_LIBS)
-  set(export_name "f3dTargets")
-else()
-  if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220928)
-    set(f3d_vtk_no_install "NO_INSTALL")
-  endif()
-endif()
-
-# We need HEADERS_COMPONENT because of a bug in vtk_module_build in VTK <= 9.1
-# See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9192
 vtk_module_build(
   MODULES ${modules}
-  INSTALL_EXPORT ${export_name}
   INSTALL_HEADERS OFF
-  HEADERS_COMPONENT vtkext
-  TARGETS_COMPONENT vtkext
   PACKAGE "f3d_vtkext_private")
 
 # We need non empty cmake vars for these calls for VTK <= 9.1

--- a/vtkext/private/module/CMakeLists.txt
+++ b/vtkext/private/module/CMakeLists.txt
@@ -72,8 +72,13 @@ if(F3D_MODULE_EXR)
   list(APPEND classes vtkF3DEXRReader)
 endif()
 
+set(_no_install "")
+if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220928)
+  set(_no_install "NO_INSTALL")
+endif()
+
 vtk_module_add_module(f3d::vtkextPrivate
-  ${f3d_vtk_no_install}
+  ${_no_install}
   FORCE_STATIC
   CLASSES ${classes}
   SOURCES ${sources}

--- a/vtkext/public/CMakeLists.txt
+++ b/vtkext/public/CMakeLists.txt
@@ -22,8 +22,10 @@ if(BUILD_SHARED_LIBS)
   set(export_name "f3d_vtkext")
   set(headers_component "plugin_sdk")
 else()
-  # When building as a static lib, the module is not installed at all
-  set(f3d_vtk_no_install "NO_INSTALL")
+  if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220928)
+    # When building as a static lib, the module is not installed at all
+    set(f3d_vtk_no_install "NO_INSTALL")
+  endif()
 endif()
 
 vtk_module_build(

--- a/vtkext/public/CMakeLists.txt
+++ b/vtkext/public/CMakeLists.txt
@@ -13,13 +13,24 @@ if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20240312)
   set(f3d_vtkext_headers_exclude "HEADERS_EXCLUDE_FROM_ALL;ON")
 endif()
   
-# The headers and all "dev" part are installed as part of the plugin SDK
-# The library itself is installed as part of the library
+set(export_name "")
+set(headers_component "")
+set(f3d_vtk_no_install "")
+if(BUILD_SHARED_LIBS)
+  # The headers and all "dev" part are installed as part of the plugin SDK
+  # The library itself is installed as part of the library
+  set(export_name "f3d_vtkext")
+  set(headers_component "plugin_sdk")
+else()
+  # When building as a static lib, the module is not installed at all
+  set(f3d_vtk_no_install "NO_INSTALL")
+endif()
+
 vtk_module_build(
   MODULES ${modules}
-  INSTALL_EXPORT "f3d_vtkext"
+  INSTALL_EXPORT ${export_name}
   INSTALL_HEADERS ON
-  HEADERS_COMPONENT plugin_sdk
+  HEADERS_COMPONENT ${headers_component}
   ${f3d_vtkext_headers_exclude}
   HEADERS_DESTINATION "include/f3d"
   TARGETS_COMPONENT library

--- a/vtkext/public/module/CMakeLists.txt
+++ b/vtkext/public/module/CMakeLists.txt
@@ -26,6 +26,7 @@ if(NOT ANDROID AND NOT EMSCRIPTEN AND VTK_VERSION VERSION_GREATER_EQUAL 9.3.2024
 endif()
 
 vtk_module_add_module(f3d::vtkext
+  ${f3d_vtk_no_install}
   CLASSES ${classes}
   SOURCES ${sources}
   PRIVATE_HEADERS ${private_headers}


### PR DESCRIPTION
 - Fix build with  `-DBUILD_SHARED_LIBS=OFF`
 - Clearly state the using the library and plugins component require BUILD_SHARED_LIBS
 - Fix installation with  `-DBUILD_SHARED_LIBS=OFF` so that the f3d application component can be found
 - Update tests to be compatible with `-DBUILD_SHARED_LIBS=OFF`
 - Add static build CI for all OSes
 - Focus macOS CI on arm64 to avoid CI slowing down.