### PR TITLE
Ignore .DS_Store file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist
 __pycache__
 *.pyc
 _version.py
+.DS_Store
+


### PR DESCRIPTION
Add `.DS_Store` to `.gitignore`. This file is used to store metadata of the file explorer on macos (Finder)