### PR TITLE
Minimal screenshot

### DIFF
--- a/application/F3DStarter.h
+++ b/application/F3DStarter.h
@@ -46,8 +46,10 @@ public:
   /**
    * Trigger a render and save a screenshot to disk according to a filename template.
    * See `F3DStarter::F3DInternals::applyFilenameTemplate` for template substitution details.
+   * If the `minimal` parameter is `true`, render with transparent background, no grid,
+   * and no overlays.
    */
-  void SaveScreenshot(const std::string& filenameTemplate);
+  void SaveScreenshot(const std::string& filenameTemplate, bool minimal = false);
 
   F3DStarter();
   ~F3DStarter();

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -233,7 +233,7 @@ function(f3d_ss_test)
   if(NOT F3D_SS_TEST_MINIMAL)
     f3d_test(NAME TestScreenshot${F3D_SS_TEST_NAME} DATA suzanne.ply ARGS --screenshot-filename=${F3D_SS_TEST_TEMPLATE} --dry-run --interaction-test-play=${F3D_SOURCE_DIR}/testing/recordings/TestScreenshot.log NO_BASELINE DEPENDS TestSetupScreenshots)
     f3d_test(NAME TestScreenshot${F3D_SS_TEST_NAME}File DATA suzanne.ply ARGS --ref=${F3D_SS_TEST_EXPECTED} DEPENDS TestScreenshot${F3D_SS_TEST_NAME} ${F3D_SS_TEST_DEPENDS} NO_BASELINE)
-  else()
+  elseif(VTK_VERSION VERSION_GREATER_EQUAL 9.1.20211007)
     # show filename, axes, fps before the "minimal screenshot" interaction; compare with --no-background only
     f3d_test(NAME TestScreenshot${F3D_SS_TEST_NAME} DATA suzanne.ply ARGS --screenshot-filename=${F3D_SS_TEST_TEMPLATE} --dry-run -nxz --interaction-test-play=${F3D_SOURCE_DIR}/testing/recordings/TestScreenshotMinimal.log NO_BASELINE DEPENDS TestSetupScreenshots)
     f3d_test(NAME TestScreenshot${F3D_SS_TEST_NAME}File DATA suzanne.ply ARGS --no-background --ref=${F3D_SS_TEST_EXPECTED} DEPENDS TestScreenshot${F3D_SS_TEST_NAME} ${F3D_SS_TEST_DEPENDS} NO_BASELINE)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -229,9 +229,15 @@ endif()
 
 # Screenshot Interaction
 function(f3d_ss_test)
-  cmake_parse_arguments(F3D_SS_TEST "" "NAME;TEMPLATE;EXPECTED;DEPENDS" "ARGS" ${ARGN})
-  f3d_test(NAME TestScreenshot${F3D_SS_TEST_NAME} DATA suzanne.ply ARGS --screenshot-filename=${F3D_SS_TEST_TEMPLATE} --dry-run --interaction-test-play=${F3D_SOURCE_DIR}/testing/recordings/TestScreenshot.log NO_BASELINE DEPENDS TestSetupScreenshots)
-  f3d_test(NAME TestScreenshot${F3D_SS_TEST_NAME}File DATA suzanne.ply ARGS --ref=${F3D_SS_TEST_EXPECTED} DEPENDS TestScreenshot${F3D_SS_TEST_NAME} ${F3D_SS_TEST_DEPENDS} NO_BASELINE)
+  cmake_parse_arguments(F3D_SS_TEST "MINIMAL" "NAME;TEMPLATE;EXPECTED;DEPENDS" "ARGS" ${ARGN})
+  if(NOT F3D_SS_TEST_MINIMAL)
+    f3d_test(NAME TestScreenshot${F3D_SS_TEST_NAME} DATA suzanne.ply ARGS --screenshot-filename=${F3D_SS_TEST_TEMPLATE} --dry-run --interaction-test-play=${F3D_SOURCE_DIR}/testing/recordings/TestScreenshot.log NO_BASELINE DEPENDS TestSetupScreenshots)
+    f3d_test(NAME TestScreenshot${F3D_SS_TEST_NAME}File DATA suzanne.ply ARGS --ref=${F3D_SS_TEST_EXPECTED} DEPENDS TestScreenshot${F3D_SS_TEST_NAME} ${F3D_SS_TEST_DEPENDS} NO_BASELINE)
+  else()
+    # show filename, axes, fps before the "minimal screenshot" interaction; compare with --no-background only
+    f3d_test(NAME TestScreenshot${F3D_SS_TEST_NAME} DATA suzanne.ply ARGS --screenshot-filename=${F3D_SS_TEST_TEMPLATE} --dry-run -nxz --interaction-test-play=${F3D_SOURCE_DIR}/testing/recordings/TestScreenshotMinimal.log NO_BASELINE DEPENDS TestSetupScreenshots)
+    f3d_test(NAME TestScreenshot${F3D_SS_TEST_NAME}File DATA suzanne.ply ARGS --no-background --ref=${F3D_SS_TEST_EXPECTED} DEPENDS TestScreenshot${F3D_SS_TEST_NAME} ${F3D_SS_TEST_DEPENDS} NO_BASELINE)
+  endif()
 endfunction()
 
 cmake_path(SET _screenshot_path ${CMAKE_BINARY_DIR}/Testing/Temporary/ss)
