### PR TITLE
OCCT: Cleanup F3D_PLUGIN_OCCT_COLORING_SUPPORT

### DIFF
--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -168,7 +168,6 @@ runs:
         -DF3D_PLUGIN_BUILD_EXODUS=${{ inputs.cpu == 'x86_64' && inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
         -DF3D_PLUGIN_BUILD_OCCT=${{ inputs.optional_deps_label == 'optional-deps' && inputs.static_label == 'no-static' && 'ON' || 'OFF' }}
         -DF3D_PLUGIN_BUILD_USD=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_OCCT_COLORING_SUPPORT=${{ runner.os == 'macOS' && 'OFF' || 'ON' }}
         -DF3D_PLUGIN_BUILD_VDB=${{ matrix.vtk_version != 'v9.0.0' && matrix.vtk_version != 'v9.1.0' && matrix.vtk_version != 'v9.2.6' && (runner.os != 'Windows' || matrix.vtk_version != 'v9.3.0') && inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
         -DF3D_STRICT_BUILD=ON
         -DF3D_WINDOWS_GUI=ON

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -83,7 +83,6 @@ runs:
         -DF3D_PLUGIN_BUILD_OCCT=ON;
         -DF3D_PLUGIN_BUILD_USD=ON;
         -DF3D_PLUGIN_BUILD_VDB=${{ runner.os == 'macOS' && 'OFF' || 'ON' }};
-        -DF3D_PLUGIN_OCCT_COLORING_SUPPORT=ON;
         -DF3D_MODULE_EXR=ON;
         -DF3D_MODULE_EXTERNAL_RENDERING=ON" >> $GITHUB_ENV
 

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -619,15 +619,17 @@ if(F3D_PLUGIN_BUILD_OCCT)
 
   f3d_test(NAME TestInvalidBREP DATA invalid.brep ARGS --verbose --load-plugins=occt NO_BASELINE)
 
-  if(F3D_PLUGIN_OCCT_COLORING_SUPPORT AND NOT F3D_MACOS_BUNDLE)
+  if(F3D_PLUGIN_OCCT_COLORING_SUPPORT)
     f3d_test(NAME TestXCAFColors DATA xcaf-colors.stp DEFAULT_LIGHTS ARGS --load-plugins=occt -csy --up=+Z --line-width=3 --camera-direction=-1,-1,-1)
 
-    file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
-    f3d_test(NAME TestDefaultConfigFileOCCT DATA f3d.stp CONFIG config_build LONG_TIMEOUT DEFAULT_LIGHTS)
+    if (NOT F3D_MACOS_BUNDLE)
+      file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/config.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/config_build.d")
+      f3d_test(NAME TestDefaultConfigFileOCCT DATA f3d.stp CONFIG config_build LONG_TIMEOUT DEFAULT_LIGHTS)
 
-    if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)
-      file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
-      f3d_test(NAME TestThumbnailConfigFileOCCT DATA f3d.stp CONFIG thumbnail_build LONG_TIMEOUT DEFAULT_LIGHTS)
+      if(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)
+        file(COPY "${F3D_SOURCE_DIR}/plugins/occt/configs/thumbnail.d/" DESTINATION "${CMAKE_BINARY_DIR}/share/f3d/configs/thumbnail_build.d")
+        f3d_test(NAME TestThumbnailConfigFileOCCT DATA f3d.stp CONFIG thumbnail_build LONG_TIMEOUT DEFAULT_LIGHTS)
+      endif()
     endif()
   endif()
 endif()

--- a/plugins/occt/CMakeLists.txt
+++ b/plugins/occt/CMakeLists.txt
@@ -38,6 +38,16 @@ if("${OpenCASCADE_VERSION}" VERSION_LESS "7.8.0")
       message(FATAL_ERROR "occt plugin: TKXDESTEP and TKXDEIGES OCCT modules are not found. Turn off F3D_PLUGIN_OCCT_COLORING_SUPPORT or enable them in your OpenCascade build.")
     endif()
   endif()
+else()
+  if(APPLE)
+    # On macOS, cell scalar coloring is not supported and the default configuration for STEP file
+    # makes it very obvious.
+    # The simplest fix for now is to force coloring support to false
+    # https://github.com/f3d-app/f3d/issues/792
+    set(F3D_PLUGIN_OCCT_COLORING_SUPPORT OFF CACHE INTERNAL "")
+  else()
+    set(F3D_PLUGIN_OCCT_COLORING_SUPPORT ON CACHE INTERNAL "")
+  endif()
 endif()
 
 f3d_plugin_init()


### PR DESCRIPTION
With OCCT 7_8_0, Coloring is always supported, so this hides the CMake option to enable/disable the feature.

However, since it is not supported on macOS because of a bug, I set it to OFF in that case. Not enterely sure this is the right logic though.

https://github.com/f3d-app/f3d/issues/792
