### PR TITLE
CI: Fix coverage again

### DIFF
--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -4,6 +4,10 @@ inputs:
   lfs_sha:
     description: 'Cache LFS sha'
     required: true
+  codecov_token:
+    description: 'Codecov token, needed for non-forked workflows'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -108,6 +112,7 @@ runs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
+        token: ${{inputs.codecov_token}}
         fail_ci_if_error: true
         files: ${{github.workspace}}/source/coverage.info
         verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,7 @@ jobs:
       uses: ./source/.github/actions/coverage-ci
       with:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        codecov_token: ${{secrets.CODECOV_TOKEN}}
 
 #----------------------------------------------------------------------------
 # Sanitizer: Build and test on linux with last VTK with sanitizer options

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,4 @@
 codecov:
-  token: 7d2ecd8b-ac89-4c2d-ad05-119518130cb2
   notify:
     after_n_builds: 1
     wait_for_ci: yes


### PR DESCRIPTION
Here is the corrected version of codecov:

 - forked workflow use tokenless upload
 - non-forked workflow uses secrect token
 - the token is empty when run in forks, but codecov action does not even look at it