### PR TITLE
minor fixes to `TestSDKHelpers.h`

### DIFF
--- a/library/testing/TestSDKHelpers.h
+++ b/library/testing/TestSDKHelpers.h
@@ -1,6 +1,9 @@
 #ifndef TestSDKHelpers_h
 #define TestSDKHelpers_h
 
+#include <image.h>
+#include <window.h>
+
 #include <fstream>
 #include <iostream>
 

--- a/library/testing/TestSDKHelpers.h
+++ b/library/testing/TestSDKHelpers.h
@@ -7,58 +7,59 @@
 #include <fstream>
 #include <iostream>
 
-class TestSDKHelpers
+namespace TestSDKHelpers
 {
-public:
-  static bool RenderTest(const f3d::image& img, const std::string& baselinePath,
-    const std::string& outputPath, const std::string& name, double threshold = 0.05)
+
+static bool RenderTest(const f3d::image& img, const std::string& baselinePath,
+  const std::string& outputPath, const std::string& name, double threshold = 0.05)
+{
+  if (baselinePath.empty() || outputPath.empty() || name.empty())
   {
-    if (baselinePath.empty() || outputPath.empty() || name.empty())
+    std::cerr << "A path or name is empty, aborting" << std::endl;
+    return false;
+  }
+
+  std::string baseline = baselinePath + name + ".png";
+  std::string output = outputPath + name + ".png";
+
+  {
+    std::ifstream file(baseline.c_str());
+    if (!file.good())
     {
-      std::cerr << "A path or name is empty, aborting" << std::endl;
-      return false;
-    }
-
-    std::string baseline = baselinePath + name + ".png";
-    std::string output = outputPath + name + ".png";
-
-    {
-      std::ifstream file(baseline.c_str());
-      if (!file.good())
-      {
-        img.save(output);
-        std::cerr << "Reference image "
-                  << baseline + " does not exist, current rendering has been outputted to "
-                  << output << std::endl;
-        return false;
-      }
-    }
-
-    f3d::image reference(baseline);
-    double error;
-
-    if (!img.compare(reference, threshold, error))
-    {
-      std::cerr << "Current rendering difference with reference image: " << error
-                << " is higher than the threshold of " << threshold << std::endl;
-      std::cerr << "Result resolution: " << img.getWidth() << "x" << img.getHeight() << std::endl;
-      std::cerr << "Reference resolution: " << reference.getWidth() << "x" << reference.getHeight()
-                << std::endl;
       img.save(output);
+      std::cerr << "Reference image "
+                << baseline + " does not exist, current rendering has been outputted to " << output
+                << std::endl;
       return false;
     }
-
-    std::cout << "Successful render test against " << baseline + " with an error of " << error
-              << std::endl;
-    return true;
   }
 
-  static bool RenderTest(f3d::window& win, const std::string& baselinePath,
-    const std::string& outputPath, const std::string& name, double threshold = 50,
-    bool noBackground = false)
+  f3d::image reference(baseline);
+  double error;
+
+  if (!img.compare(reference, threshold, error))
   {
-    return TestSDKHelpers::RenderTest(
-      win.renderToImage(noBackground), baselinePath, outputPath, name, threshold);
+    std::cerr << "Current rendering difference with reference image: " << error
+              << " is higher than the threshold of " << threshold << std::endl;
+    std::cerr << "Result resolution: " << img.getWidth() << "x" << img.getHeight() << std::endl;
+    std::cerr << "Reference resolution: " << reference.getWidth() << "x" << reference.getHeight()
+              << std::endl;
+    img.save(output);
+    return false;
   }
-};
+
+  std::cout << "Successful render test against " << baseline + " with an error of " << error
+            << std::endl;
+  return true;
+}
+
+static bool RenderTest(f3d::window& win, const std::string& baselinePath,
+  const std::string& outputPath, const std::string& name, double threshold = 50,
+  bool noBackground = false)
+{
+  return TestSDKHelpers::RenderTest(
+    win.renderToImage(noBackground), baselinePath, outputPath, name, threshold);
+}
+
+}
 #endif


### PR DESCRIPTION
`TestSDKHelpers.h` is missing some includes, which isn't a problem as they are currently always already included before any use of the file, but still, let's have them in there.

Also `class TestSDKHelpers` only has static methods and holds no state so it can be a namespace instead