### PR TITLE
improve suggestions on unknown options

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -467,21 +467,17 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
           // check if it's a long option
           if (unknownOption.substr(0, 2) == "--")
           {
-            // remove trailing '--'
-            unknownOption = unknownOption.substr(2);
+            const size_t i = unknownOption.rfind("=");
 
-            auto it = std::find_if(unknownOption.rbegin(), unknownOption.rend(),
-              [](unsigned char ch) { return ch == '='; });
+            // remove "--" and everything after the last "=" (if any)
+            const std::string unknownName =
+              unknownOption.substr(2, i != std::string::npos ? i - 2 : i);
 
-            // remove everything after the character '='
-            if (it != unknownOption.rend())
-            {
-              unknownOption.erase(it.base() - 1, unknownOption.end());
-            }
+            auto [closestName, dist] = this->GetClosestOption(unknownOption);
+            const std::string closestOption =
+              i == std::string::npos ? closestName : closestName + unknownOption.substr(i);
 
-            auto [name, dist] = this->GetClosestOption(unknownOption);
-
-            f3d::log::error("Did you mean '--", name, "'?");
+            f3d::log::error("Did you mean '--", closestOption, "'?");
           }
         }
       }

--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -467,7 +467,7 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
           // check if it's a long option
           if (unknownOption.substr(0, 2) == "--")
           {
-            const size_t i = unknownOption.rfind("=");
+            const size_t i = unknownOption.rfind('=');
 
             // remove "--" and everything after the last "=" (if any)
             const std::string unknownName =

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -880,7 +880,7 @@ f3d_test(NAME TestInvalidTexture DATA cow.vtp ARGS --texture-material=${F3D_SOUR
 f3d_test(NAME TestNonExistentInteraction DATA cow.vtp INTERACTION REGEXP "Interaction record file to play does not exist" NO_BASELINE)
 
 # Test unknown options, do not add a --colour option
-f3d_test(NAME TestUnknownOptionVerbose ARGS --colour=1,0,0 REGEXP "Did you mean '--color'?")
+f3d_test(NAME TestUnknownOptionVerbose ARGS --colour=1,0,0 REGEXP "Did you mean '--color=1,0,0'?")
 f3d_test(NAME TestUnknownOptionExitCode ARGS --colour=1,0,0 WILL_FAIL)
 
 # Test non-existent config filepath, do not add a dummy.json


### PR DESCRIPTION
Include the original value in the closest option suggestions:
```
Unknown option '--grid-unitt=12'
Did you mean '--grid-unit=12'?
```
Currently only outputs the name: `Did you mean '--grid-unit'?`