### PR TITLE
Fix fish completion when an option is specified in comments

### DIFF
--- a/resources/completion.fish
+++ b/resources/completion.fish
@@ -1,3 +1,3 @@
-set -l compl_cmds (f3d --help 2>&1 | sed '1,/Examples/!d' | grep "[-]-" | sed 's/-\(.\),/-s \1/g' | sed 's/=.*>//g' | sed 's/--\([^ ]*\) *\(.*\)/-l \1 -d \'\2\'/g' | sed 's/^ */complete -c f3d /')
+set -l compl_cmds (f3d --help 2>&1 | sed '1,/Examples/!d' | grep "[, ] [-]-" | sed 's/-\(.\),/-s \1/g' | sed 's/=.*>//g' | sed 's/--\([^ ]*\) *\(.*\)/-l \1 -d \'\2\'/g' | sed 's/^ */complete -c f3d /')
 
 for current_cmd in $compl_cmds; eval $current_cmd; end


### PR DESCRIPTION
Fix a fish issue caused by the string `--verbose` wrongly grepped as a long option although it's inside another option description:
```
      --no-render               Do not render anything and quit right after 
                                loading the first file, use with --verbose 
                                to recover information about a file.
```

![image](https://github.com/f3d-app/f3d/assets/6069752/ece1ab52-6966-44ae-afb2-b66eae821121)
