### PR TITLE
add camera zoom method

### DIFF
--- a/library/private/camera_impl.h
+++ b/library/private/camera_impl.h
@@ -53,6 +53,7 @@ public:
 
   camera& dolly(double val) override;
   camera& pan(double right, double up, double forward) override;
+  camera& zoom(double factor) override;
   camera& roll(angle_deg_t angle) override;
   camera& azimuth(angle_deg_t angle) override;
   camera& yaw(angle_deg_t angle) override;

--- a/library/public/camera.h
+++ b/library/public/camera.h
@@ -52,18 +52,25 @@ public:
   ///@}
 
   ///@{ @name Manipulation
-  /**
-   * Standard camera manipulation methods.
-   * Angles are in degrees.
-   */
+  /// Standard camera manipulation methods. Angles are in degrees.
+
+  /** Divide the camera's distance from the focal point by the given value. */
   virtual camera& dolly(double val) = 0;
+  /** Move the camera along its horizontal, vertical, and forward axes */
   virtual camera& pan(double right, double up, double forward = 0) = 0;
+  /** Decrease the view angle (or the parallel scale in parallel mode) by the specified factor. */
   virtual camera& zoom(double factor) = 0;
+  /** Rotate the camera about its forward axis. */
   virtual camera& roll(angle_deg_t angle) = 0;
+  /** Rotate the camera about its vertical axis, centered at the focal point. */
   virtual camera& azimuth(angle_deg_t angle) = 0;
+  /** Rotate the camera about its vertical axis, centered the camera's position. */
   virtual camera& yaw(angle_deg_t angle) = 0;
+  /** Rotate the camera about its horizontal axis, centered at the focal point. */
   virtual camera& elevation(angle_deg_t angle) = 0;
+  /** Rotate the camera about its horizontal axis, centered the camera's position. */
   virtual camera& pitch(angle_deg_t angle) = 0;
+
   ///@}
 
   /**

--- a/library/public/camera.h
+++ b/library/public/camera.h
@@ -58,6 +58,7 @@ public:
    */
   virtual camera& dolly(double val) = 0;
   virtual camera& pan(double right, double up, double forward = 0) = 0;
+  virtual camera& zoom(double factor) = 0;
   virtual camera& roll(angle_deg_t angle) = 0;
   virtual camera& azimuth(angle_deg_t angle) = 0;
   virtual camera& yaw(angle_deg_t angle) = 0;

--- a/library/src/camera_impl.cxx
+++ b/library/src/camera_impl.cxx
@@ -196,6 +196,15 @@ camera& camera_impl::pan(double right, double up, double forward)
 }
 
 //----------------------------------------------------------------------------
+camera& camera_impl::zoom(double factor)
+{
+  vtkCamera* cam = this->GetVTKCamera();
+  cam->Zoom(factor);
+  this->Internals->VTKRenderer->ResetCameraClippingRange();
+  return *this;
+}
+
+//----------------------------------------------------------------------------
 camera& camera_impl::roll(angle_deg_t angle)
 {
   vtkCamera* cam = this->GetVTKCamera();

--- a/library/testing/TestSDKCamera.cxx
+++ b/library/testing/TestSDKCamera.cxx
@@ -53,6 +53,18 @@ void checkVec3(const std::array<double, 3>& actual, const std::array<double, 3>&
   }
 }
 
+void checkDouble(const double actual, const double expected, const std::string& label)
+{
+  if (!compareDouble(actual, expected))
+  {
+    std::stringstream ss;
+    ss << label << ": ";
+    ss << std::setprecision(12);
+    ss << actual << " != " << expected;
+    throw testFailure(ss.str());
+  }
+}
+
 int TestSDKCamera(int argc, char* argv[])
 {
   f3d::engine eng(f3d::window::Type::NATIVE_OFFSCREEN);
@@ -243,6 +255,16 @@ int TestSDKCamera(int argc, char* argv[])
     checkVec3(cam.getPosition(), { -2, -3, 7 }, "pos after pan");
     checkVec3(cam.getFocalPoint(), { -2, -7, 7 }, "foc after pan");
     checkVec3(cam.getViewUp(), { 0, 0, 1 }, "up after pan");
+
+    cam.setPosition({ 1, 2, 3 });
+    cam.setFocalPoint({ 1, 2, 13 });
+    cam.setViewUp({ 0, 1, 0 });
+    cam.setViewAngle(25);
+    cam.zoom(1.5);
+    checkVec3(cam.getPosition(), { 1, 2, 3 }, "pos after zoom");
+    checkVec3(cam.getFocalPoint(), { 1, 2, 13 }, "foc after zoom");
+    checkVec3(cam.getViewUp(), { 0, 1, 0 }, "up after zoom");
+    checkDouble(cam.getViewAngle(), 25 / 1.5, "angle after zoom");
   }
   catch (testFailure& e)
   {

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -349,7 +349,8 @@ PYBIND11_MODULE(pyf3d, module)
     .def_static("set_verbose_level", &f3d::log::setVerboseLevel, py::arg("level"),
       py::arg("force_std_err") = false)
     .def_static("set_use_coloring", &f3d::log::setUseColoring)
-    .def_static("print", [](f3d::log::VerboseLevel& level, const std::string& message)
+    .def_static("print",
+      [](f3d::log::VerboseLevel& level, const std::string& message)
       { f3d::log::print(level, message); });
 
   py::enum_<f3d::log::VerboseLevel>(log, "VerboseLevel")

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -272,6 +272,7 @@ PYBIND11_MODULE(pyf3d, module)
       "state", [](f3d::camera& cam) { return cam.getState(); }, &f3d::camera::setState)
     .def("dolly", &f3d::camera::dolly)
     .def("pan", &f3d::camera::pan, py::arg("right"), py::arg("up"), py::arg("forward") = 0.0)
+    .def("zoom", &f3d::camera::zoom)
     .def("roll", &f3d::camera::roll)
     .def("azimuth", &f3d::camera::azimuth)
     .def("yaw", &f3d::camera::yaw)
@@ -348,8 +349,7 @@ PYBIND11_MODULE(pyf3d, module)
     .def_static("set_verbose_level", &f3d::log::setVerboseLevel, py::arg("level"),
       py::arg("force_std_err") = false)
     .def_static("set_use_coloring", &f3d::log::setUseColoring)
-    .def_static("print",
-      [](f3d::log::VerboseLevel& level, const std::string& message)
+    .def_static("print", [](f3d::log::VerboseLevel& level, const std::string& message)
       { f3d::log::print(level, message); });
 
   py::enum_<f3d::log::VerboseLevel>(log, "VerboseLevel")


### PR DESCRIPTION
Add `f3d::camera::zoom(factor)` method by delegating to `vtkCamera::Zoom(factor)` to be able to "get closer" in both perspective and orthographic mode (where `dolly` is not applicable) 

fixes #1429 