### PR TITLE
Add default *.brep config files

### DIFF
--- a/plugins/occt/configs/config.d/10_occt.json
+++ b/plugins/occt/configs/config.d/10_occt.json
@@ -1,5 +1,5 @@
 {
-  ".*(step|stp|iges|igs)":
+  ".*(step|stp|iges|igs|brep)":
   {
     "load-plugins": "occt",
     "up": "+Z",

--- a/plugins/occt/configs/thumbnail.d/10_occt.json
+++ b/plugins/occt/configs/thumbnail.d/10_occt.json
@@ -1,5 +1,5 @@
 {
-  ".*(step|stp|iges|igs)":
+  ".*(step|stp|iges|igs|brep)":
   {
     "load-plugins": "occt",
     "up": "+Z",


### PR DESCRIPTION
# Fixing Brep Configuraiton Files

Cut a branch from status of https://github.com/f3d-app/f3d on July 19 2024, 4:45PM PST.

```
C:\dev\f3d\src>git status
On branch fix_brep_default_config
nothing to commit, working tree clean

C:\dev\f3d\src>git log
Author: Mathieu Westphal <mathieu.westphal@gmail.com>
Date:   Tue Jul 16 08:32:29 2024 +0200

    CI: Use VTK 9.3.1 in CI (#1542)
```

Default settings for a test .brep file were not respected in either the application's main window nor the thumbnail functionality on Windows

*Application*

![BrepTestOne](https://github.com/user-attachments/assets/dd7938a6-929b-4933-883b-3ccd61129b39)

*Thumbnail*

![BrepTestTwo](https://github.com/user-attachments/assets/efc593e5-7355-4c7a-b0ff-8eae862e4fae)


After

```
commit 9770dd3a20e628e719609c2a8e12bd2031f50298 (HEAD -> fix_brep_default_config)
Author: Spencer Little <slittle57@gmail.com>
Date:   Fri Jul 19 17:57:27 2024 -0700

    Add default *.brep config files
```

default settings for test .brep file were respected in both the application's main window and thumbnail


*Application*

![BrepDefaultFixedApp](https://github.com/user-attachments/assets/8fff9d4e-fd27-4a48-9f3b-dc15ad893aa4)

*Thumbnail*

![BrepDefaultFixedThumbnail](https://github.com/user-attachments/assets/3c174473-7213-48ff-92dd-72dbc9954a10)

