### PR TITLE
Disable warning on macos with dmon.h

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -15,6 +15,11 @@
 // dmon includes Windows.h which defines 'ERROR' and conflicts with log.h
 #undef ERROR
 #pragma warning(pop)
+#elif __APPLE__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#include "dmon.h"
+#pragma clang diagnostic pop
 #else
 #include "dmon.h"
 #endif


### PR DESCRIPTION
Silent the following warning:

```
[1/2] Building CXX object application/CMakeFiles/f3d.dir/F3DStarter.cxx.o
In file included from /Users/michael/dev/f3d/application/F3DStarter.cxx:21:
/Users/michael/dev/f3d/external/dmon/dmon.h:1481:17: warning: 'FSEventStreamScheduleWithRunLoop' is deprecated: first deprecated in macOS 13.0 - Use FSEventStreamSetDispatchQueue instead. [-Wdeprecated-declarations]
                FSEventStreamScheduleWithRunLoop(watch->fsev_stream_ref, _dmon.cf_loop_ref, kCFRunLoopDefaultMode);
                ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/FSEvents.framework/Headers/FSEvents.h:1153:1: note: 'FSEventStreamScheduleWithRunLoop' has been explicitly marked deprecated here
FSEventStreamScheduleWithRunLoop(
^
1 warning generated.
```