### PR TITLE
Update TestTextureColor baseline

### DIFF
--- a/testing/baselines/TestTextureColor.png
+++ b/testing/baselines/TestTextureColor.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:477b3efbca4e6a0d9d8fe76ecd0328e47f666b6537f62e1b922c51822aa17003
-size 12751
+oid sha256:484b18a3c7394b974c81274e752a715eb70d11a0e9bf5075b6dc92c500de55dc
+size 12609


### PR DESCRIPTION
Between F3D 2.0 and 2.1, The VTK version changed which had a small effect on Zoom bouding box for some reasons, this effect was small enough to not be detected on some cases, this fixes a baselines that should have been updated at the time.