### PR TITLE
Fix occt 7_8_0 module logic and update OCCT in CI

### DIFF
--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: dependencies/occt_install
-        key: occt-V7_7_2-${{runner.os}}-${{inputs.cpu}}-2
+        key: occt-V7_8_1-${{runner.os}}-${{inputs.cpu}}-0
 
     - name: Checkout OCCT
       if: steps.cache-occt.outputs.cache-hit != 'true'
@@ -24,7 +24,7 @@ runs:
         repository: Open-Cascade-SAS/OCCT
         submodules: true
         path: './dependencies/occt'
-        ref: V7_7_2
+        ref: V7_8_1
 
     - name: Patch OCCT
       if: steps.cache-occt.outputs.cache-hit != 'true'
@@ -49,7 +49,7 @@ runs:
       shell: bash
       run: >
         cmake ../occt
-        -DBUILD_ADDITIONAL_TOOLKITS="TKSTEP;TKIGES;TKMesh;TKXDESTEP;TKXDEIGES"
+        -DBUILD_ADDITIONAL_TOOLKITS="TKDESTEP;TKDEIGES;TKMesh"
         -DBUILD_DOC_Overview=OFF
         -DBUILD_LIBRARY_TYPE=Shared
         -DBUILD_MODULE_ApplicationFramework=OFF

--- a/plugins/occt/CMakeLists.txt
+++ b/plugins/occt/CMakeLists.txt
@@ -29,17 +29,13 @@ endif()
 
 message(STATUS "Plugin: OpenCASCADE ${OpenCASCADE_VERSION} found")
 
-option(F3D_PLUGIN_OCCT_COLORING_SUPPORT "Enable coloring support in occt plugin" ON)
-mark_as_advanced(F3D_PLUGIN_OCCT_COLORING_SUPPORT)
-
-if(F3D_PLUGIN_OCCT_COLORING_SUPPORT)
-  if("${OpenCASCADE_VERSION}" VERSION_LESS "7.8.0")
+# For 7_8_0 and above, coloring is always available in TKDE* modules
+if("${OpenCASCADE_VERSION}" VERSION_LESS "7.8.0")
+  option(F3D_PLUGIN_OCCT_COLORING_SUPPORT "Enable coloring support in occt plugin" ON)
+  mark_as_advanced(F3D_PLUGIN_OCCT_COLORING_SUPPORT)
+  if(F3D_PLUGIN_OCCT_COLORING_SUPPORT)
     if (NOT (TARGET "TKXDESTEP") OR NOT (TARGET "TKXDEIGES"))
       message(FATAL_ERROR "occt plugin: TKXDESTEP and TKXDEIGES OCCT modules are not found. Turn off F3D_PLUGIN_OCCT_COLORING_SUPPORT or enable them in your OpenCascade build.")
-    endif()
-  else()
-    if (NOT (TARGET "TKXSDRAWSTEP") OR NOT (TARGET "TKXSDRAWIGES"))
-        message(FATAL_ERROR "occt plugin: TKXSDRAWSTEP and TKXSDRAWIGES OCCT modules are not found. Turn off F3D_PLUGIN_OCCT_COLORING_SUPPORT or enable them in your OpenCascade build.")
     endif()
   endif()
 endif()

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -492,7 +492,8 @@ public:
     return this->ShapeTool->GetShape(label, aShape) ? aShape.HashCode(INT_MAX) : 0;
 #else
     // OCCT V7_8_0 returns a size_t, casting to avoid warnings
-    return static_cast<int>(this->ShapeTool->GetShape(label, aShape) ? std::hash<TopoDS_Shape>{}(aShape) : 0);
+    return static_cast<int>(
+      this->ShapeTool->GetShape(label, aShape) ? std::hash<TopoDS_Shape>{}(aShape) : 0);
 #endif
   }
 

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -491,7 +491,8 @@ public:
 #if OCC_VERSION_HEX < 0x070800
     return this->ShapeTool->GetShape(label, aShape) ? aShape.HashCode(INT_MAX) : 0;
 #else
-    return this->ShapeTool->GetShape(label, aShape) ? std::hash<TopoDS_Shape>{}(aShape) : 0;
+    // OCCT V7_8_0 returns a size_t, casting to avoid warnings
+    return static_cast<int>(this->ShapeTool->GetShape(label, aShape) ? std::hash<TopoDS_Shape>{}(aShape) : 0);
 #endif
   }
 


### PR DESCRIPTION
 - Fix incorrect OCCT module logic introduced in https://github.com/f3d-app/f3d/pull/1306
 - Update OCCT to V7_8_0 in CI
 
 To backport to release branch: 536e00025df0827cd757e54d3aab0eb28ed95abb