### PR TITLE
Create Github Action to release winget package

### DIFF
--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Submit package to Windows Package Manager Community Repository
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
-          identifier: f3d.F3D
+          identifier: f3d-app.f3d
           installers-regex: '^F3D-[\d\.]+-Windows-x86_64\.exe$'
           version: ${{ env.WINGET_TAG_NAME }}
           release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}

--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: F3d.F3d
-          installers-regex: '^F3D-[\d\.]+-Windows-x86_64.exe\.exe$'
+          installers-regex: '^F3D-[\d\.]+-Windows-x86_64\.exe$'
           version: ${{ env.WINGET_TAG_NAME }}
           release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}
           token: ${{ secrets.WINGET_ACC_TOKEN }}

--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -6,10 +6,8 @@ on:
     inputs:
       tag_name:
         description: "Specific tag name"
-        required: false
+        required: true
         type: string
-env:
-  CI: true
 jobs:
   winget-publish:
     name: Publish winget package
@@ -22,7 +20,7 @@ jobs:
       - name: Submit package to Windows Package Manager Community Repository
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
-          identifier: F3d.F3d
+          identifier: f3d.F3D
           installers-regex: '^F3D-[\d\.]+-Windows-x86_64\.exe$'
           version: ${{ env.WINGET_TAG_NAME }}
           release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}

--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -1,0 +1,29 @@
+name: Submit Winget Package to Windows Package Manager Community Repository
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Specific tag name"
+        required: false
+        type: string
+env:
+  CI: true
+jobs:
+  winget-publish:
+    name: Publish winget package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set winget version env
+        env:
+          TAG_NAME: ${{ inputs.tag_name || github.event.release.tag_name }}
+        run: echo "WINGET_TAG_NAME=$(echo ${TAG_NAME#v})" >> $GITHUB_ENV
+      - name: Submit package to Windows Package Manager Community Repository
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: F3d.F3d
+          installers-regex: '^F3D-[\d\.]+-Windows-x86_64.exe\.exe$'
+          version: ${{ env.WINGET_TAG_NAME }}
+          release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_ACC_TOKEN }}


### PR DESCRIPTION
Following issue https://github.com/f3d-app/f3d/issues/221 Uses [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) I suggest a `Classic Github Token` with `public_repo` scope is created by f3d-app org or another maintainer, following [this link](https://github.com/settings/tokens/new), then the Token can be added to the f3d repo as a secret named `WINGET_ACC_TOKEN`. See below, that user also will have to fork the winget-pkgs repository.

Notes:
> You will need to create a *classic* Personal Access Token (PAT) with `public_repo` scope. New fine-grained PATs aren't supported by the action. Review #172 for information.
> Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under the same account/organization as the project's repository. If you are forking winget-pkgs on a different account (e.g. bot/personal account), you can use the fork-user input to specify the username of the account where the fork is present.