### PR TITLE
Removed recurrent logs from getReader

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -846,6 +846,7 @@ void F3DStarter::LoadFile(int index, bool relativeIndex)
         }
         else
         {
+          f3d::log::debug("No reader found for \"" + filePath.string() + "\"");
           f3d::log::warn(filePath.string(), " is not a file of a supported file format\n");
           filenameInfo += " [UNSUPPORTED]";
         }

--- a/library/src/factory.cxx.in
+++ b/library/src/factory.cxx.in
@@ -54,15 +54,6 @@ reader* factory::getReader(const std::string& fileName)
     }
   }
 
-  if (bestReader)
-  {
-    log::debug("The best reader for \"" + fileName + "\" is \"" + bestReader->getName() + "\"");
-  }
-  else
-  {
-    log::debug("No reader found for \"" + fileName + "\"");
-  }
-
   return bestReader;
 }
 

--- a/library/src/loader_impl.cxx
+++ b/library/src/loader_impl.cxx
@@ -224,8 +224,13 @@ loader& loader_impl::loadGeometry(const std::string& filePath, bool reset)
   }
 
   f3d::reader* reader = f3d::factory::instance()->getReader(filePath);
-  if (!reader)
+  if (reader)
   {
+    log::debug("The best reader for \"" + filePath + "\" is \"" + reader->getName() + "\"");
+  }
+  else
+  {
+    log::debug("No reader found for \"" + filePath + "\"");
     throw loader::load_failure_exception(
       filePath + " is not a file of a supported 3D geometry file format");
   }
@@ -259,8 +264,13 @@ loader& loader_impl::loadScene(const std::string& filePath)
   // Recover the importer for the provided file path
   this->Internals->CurrentFullSceneImporter = nullptr;
   f3d::reader* reader = f3d::factory::instance()->getReader(filePath);
-  if (!reader)
+  if (reader)
   {
+    log::debug("The best reader for \"" + filePath + "\" is \"" + reader->getName() + "\"");
+  }
+  else
+  {
+    log::debug("No reader found for \"" + filePath + "\"");
     throw loader::load_failure_exception(
       filePath + " is not a file of a supported 3D scene file format");
   }

--- a/library/src/loader_impl.cxx
+++ b/library/src/loader_impl.cxx
@@ -226,7 +226,7 @@ loader& loader_impl::loadGeometry(const std::string& filePath, bool reset)
   f3d::reader* reader = f3d::factory::instance()->getReader(filePath);
   if (reader)
   {
-    log::debug("The best reader for \"" + filePath + "\" is \"" + reader->getName() + "\"");
+    log::debug("Found a reader for \"" + filePath + "\" : \"" + reader->getName() + "\"");
   }
   else
   {
@@ -266,7 +266,7 @@ loader& loader_impl::loadScene(const std::string& filePath)
   f3d::reader* reader = f3d::factory::instance()->getReader(filePath);
   if (reader)
   {
-    log::debug("The best reader for \"" + filePath + "\" is \"" + reader->getName() + "\"");
+    log::debug("Found a reader for \"" + filePath + "\" : \"" + reader->getName() + "\"");
   }
   else
   {


### PR DESCRIPTION
Moved debug logs from getReader() to loadScene() and loadGeometry() to reduce the same logs displayed many times.