### PR TITLE
Add jekyll-include-cache

### DIFF
--- a/doc/dev/GENERATE.md
+++ b/doc/dev/GENERATE.md
@@ -18,7 +18,7 @@ Requires `clang` toolchain.
 # How to locally generate the jekyll based website
 
 1. Install `ruby` and make sure ruby binaries directory is added to your `PATH`
-2. Install jekyll and all dependencies: `gem install jekyll jekyll-remote-theme jekyll-relative-links jekyll-seo-tag jekyll-optional-front-matter jekyll-titles-from-headings`
+2. Install jekyll and all dependencies: `gem install jekyll jekyll-remote-theme jekyll-relative-links jekyll-seo-tag jekyll-optional-front-matter jekyll-titles-from-headings jekyll-include-cache`
 3. Run jekyll locally: `jekyll server`
 4. Open http://127.0.0.1:4000/ in a browser
 


### PR DESCRIPTION
Having installed what is written in the docs, I've got:
```
  Dependency Error: Yikes! It looks like you don't have jekyll-include-cache or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. If you've run Jekyll with `bundle exec`, ensure that you have included the jekyll-include-cache gem in your Gemfile as well. The full error message from Ruby is: 'cannot load such file -- jekyll-include-cache' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/! 
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    jekyll-include-cache
                    ------------------------------------------------
      Jekyll 4.3.3   Please append `--trace` to the `serve` command 
                     for any additional information or backtrace. 
                    ------------------------------------------------
```