### PR TITLE
AppOptions: Extract filename for executable name

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -34,7 +34,7 @@ public:
     : Argc(argc)
     , Argv(argv)
   {
-    this->ExecutableName = argc > 0 && argv[0][0] ? argv[0] : "f3d";
+    this->ExecutableName = argc > 0 && argv[0][0] ? fs::path(argv[0]).filename().string() : "f3d";
   }
 
   void GetOptions(F3DAppOptions& appOptions, f3d::options& options,


### PR DESCRIPTION
Fix https://github.com/f3d-app/f3d/issues/1376