### PR TITLE
WSL: Fixes related to the errors caused by Windows Subsystem Linux's strict compilation rules.

### DIFF
--- a/vtkext/private/module/vtkF3DInteractorEventRecorder.h
+++ b/vtkext/private/module/vtkF3DInteractorEventRecorder.h
@@ -23,6 +23,11 @@ public:
   vtkF3DInteractorEventRecorder(const vtkF3DInteractorEventRecorder&) = delete;
   void operator=(const vtkF3DInteractorEventRecorder&) = delete;
 
+  void WriteEvent(const char* eventId, int* position, int modifier, int keyCode, int repeatCount, 
+                char* keySym, void* callData);
+
+void Clear();
+
 protected:
   vtkF3DInteractorEventRecorder();
   ~vtkF3DInteractorEventRecorder() override = default;


### PR DESCRIPTION
The first fix involves the `WriteEvent` method in `vtkF3DInteractorEventRecorder`. The mentioned method passed down an extra argument called `void* callData` was never declared in the original header file. This caused a compilation error in WSL. To fix it I overloaded the `WriteEvent` function to handle additional argument as expected. For the second fix I declared the method `Clear()`. This method was used in `vtkF3DInteractorEventRecorder` with no declarations. I also improved on `SetInteractor` a bit so it works better in strict compilation environments. This improvement involves checking for null pointers, cleanup and state management.