### PR TITLE
Add dedicated animation documentation

### DIFF
--- a/doc/user/ANIMATIONS.md
+++ b/doc/user/ANIMATIONS.md
@@ -1,22 +1,26 @@
-F3D can play animations for a number of file formats (.ex2/.e/.exo/.g, .gltf/.glb, .fbx, .dae, .x, .usd) if the file contains an animation.
+#Animations
+
+F3D is able to play animations for any files which contain them.
+Play them either interactively or by selecting a specific time to display.
+For files containing multiple animations, F3D allows the user to either play each animation separately or play all animations at the same time.
 ## Demonstration
 This specific example uses an animation file which can be downloaded [here](https://github.com/f3d-app/f3d/blob/606089959c9520085a9cbf70660fb0ffc68fb934/testing/data/InterpolationTest.glb).
 
-<img width="305" alt="Screenshot 2024-05-07 at 3 25 14 PM" src="https://github.com/f3d-app/f3d/assets/2395780/9b92e833-d497-4fca-a75c-ce651ae973f6">
+<img width="1024" alt="1" src="https://github.com/f3d-app/f3d/assets/2395780/1402c513-b3fd-454b-84a4-738eb41a1ccf">
 
 Load the example animation file shown above by executing within command line: `f3d InterpolationTest.glb`
 
-<img width="1105" alt="Screenshot 2024-05-07 at 1 16 37 PM" src="https://github.com/f3d-app/f3d/assets/2395780/2668544e-7744-4adc-8867-e83579e9c915">
+<img width="1024" alt="2" src="https://github.com/f3d-app/f3d/assets/2395780/eb3fbb74-5ccd-482f-9de7-92017285c73a">
 To view current animation name, press <kbd>H</kbd> to open up cheatsheet menu
 
-<img width="1079" alt="Screenshot 2024-05-07 at 4 03 08 PM" src="https://github.com/f3d-app/f3d/assets/2395780/8789180c-b470-441c-8395-c010a44941e6">
+<img width="1024" alt="3" src="https://github.com/f3d-app/f3d/assets/2395780/5eedaaf5-a355-4742-b2f4-bdae27054f17">
 Press <kbd>W</kbd> to cycle through available animations
 
-<img width="1112" alt="Screenshot 2024-05-07 at 3 59 44 PM" src="https://github.com/f3d-app/f3d/assets/2395780/073c4670-1db6-4411-b571-85c41be93039">
+<img width="1024" alt="4" src="https://github.com/f3d-app/f3d/assets/2395780/446e9d31-fc95-4b99-81b0-e54ca8ef1998">
 Press <kbd>space</kbd> to play/pause current animation.
 Note: A red bar runs along the bottom of screen to indicate the current time interval of the animation sequence.
 
-<img width="1108" alt="Screenshot 2024-05-07 at 3 48 15 PM" src="https://github.com/f3d-app/f3d/assets/2395780/5f2ccff1-7c71-44eb-95dc-38d67161e247">
+<img width="1024" alt="5" src="https://github.com/f3d-app/f3d/assets/2395780/59e1e8ae-78e6-4edc-9c87-c7b06d3bba5f">
 "All Animations" will play all animations at the same time.
 
 ## Command line options

--- a/doc/user/ANIMATIONS.md
+++ b/doc/user/ANIMATIONS.md
@@ -1,4 +1,4 @@
-#Animations
+# Animations
 
 F3D is able to play animations for any files which contain them.
 Play them either interactively or by selecting a specific time to display.

--- a/doc/user/ANIMATIONS.md
+++ b/doc/user/ANIMATIONS.md
@@ -1,7 +1,9 @@
+F3D can play animations for a number of file formats (.ex2/.e/.exo/.g, .gltf/.glb, .fbx, .dae, .x, .usd) if the file contains an animation.
 ## Demonstration
-This specific example uses an animation file which can be downloaded here: <\insert download link for: `InterpolationTest.glb`>\
+This specific example uses an animation file which can be downloaded [here](https://github.com/f3d-app/f3d/blob/606089959c9520085a9cbf70660fb0ffc68fb934/testing/data/InterpolationTest.glb).
 
 <img width="305" alt="Screenshot 2024-05-07 at 3 25 14 PM" src="https://github.com/f3d-app/f3d/assets/2395780/9b92e833-d497-4fca-a75c-ce651ae973f6">
+
 Load the example animation file shown above by executing within command line: `f3d InterpolationTest.glb`
 
 <img width="1105" alt="Screenshot 2024-05-07 at 1 16 37 PM" src="https://github.com/f3d-app/f3d/assets/2395780/2668544e-7744-4adc-8867-e83579e9c915">
@@ -30,12 +32,5 @@ F3D animation behavior can be fully controlled from the command line using the f
 ## Animation Interactions
 - Press <kbd>W</kbd> to cycle through animations
 - Press <kbd>Space</kbd> to play/pause animation
-## Supported File Types
-- ex2/.e/.exo/.g
-- .gltf/.glb
-- .fbx
-- .dae
-- .x
-- .usd
 ## Time Units
 - When F3D plays an animation, it assumes the time unit is in seconds to show accurate speed of animation.

--- a/doc/user/ANIMATIONS.md
+++ b/doc/user/ANIMATIONS.md
@@ -1,0 +1,41 @@
+## Demonstration
+This specific example uses an animation file which can be downloaded here: <\insert download link for: `InterpolationTest.glb`>\
+
+<img width="305" alt="Screenshot 2024-05-07 at 3 25 14 PM" src="https://github.com/f3d-app/f3d/assets/2395780/9b92e833-d497-4fca-a75c-ce651ae973f6">
+Load the example animation file shown above by executing within command line: `f3d InterpolationTest.glb`
+
+<img width="1105" alt="Screenshot 2024-05-07 at 1 16 37 PM" src="https://github.com/f3d-app/f3d/assets/2395780/2668544e-7744-4adc-8867-e83579e9c915">
+To view current animation name, press <kbd>H</kbd> to open up cheatsheet menu
+
+<img width="1079" alt="Screenshot 2024-05-07 at 4 03 08 PM" src="https://github.com/f3d-app/f3d/assets/2395780/8789180c-b470-441c-8395-c010a44941e6">
+Press <kbd>W</kbd> to cycle through available animations
+
+<img width="1112" alt="Screenshot 2024-05-07 at 3 59 44 PM" src="https://github.com/f3d-app/f3d/assets/2395780/073c4670-1db6-4411-b571-85c41be93039">
+Press <kbd>space</kbd> to play/pause current animation.
+Note: A red bar runs along the bottom of screen to indicate the current time interval of the animation sequence.
+
+<img width="1108" alt="Screenshot 2024-05-07 at 3 48 15 PM" src="https://github.com/f3d-app/f3d/assets/2395780/5f2ccff1-7c71-44eb-95dc-38d67161e247">
+"All Animations" will play all animations at the same time.
+
+## Command line options
+
+F3D animation behavior can be fully controlled from the command line using the following options.
+
+| Options                      | Default             | Description                                    |
+| ---------------------------- | ------------------- | ---------------------------------------------- |
+| \-\-animation\-index         |                     | Select the animation to play.                  |
+| \-\-animation\-index=-1      |                     | Play all animations at once (.gltf/.glb only). |
+| \-\-animation\-speed\-factor | Time Unit = Seconds | Adjust time unit.                              |
+| \-\-animation\-frame\-rate   | 60 FPS              | Adjust animation frame rate.                   |
+## Animation Interactions
+- Press <kbd>W</kbd> to cycle through animations
+- Press <kbd>Space</kbd> to play/pause animation
+## Supported File Types
+- ex2/.e/.exo/.g
+- .gltf/.glb
+- .fbx
+- .dae
+- .x
+- .usd
+## Time Units
+- When F3D plays an animation, it assumes the time unit is in seconds to show accurate speed of animation.

--- a/doc/user/README_USER.md
+++ b/doc/user/README_USER.md
@@ -4,6 +4,7 @@
 - [How to install F3D.](INSTALLATION.md)
 - [List of all F3D command line options.](OPTIONS.md)
 - [The different interactions in F3D.](INTERACTIONS.md)
+- [How to use animations in F3D.](ANIMATIONS.md)
 - [How to use colormaps in F3D.](COLOR_MAPS.md)
 - [How to configure F3D using a configuration file.](CONFIGURATION_FILE.md)
 - [How to integrate F3D in your desktop.](DESKTOP_INTEGRATION.md)


### PR DESCRIPTION
Closes [#1258](https://github.com/f3d-app/f3d/issues/1258)

I wrote a draft for the improved animation documentation which consists of:

- demonstration example
- command line options
- hotkey interactions
- supported file types
- time units

I used InterpolationTest.glb for the example since it was personally the most helpful animation file for me to better understand how animations work in F3D. Being new to 3D graphics, the idea of multiple animation sequences attached to one model was quite confusing for me at first.

This file is currently only available for F3D developers to download. I wonder if F3D can have an official download link for regular F3D users? That way, they can load up a good example of an animation-supported file and play around with it to better understand animation capability within F3D.

Currently, it seems most of the available example model files do not clearly demonstrate much of the animation aspect.

Feedback appreciated!