### PR TITLE
Fix zsh completion when an option is specified in comments

### DIFF
--- a/resources/completion.zsh
+++ b/resources/completion.zsh
@@ -8,7 +8,7 @@ local f3dhelp
 f3dhelp=$(f3d --help 2>&1 | sed '1,/Examples/!d' | sed 's/\[.*\] *//')
 
 shortopts=$(echo $f3dhelp | grep "^\s*[-].," | sed "s/^ *\(-.\), *--[^ ]* *\(.*\)$/\1[\2]/")
-longopts=$(echo $f3dhelp | grep "[-]-" | sed 's/=.*>//g' | sed 's/-.,//g' | sed "s/^ *\([^ ]*\) *\(.*\)$/\1[\2]/g")
+longopts=$(echo $f3dhelp | grep "[, ] [-]-" | sed 's/=.*>//g' | sed 's/-.,//g' | sed "s/^ *\([^ ]*\) *\(.*\)$/\1[\2]/g")
 
 arguments=("${(f)shortopts}")
 arguments+=("${(f)longopts}")


### PR DESCRIPTION
For #1361. Solution is the same as for #1325.

As I mentioned in https://github.com/f3d-app/f3d/issues/1361#issuecomment-2037240490, this works as a quick fix but it would still be nice to fix multi-line helptext in general.

I verified this works on Ubuntu and MacOS (the same versions as listed in #1361)