@@ -251,6 +257,7 @@ string(TIMESTAMP DATE_Y "%Y")
 string(TIMESTAMP DATE_Ymd "%Y%m%d")
 f3d_ss_test(NAME Date TEMPLATE ${_screenshot_dir}/{model}_{date}_{date:%Y}.png EXPECTED ${_screenshot_dir}/suzanne_${DATE_Ymd}_${DATE_Y}.png)
 f3d_ss_test(NAME Esc TEMPLATE ${_screenshot_dir}/{model}_{{model}}_{}.png EXPECTED ${_screenshot_dir}/suzanne_{model}_{}.png)
+f3d_ss_test(NAME Minimal MINIMAL TEMPLATE ${_screenshot_dir}/minimal.png EXPECTED ${_screenshot_dir}/minimal.png)
 
 f3d_ss_test(NAME UserModelN TEMPLATE {model}_{n}.png EXPECTED ${_screenshot_user_dir}/suzanne_1.png)
 set_tests_properties(f3d::TestScreenshotUserModelN PROPERTIES ENVIRONMENT "XDG_PICTURES_DIR=${_screenshot_user_dir};HOME=${_screenshot_user_dir};USERPROFILE=${_screenshot_user_dir}")

--- a/doc/user/INTERACTIONS.md
+++ b/doc/user/INTERACTIONS.md
@@ -73,6 +73,7 @@ Other hotkeys are available:
 * <kbd>&uarr;</kbd>: reload the current file.
 * <kbd>&darr;</kbd>: add current file parent directory to the list of files, reload the current file and reset the camera.
 * <kbd>F12</kbd>: take a screenshot, ie. render the current view to an image file.
+* <kbd>F11</kbd>: take a "minimal" screenshot, ie. render the current view with no grid and no overlays to an image file with a transparent background.
 
 When loading another file or reloading, options that have been changed interactively are kept but can be overridden
 if a dedicated regular expression block in the configuration file is present, see the [configuration file](CONFIGURATION_FILE.md)
@@ -95,7 +96,7 @@ as specified above.
 
 ## Taking Screenshots
 
-The destination filename used to save the screenshots (created by pressing <kbd>F12</kbd>) is configurable (using the `screenshot-filename` option) and can use template variables as described [on the options page](OPTIONS.md#filename-templating).
+The destination filename used to save the screenshots (created by pressing <kbd>F12</kbd> or <kbd>F11</kbd>) is configurable (using the `screenshot-filename` option) and can use template variables as described [on the options page](OPTIONS.md#filename-templating).
 
 Unless the configured filename template is an absolute path, images will be saved into the user's home directory
 (using the following environment variables, if defined and pointing to an existing directory, in that order: `XDG_PICTURES_DIR`, `HOME`, or `USERPROFILE`).

--- a/testing/recordings/TestScreenshotMinimal.log
+++ b/testing/recordings/TestScreenshotMinimal.log
@@ -1,0 +1,7 @@
+# StreamVersion 1.2
+ExposeEvent 0 599 0 0 0 0 0
+RenderEvent 0 599 0 0 0 0 0
+KeyPressEvent 916 614 0 0 1 F11 0
+RenderEvent 916 614 0 0 1 F11 0
+CharEvent 916 614 0 0 1 F11 0
+KeyReleaseEvent 916 614 0 0 1 F11 0


### PR DESCRIPTION
Allow saving "minimal"/"clean" screenshots with transparent background and no grid or overlays, as requested by a user on Discord.
Bound to `F11` instead of the initially proposed `shift+F12` because of current technical limitations.