### PR TITLE
Improve `--readers-list` output

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -660,14 +660,15 @@ void ConfigurationOptions::PrintReadersList()
       mimeColSize = std::max(mimeColSize, mime.length());
     }
   }
-  nameColSize++;
-  extsColSize++;
-  mimeColSize++;
-  descColSize++;
-  plugColSize++;
+  const size_t colGap = 4;
+  nameColSize += colGap;
+  extsColSize += colGap;
+  mimeColSize += colGap;
+  descColSize += colGap;
+  plugColSize += colGap;
 
   std::string separator =
-    std::string(nameColSize + extsColSize + descColSize + mimeColSize + plugColSize, '-');
+    std::string(nameColSize + extsColSize + descColSize + mimeColSize + plugColSize - colGap, '-');
 
   // Print the rows split in 3 columns
   std::stringstream headerLine;

--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -674,7 +674,7 @@ void ConfigurationOptions::PrintReadersList()
   std::stringstream headerLine;
   headerLine << std::left << std::setw(nameColSize) << "Name" << std::setw(plugColSize) << "Plugin"
              << std::setw(descColSize) << "Description" << std::setw(extsColSize) << "Exts"
-             << std::setw(mimeColSize) << "Mime-types";
+             << std::setw(mimeColSize - colGap) << "Mime-types";
   f3d::log::info(headerLine.str());
   f3d::log::info(separator);
 
@@ -683,22 +683,14 @@ void ConfigurationOptions::PrintReadersList()
     for (size_t i = 0; i < reader.Extensions.size(); i++)
     {
       std::stringstream readerLine;
-      if (i == 0)
-      {
-        readerLine << std::left << std::setw(nameColSize) << reader.Name << std::setw(plugColSize)
-                   << reader.PluginName << std::setw(descColSize) << reader.Description;
-      }
-      else
-      {
-        readerLine << std::left << std::setw(nameColSize + descColSize + plugColSize) << " ";
-      }
-
-      readerLine << std::setw(extsColSize) << reader.Extensions[i];
-
-      if (i < reader.MimeTypes.size())
-      {
-        readerLine << std::setw(mimeColSize) << reader.MimeTypes[i];
-      }
+      readerLine << std::left;
+      readerLine << std::setw(nameColSize) << (i == 0 ? reader.Name : "");
+      readerLine << std::setw(plugColSize) << (i == 0 ? reader.PluginName : "");
+      readerLine << std::setw(descColSize) << (i == 0 ? reader.Description : "");
+      readerLine << std::setw(extsColSize)
+                 << (i < reader.Extensions.size() ? reader.Extensions[i] : "");
+      readerLine << std::setw(mimeColSize - colGap)
+                 << (i < reader.MimeTypes.size() ? reader.MimeTypes[i] : "");
 
       f3d::log::info(readerLine.str());
     }

--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -701,7 +701,6 @@ void ConfigurationOptions::PrintReadersList()
 
       f3d::log::info(readerLine.str());
     }
-    f3d::log::info(separator);
   }
   f3d::log::waitForUser();
 }


### PR DESCRIPTION
`--readers-list` output had extra separator lines.
I've also increased the gap between columns while I was at it (set at 4 spaces currently but could be reduced to 3 or 2 to be more compact).

before:
```
Name       Plugin Description                Exts  Mime-types             
--------------------------------------------------------------------------
FBX        assimp Filmbox                    fbx   application/vnd.fbx    
--------------------------------------------------------------------------
Collada    assimp Collada                    dae   application/vnd.dae    
--------------------------------------------------------------------------
DXF        assimp AutoCAD DXF                dxf   image/vnd.dxf          
--------------------------------------------------------------------------
OFF        assimp Object File Format         off   application/vnd.off    
--------------------------------------------------------------------------
DirectX    assimp DirectX File Format        x     application/vnd.x      
--------------------------------------------------------------------------
3MF        assimp 3D Manufacturing Format    3mf   model/3mf              
--------------------------------------------------------------------------
ExodusII   exodus Exodus II                  exo   application/vnd.exodus 
                                             ex2   
                                             e     
--------------------------------------------------------------------------
...
```
after:
```
Name          Plugin    Description                   Exts     Mime-types                
-------------------------------------------------------------------------------------
FBX           assimp    Filmbox                       fbx      application/vnd.fbx       
Collada       assimp    Collada                       dae      application/vnd.dae       
DXF           assimp    AutoCAD DXF                   dxf      image/vnd.dxf             
OFF           assimp    Object File Format            off      application/vnd.off       
DirectX       assimp    DirectX File Format           x        application/vnd.x         
3MF           assimp    3D Manufacturing Format       3mf      model/3mf                 
ExodusII      exodus    Exodus II                     exo      application/vnd.exodus    
                                                      ex2      
                                                      e        
...
```