### PR TITLE
Set clang-format cpp style to modern C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,5 +19,5 @@ ColumnLimit: 100
 # For your commits to be compatible with clang 3.8
 # you are best off running clang-format 3.8 on your
 # system
-Standard: Cpp03
+Standard: Cpp11
 ...

--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -572,7 +572,7 @@ void ConfigurationOptions::PrintHelpPair(
 //----------------------------------------------------------------------------
 void ConfigurationOptions::PrintHelp(const cxxopts::Options& cxxOptions)
 {
-  const std::vector<std::pair<std::string, std::string> > examples = {
+  const std::vector<std::pair<std::string, std::string>> examples = {
     { this->ExecutableName + " file.vtu -xtgans",
       "View a unstructured mesh in a typical nice looking sciviz style" },
     { this->ExecutableName + " file.glb -tuqap --hdri-file=file.hdr --hdri-ambient --hdri-skybox",

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -261,7 +261,7 @@ public:
       const std::regex escapedVarRe(escapedVar);
       const std::regex substVarRe(substVar);
 
-      std::vector<std::pair<std::string, bool> > fragments;
+      std::vector<std::pair<std::string, bool>> fragments;
       const auto callback = [&](const std::string& m)
       {
         if (std::regex_match(m, escapedVarRe))

--- a/library/plugin/plugin.h
+++ b/library/plugin/plugin.h
@@ -26,7 +26,7 @@ class plugin
 {
 public:
   plugin(const std::string& name, const std::string& desc, const std::string& vers,
-    const std::vector<std::shared_ptr<reader> >& readers)
+    const std::vector<std::shared_ptr<reader>>& readers)
     : Name(name)
     , Description(desc)
     , Version(vers)
@@ -61,7 +61,7 @@ public:
   /**
    * Get the list of readers created by this plugin
    */
-  const std::vector<std::shared_ptr<reader> >& getReaders()
+  const std::vector<std::shared_ptr<reader>>& getReaders()
   {
     return this->Readers;
   }
@@ -85,7 +85,7 @@ private:
   std::string Name;
   std::string Description;
   std::string Version;
-  std::vector<std::shared_ptr<reader> > Readers;
+  std::vector<std::shared_ptr<reader>> Readers;
   std::string Origin = "undefined";
 };
 

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -98,7 +98,7 @@ public:
   /**
    * Get a structure of strings describing default interactions.
    */
-  static const std::vector<std::pair<std::string, std::string> >& getDefaultInteractionsInfo();
+  static const std::vector<std::pair<std::string, std::string>>& getDefaultInteractionsInfo();
 
 protected:
   //! @cond

--- a/library/src/image.cxx
+++ b/library/src/image.cxx
@@ -176,7 +176,8 @@ image& image::operator=(const image& img) noexcept
 }
 
 //----------------------------------------------------------------------------
-image::image(image&& img) noexcept : Internals(nullptr)
+image::image(image&& img) noexcept
+  : Internals(nullptr)
 {
   std::swap(this->Internals, img.Internals);
 }
@@ -512,11 +513,9 @@ const f3d::image& image::toTerminalText(std::ostream& stream) const
   };
 
   constexpr std::string_view EMPTY_BLOCK = " ";
-  // clang-format off
   constexpr std::string_view TOP_BLOCK = u8"\u2580";
   constexpr std::string_view BOTTOM_BLOCK = u8"\u2584";
   constexpr std::string_view FULL_BLOCK = u8"\u2588";
-  // clang-format on
   constexpr std::string_view EOL = "\n";
 
   for (int y = 0; y < height; y += 2)

--- a/library/src/interactor.cxx
+++ b/library/src/interactor.cxx
@@ -2,7 +2,7 @@
 
 namespace f3d
 {
-const std::vector<std::pair<std::string, std::string> >& interactor::getDefaultInteractionsInfo()
+const std::vector<std::pair<std::string, std::string>>& interactor::getDefaultInteractionsInfo()
 {
   // clang-format off
   static const std::vector<std::pair<std::string, std::string> > DefaultInteractionsInfo{

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -548,7 +548,7 @@ public:
   vtkNew<vtkRenderWindowInteractor> VTKInteractor;
   vtkNew<vtkF3DInteractorStyle> Style;
   vtkSmartPointer<vtkF3DInteractorEventRecorder> Recorder;
-  std::map<unsigned long, std::pair<int, std::function<void()> > > TimerCallBacks;
+  std::map<unsigned long, std::pair<int, std::function<void()>>> TimerCallBacks;
 
   vtkNew<vtkCellPicker> CellPicker;
   vtkNew<vtkPointPicker> PointPicker;

--- a/library/src/options.cxx
+++ b/library/src/options.cxx
@@ -20,13 +20,13 @@ class options::internals
 {
 public:
   using OptionVariant =
-    std::variant<bool, int, double, std::string, std::vector<int>, std::vector<double> >;
+    std::variant<bool, int, double, std::string, std::vector<int>, std::vector<double>>;
 
   template<typename T, typename U>
   struct IsTypeValid;
 
   template<typename T, typename... Ts>
-  struct IsTypeValid<T, std::variant<Ts...> > : public std::disjunction<std::is_same<T, Ts>...>
+  struct IsTypeValid<T, std::variant<Ts...>> : public std::disjunction<std::is_same<T, Ts>...>
   {
   };
 
@@ -390,13 +390,13 @@ std::string options::getAsString(const std::string& name) const
 //----------------------------------------------------------------------------
 std::vector<int> options::getAsIntVector(const std::string& name) const
 {
-  return this->Internals->get<std::vector<int> >(name);
+  return this->Internals->get<std::vector<int>>(name);
 }
 
 //----------------------------------------------------------------------------
 std::vector<double> options::getAsDoubleVector(const std::string& name) const
 {
-  return this->Internals->get<std::vector<double> >(name);
+  return this->Internals->get<std::vector<double>>(name);
 }
 
 //----------------------------------------------------------------------------
@@ -426,13 +426,13 @@ std::string& options::getAsStringRef(const std::string& name)
 //----------------------------------------------------------------------------
 std::vector<int>& options::getAsIntVectorRef(const std::string& name)
 {
-  return this->Internals->getRef<std::vector<int> >(name);
+  return this->Internals->getRef<std::vector<int>>(name);
 }
 
 //----------------------------------------------------------------------------
 std::vector<double>& options::getAsDoubleVectorRef(const std::string& name)
 {
-  return this->Internals->getRef<std::vector<double> >(name);
+  return this->Internals->getRef<std::vector<double>>(name);
 }
 
 //----------------------------------------------------------------------------

--- a/plugins/assimp/module/vtkF3DAssimpImporter.cxx
+++ b/plugins/assimp/module/vtkF3DAssimpImporter.cxx
@@ -865,19 +865,19 @@ public:
   Assimp::Importer Importer;
   const aiScene* Scene = nullptr;
   std::string Description;
-  std::vector<vtkSmartPointer<vtkPolyData> > Meshes;
-  std::vector<vtkSmartPointer<vtkProperty> > Properties;
-  std::vector<vtkSmartPointer<vtkTexture> > EmbeddedTextures;
+  std::vector<vtkSmartPointer<vtkPolyData>> Meshes;
+  std::vector<vtkSmartPointer<vtkProperty>> Properties;
+  std::vector<vtkSmartPointer<vtkTexture>> EmbeddedTextures;
   vtkIdType ActiveAnimation = 0;
-  std::vector<std::pair<std::string, vtkSmartPointer<vtkLight> > > Lights;
+  std::vector<std::pair<std::string, vtkSmartPointer<vtkLight>>> Lights;
   std::vector<
-    std::pair<std::string, std::pair<vtkSmartPointer<vtkCamera>, vtkSmartPointer<vtkCamera> > > >
+    std::pair<std::string, std::pair<vtkSmartPointer<vtkCamera>, vtkSmartPointer<vtkCamera>>>>
     Cameras;
   vtkIdType ActiveCameraIndex = -1;
-  std::unordered_map<std::string, vtkSmartPointer<vtkActorCollection> > NodeActors;
-  std::unordered_map<std::string, vtkSmartPointer<vtkMatrix4x4> > NodeLocalMatrix;
-  std::unordered_map<std::string, vtkSmartPointer<vtkMatrix4x4> > NodeTRSMatrix;
-  std::unordered_map<std::string, vtkSmartPointer<vtkMatrix4x4> > NodeGlobalMatrix;
+  std::unordered_map<std::string, vtkSmartPointer<vtkActorCollection>> NodeActors;
+  std::unordered_map<std::string, vtkSmartPointer<vtkMatrix4x4>> NodeLocalMatrix;
+  std::unordered_map<std::string, vtkSmartPointer<vtkMatrix4x4>> NodeTRSMatrix;
+  std::unordered_map<std::string, vtkSmartPointer<vtkMatrix4x4>> NodeGlobalMatrix;
   vtkF3DAssimpImporter* Parent;
 };
 

--- a/plugins/draco/module/vtkF3DDracoReader.cxx
+++ b/plugins/draco/module/vtkF3DDracoReader.cxx
@@ -30,10 +30,10 @@ public:
   }
 
   template<typename T>
-  static vtkSmartPointer<vtkAOSDataArrayTemplate<T> > FillArray(
+  static vtkSmartPointer<vtkAOSDataArrayTemplate<T>> FillArray(
     int nbPoints, draco::PointAttribute* attribute)
   {
-    vtkNew<vtkAOSDataArrayTemplate<T> > arr;
+    vtkNew<vtkAOSDataArrayTemplate<T>> arr;
 
     arr->SetNumberOfComponents(attribute->num_components());
     arr->SetNumberOfTuples(nbPoints);

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -528,7 +528,7 @@ public:
     }
   }
 
-  std::unordered_map<int, vtkSmartPointer<vtkPolyData> > ShapeMap;
+  std::unordered_map<int, vtkSmartPointer<vtkPolyData>> ShapeMap;
   Handle(XCAFDoc_ShapeTool) ShapeTool;
 #endif
 

--- a/plugins/usd/module/vtkF3DUSDImporter.cxx
+++ b/plugins/usd/module/vtkF3DUSDImporter.cxx
@@ -1167,10 +1167,10 @@ public:
   pxr::UsdStageRefPtr Stage = nullptr;
 
 private:
-  std::unordered_map<std::string, vtkSmartPointer<vtkActor> > ActorMap;
-  std::unordered_map<std::string, vtkSmartPointer<vtkPolyData> > MeshMap;
-  std::unordered_map<std::string, vtkSmartPointer<vtkProperty> > ShaderMap;
-  std::unordered_map<std::string, vtkSmartPointer<vtkImageData> > TextureMap;
+  std::unordered_map<std::string, vtkSmartPointer<vtkActor>> ActorMap;
+  std::unordered_map<std::string, vtkSmartPointer<vtkPolyData>> MeshMap;
+  std::unordered_map<std::string, vtkSmartPointer<vtkProperty>> ShaderMap;
+  std::unordered_map<std::string, vtkSmartPointer<vtkImageData>> TextureMap;
   double CurrentTime = 0.0;
 
   class DiagDelegate : public pxr::TfDiagnosticMgr::Delegate

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -212,7 +212,7 @@ PYBIND11_MODULE(pyf3d, module)
     .def_static("text_distance", &f3d::utils::textDistance);
 
   // f3d::interactor
-  py::class_<f3d::interactor, std::unique_ptr<f3d::interactor, py::nodelete> > interactor(
+  py::class_<f3d::interactor, std::unique_ptr<f3d::interactor, py::nodelete>> interactor(
     module, "Interactor");
   interactor //
     .def("toggle_animation", &f3d::interactor::toggleAnimation, "Toggle the animation")
@@ -246,7 +246,7 @@ PYBIND11_MODULE(pyf3d, module)
     .def_readwrite("face_indices", &f3d::mesh_t::face_indices);
 
   // f3d::loader
-  py::class_<f3d::loader, std::unique_ptr<f3d::loader, py::nodelete> > loader(module, "Loader");
+  py::class_<f3d::loader, std::unique_ptr<f3d::loader, py::nodelete>> loader(module, "Loader");
   loader //
     .def("has_geometry_reader", &f3d::loader::hasGeometryReader)
     .def("load_geometry", py::overload_cast<const std::string&, bool>(&f3d::loader::loadGeometry),
@@ -257,7 +257,7 @@ PYBIND11_MODULE(pyf3d, module)
       "Load a surfacic mesh from memory", py::arg("mesh"), py::arg("reset") = false);
 
   // f3d::camera
-  py::class_<f3d::camera, std::unique_ptr<f3d::camera, py::nodelete> > camera(module, "Camera");
+  py::class_<f3d::camera, std::unique_ptr<f3d::camera, py::nodelete>> camera(module, "Camera");
   camera //
     .def_property(
       "position", [](f3d::camera& cam) { return cam.getPosition(); }, &f3d::camera::setPosition)
@@ -291,7 +291,7 @@ PYBIND11_MODULE(pyf3d, module)
     .def_readwrite("angle", &f3d::camera_state_t::angle);
 
   // f3d::window
-  py::class_<f3d::window, std::unique_ptr<f3d::window, py::nodelete> > window(module, "Window");
+  py::class_<f3d::window, std::unique_ptr<f3d::window, py::nodelete>> window(module, "Window");
 
   py::enum_<f3d::window::Type>(window, "Type")
     .value("NONE", f3d::window::Type::NONE)

--- a/vtkext/private/module/vtkF3DGenericImporter.cxx
+++ b/vtkext/private/module/vtkF3DGenericImporter.cxx
@@ -407,10 +407,10 @@ void vtkF3DGenericImporter::UpdateTimeStep(double timestep)
 }
 
 //----------------------------------------------------------------------------
-std::vector<std::pair<vtkActor*, vtkPolyDataMapper*> >
+std::vector<std::pair<vtkActor*, vtkPolyDataMapper*>>
 vtkF3DGenericImporter::GetGeometryActorsAndMappers()
 {
-  std::vector<std::pair<vtkActor*, vtkPolyDataMapper*> > actorsAndMappers(
+  std::vector<std::pair<vtkActor*, vtkPolyDataMapper*>> actorsAndMappers(
     this->Pimpl->Readers.size());
 
   std::transform(this->Pimpl->Readers.cbegin(), this->Pimpl->Readers.cend(),
@@ -422,10 +422,10 @@ vtkF3DGenericImporter::GetGeometryActorsAndMappers()
 }
 
 //----------------------------------------------------------------------------
-std::vector<std::pair<vtkActor*, vtkPointGaussianMapper*> >
+std::vector<std::pair<vtkActor*, vtkPointGaussianMapper*>>
 vtkF3DGenericImporter::GetPointSpritesActorsAndMappers()
 {
-  std::vector<std::pair<vtkActor*, vtkPointGaussianMapper*> > actorsAndMappers(
+  std::vector<std::pair<vtkActor*, vtkPointGaussianMapper*>> actorsAndMappers(
     this->Pimpl->Readers.size());
 
   std::transform(this->Pimpl->Readers.cbegin(), this->Pimpl->Readers.cend(),
@@ -437,10 +437,10 @@ vtkF3DGenericImporter::GetPointSpritesActorsAndMappers()
 }
 
 //----------------------------------------------------------------------------
-std::vector<std::pair<vtkVolume*, vtkSmartVolumeMapper*> >
+std::vector<std::pair<vtkVolume*, vtkSmartVolumeMapper*>>
 vtkF3DGenericImporter::GetVolumePropsAndMappers()
 {
-  std::vector<std::pair<vtkVolume*, vtkSmartVolumeMapper*> > propsAndMappers(
+  std::vector<std::pair<vtkVolume*, vtkSmartVolumeMapper*>> propsAndMappers(
     this->Pimpl->Readers.size());
 
   std::transform(this->Pimpl->Readers.cbegin(), this->Pimpl->Readers.cend(),

--- a/vtkext/private/module/vtkF3DGenericImporter.h
+++ b/vtkext/private/module/vtkF3DGenericImporter.h
@@ -74,9 +74,9 @@ public:
    * Access to actors vectors. They all have the same size, which correspond to the number
    * of added internal readers.
    */
-  std::vector<std::pair<vtkActor*, vtkPolyDataMapper*> > GetGeometryActorsAndMappers();
-  std::vector<std::pair<vtkActor*, vtkPointGaussianMapper*> > GetPointSpritesActorsAndMappers();
-  std::vector<std::pair<vtkVolume*, vtkSmartVolumeMapper*> > GetVolumePropsAndMappers();
+  std::vector<std::pair<vtkActor*, vtkPolyDataMapper*>> GetGeometryActorsAndMappers();
+  std::vector<std::pair<vtkActor*, vtkPointGaussianMapper*>> GetPointSpritesActorsAndMappers();
+  std::vector<std::pair<vtkVolume*, vtkSmartVolumeMapper*>> GetVolumePropsAndMappers();
   ///@}
 
   /**
@@ -87,7 +87,7 @@ public:
     std::string Name;
     int MaximumNumberOfComponents = 0;
     std::vector<std::string> ComponentNames;
-    std::vector<std::array<double, 2> > ComponentRanges;
+    std::vector<std::array<double, 2>> ComponentRanges;
     std::array<double, 2> MagnitudeRange = { std::numeric_limits<float>::max(),
       std::numeric_limits<float>::min() };
     std::vector<vtkDataArray*> Arrays;

--- a/vtkext/private/module/vtkF3DWin32OutputWindow.cxx
+++ b/vtkext/private/module/vtkF3DWin32OutputWindow.cxx
@@ -90,7 +90,7 @@ void vtkF3DWin32OutputWindow::DisplayText(const char* text)
   std::string str(text);
   str = std::regex_replace(str, std::regex("\n"), "\r\n");
 
-  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t> > converter;
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   std::wstring wstr = converter.from_bytes(str);
   wstr += L"\r\n";
 

--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -111,8 +111,7 @@ EMSCRIPTEN_BINDINGS(f3d)
     .function("resetCamera", &resetCamera, emscripten::allow_raw_pointers());
 
   // f3d::interactor
-  emscripten::class_<f3d::interactor>("Interactor")
-    .function("start", &f3d::interactor::start);
+  emscripten::class_<f3d::interactor>("Interactor").function("start", &f3d::interactor::start);
 
   // f3d::engine
   emscripten::class_<f3d::engine> engine("Engine");

--- a/winshellext/F3DShellExtension.cxx
+++ b/winshellext/F3DShellExtension.cxx
@@ -55,7 +55,7 @@ void RunOnJSONExtensions(fs::path modulePath, F callback)
                   {
                     std::wstring ret = L".";
 
-                    std::wstring_convert<std::codecvt_utf8<wchar_t> > toUnicode;
+                    std::wstring_convert<std::codecvt_utf8<wchar_t>> toUnicode;
                     ret += toUnicode.from_bytes(e.get<std::string>());
 
                     callback(ret);


### PR DESCRIPTION
Let's bump C++ version to `Cpp11` (which means C++11 and above).  
It mainly impacts the closing bracket of nested template argument but I'll need it for a upcoming PR where I'm using raw strings.