### PR TITLE
Remove double backslashes from file path when opening unsupported files.

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -846,7 +846,7 @@ void F3DStarter::LoadFile(int index, bool relativeIndex)
         }
         else
         {
-          f3d::log::warn(filePath, " is not a file of a supported file format\n");
+          f3d::log::warn(filePath.string(), " is not a file of a supported file format\n");
           filenameInfo += " [UNSUPPORTED]";
         }
       }


### PR DESCRIPTION
Closes [#1014](https://github.com/f3d-app/f3d/issues/1014)