### PR TITLE
WSL: Fixes related to the errors caused by Windows Subsystem Linux's strict compilation rules.

### DIFF
--- a/vtkext/private/module/vtkF3DInteractorEventRecorder.cxx
+++ b/vtkext/private/module/vtkF3DInteractorEventRecorder.cxx
@@ -34,6 +34,12 @@ void vtkF3DInteractorEventRecorder::SetInteractor(vtkRenderWindowInteractor* int
 }
 
 //------------------------------------------------------------------------------
+void vtkF3DInteractorEventRecorder::Clear()
+{
+  // Place holder
+}
+
+//------------------------------------------------------------------------------
 void vtkF3DInteractorEventRecorder::ProcessEvents(
   vtkObject* object, unsigned long event, void* clientData, void* callData)
 {
@@ -69,8 +75,8 @@ void vtkF3DInteractorEventRecorder::ProcessEvents(
           {
             mod |= ModifierKey::AltKey;
           }
-          self->WriteEvent(vtkCommand::GetStringFromEventId(event), rwi->GetEventPosition(), mod,
-            rwi->GetKeyCode(), rwi->GetRepeatCount(), rwi->GetKeySym(), callData);
+          self->WriteEvent(vtkCommand::GetStringFromEventId(event), rwi->GetEventPosition(), mod, 
+            rwi->GetKeyCode(), rwi->GetRepeatCount(), rwi->GetKeySym());
         }
     }
     self->OutputStream->flush();

--- a/vtkext/private/module/vtkF3DInteractorEventRecorder.h
+++ b/vtkext/private/module/vtkF3DInteractorEventRecorder.h
@@ -23,6 +23,8 @@ public:
   vtkF3DInteractorEventRecorder(const vtkF3DInteractorEventRecorder&) = delete;
   void operator=(const vtkF3DInteractorEventRecorder&) = delete;
 
+  void Clear();
+
 protected:
   vtkF3DInteractorEventRecorder();
   ~vtkF3DInteractorEventRecorder() override = default;


### PR DESCRIPTION
The error that I have encountered was related to the mismatch between the number of arguments passed to the WriteEvent function. The `vtkInteractorEventRecorder::WriteEvent` expects 6 arguments but the actual code calls this function with 7 arguments. The arguments are listed as; 

1. `vtkCommand::GetStringFromEventId(event) -> const char*`
2. `rwi->GetEventPosition() -> int*`
3. `mod -> int`
4. `rwi->GetKeyCode() -> int`
5. `rwi->GetRepeatCount() -> int`
6. `rwi->GetKeySym() -> char*`
7. `callData` -> This is an extra argument that isn't defined in `WriteEvent` function signature.

I removed the mentioned argument and now it seems to be working just fine. I will implement and handle `callData` separately in my next commit. I also implemented the `Clear()` function which wasn't properly defined before and added a placeholder which I will also implement.