### PR TITLE
Fix incorrect usage of internal variable PACKAGE_PREFIX_DIR

### DIFF
--- a/cmake/f3dConfig.cmake.in
+++ b/cmake/f3dConfig.cmake.in
@@ -10,6 +10,7 @@
 #   f3d_MODULE_EXTERNAL_RENDERING  Will be enabled if F3D was built with external rendering support
 #   f3d_MODULE_RAYTRACING          Will be enabled if F3D was built with raytracing support
 #   f3d_PLUGINS_INSTALL_DIR        Path to the location to install plugins so that F3D can find them
+#   f3d_PREFIX_DIR                 Absolute path to the directory where F3D was installed
 #
 # It is also possible to look for optional components.
 #
@@ -38,6 +39,8 @@
 # Please note, if no components are set, `library` will be added by default
 
 @PACKAGE_INIT@
+
+get_filename_component(f3d_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
 
 include(${CMAKE_CURRENT_LIST_DIR}/f3dConfigVersion.cmake)
 message(STATUS "Found f3d ${PACKAGE_VERSION}")

--- a/cmake/library-config.cmake
+++ b/cmake/library-config.cmake
@@ -2,7 +2,7 @@
 include("${CMAKE_CURRENT_LIST_DIR}/f3dLibraryTargets.cmake")
 
 # Provide f3d_INCLUDE_DIR
-set_and_check(f3d_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(f3d_INCLUDE_DIR "${f3d_PREFIX_DIR}/include")
 
 # Set the required variable
 message(STATUS "Found f3d library component")

--- a/cmake/pluginsdk-config.cmake
+++ b/cmake/pluginsdk-config.cmake
@@ -8,7 +8,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/f3dPlugin.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/../f3d_vtkext/f3d_vtkext-targets.cmake")
 
 # Provide f3d_INCLUDE_DIR
-set_and_check(f3d_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(f3d_INCLUDE_DIR "${f3d_PREFIX_DIR}/include")
 
 # Set the required variable
 message(STATUS "Found f3d plugin component")


### PR DESCRIPTION
See https://discourse.cmake.org/t/cmake-v3-29-1-regression-up-to-cmake-3-29-is-fine/10628/7 for more info about the "regression" in CMake and why this is needed.