### PR TITLE
fix suggestions on unknown options 

### DIFF
--- a/application/F3DOptionsParser.cxx
+++ b/application/F3DOptionsParser.cxx
@@ -467,13 +467,13 @@ void ConfigurationOptions::GetOptions(F3DAppOptions& appOptions, f3d::options& o
           // check if it's a long option
           if (unknownOption.substr(0, 2) == "--")
           {
-            const size_t i = unknownOption.rfind('=');
+            const size_t i = unknownOption.find('=');
 
-            // remove "--" and everything after the last "=" (if any)
+            // remove "--" and everything after the first "=" (if any)
             const std::string unknownName =
               unknownOption.substr(2, i != std::string::npos ? i - 2 : i);
 
-            auto [closestName, dist] = this->GetClosestOption(unknownOption);
+            auto [closestName, dist] = this->GetClosestOption(unknownName);
             const std::string closestOption =
               i == std::string::npos ? closestName : closestName + unknownOption.substr(i);
 

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -880,7 +880,7 @@ f3d_test(NAME TestInvalidTexture DATA cow.vtp ARGS --texture-material=${F3D_SOUR
 f3d_test(NAME TestNonExistentInteraction DATA cow.vtp INTERACTION REGEXP "Interaction record file to play does not exist" NO_BASELINE)
 
 # Test unknown options, do not add a --colour option
-f3d_test(NAME TestUnknownOptionVerbose ARGS --colour=1,0,0 REGEXP "Did you mean '--color=1,0,0'?")
+f3d_test(NAME TestUnknownOptionVerbose ARGS --colour=a=b REGEXP "Did you mean '--color=a=b'?")
 f3d_test(NAME TestUnknownOptionExitCode ARGS --colour=1,0,0 WILL_FAIL)
 
 # Test non-existent config filepath, do not add a dummy.json


### PR DESCRIPTION
- fix a bug from #1577
- handle the (unlikely?) case of `=` in argument value