### PR TITLE
Fix: --camera-index should override other camera options #1638

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -1101,7 +1101,7 @@ void F3DStarter::LoadFile(int index, bool relativeIndex)
         f3d::log::error("Could not load file: ", ex.what());
       }
 
-      if (!this->Internals->AppOptions.cameraIndexPassed && !this->Internals->AppOptions.NoRender)
+      if (!this->Internals->Options.scene.camera.index.hasValue() && !this->Internals->AppOptions.NoRender)
       {
         // Setup the camera according to options
         this->Internals->SetupCamera(this->Internals->AppOptions.CamConf);

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -69,7 +69,6 @@ public:
     std::string Output;
     bool NoBackground;
     bool NoRender;
-    bool cameraIndexPassed;
     double MaxSize;
     bool Watch;
     std::vector<std::string> Plugins;
@@ -673,11 +672,6 @@ int F3DStarter::Start(int argc, char** argv)
   {
     this->Internals->AppOptions.VerboseLevel =
       f3d::options::parse<std::string>(cliOptionsDict["verbose"]);
-  }
-  this->Internals->AppOptions.cameraIndexPassed = false;
-  if (cliOptionsDict.find("camera-index") != cliOptionsDict.end())
-  {
-    this->Internals->AppOptions.cameraIndexPassed = true;
   }
 
   // Set verbosity level early from command line

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -1101,7 +1101,7 @@ void F3DStarter::LoadFile(int index, bool relativeIndex)
         f3d::log::error("Could not load file: ", ex.what());
       }
 
-      if (!this->Internals->Options.scene.camera.index.hasValue() && !this->Internals->AppOptions.NoRender)
+      if (!dynamicOptions.scene.camera.index.has_value() && !this->Internals->AppOptions.NoRender)
       {
         // Setup the camera according to options
         this->Internals->SetupCamera(this->Internals->AppOptions.CamConf);

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -675,7 +675,8 @@ int F3DStarter::Start(int argc, char** argv)
       f3d::options::parse<std::string>(cliOptionsDict["verbose"]);
   }
   this->Internals->AppOptions.cameraIndexPassed = false;
-  if(cliOptionsDict.find("camera-index") != cliOptionsDict.end()){
+  if(cliOptionsDict.find("camera-index") != cliOptionsDict.end())
+  {
     this->Internals->AppOptions.cameraIndexPassed = true;
   }
 

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -69,6 +69,7 @@ public:
     std::string Output;
     bool NoBackground;
     bool NoRender;
+    bool cameraIndexPassed;
     double MaxSize;
     bool Watch;
     std::vector<std::string> Plugins;
@@ -673,6 +674,10 @@ int F3DStarter::Start(int argc, char** argv)
     this->Internals->AppOptions.VerboseLevel =
       f3d::options::parse<std::string>(cliOptionsDict["verbose"]);
   }
+  this->Internals->AppOptions.cameraIndexPassed = false;
+  if(cliOptionsDict.find("camera-index") != cliOptionsDict.end()){
+    this->Internals->AppOptions.cameraIndexPassed = true;
+  }
 
   // Set verbosity level early from command line
   F3DInternals::SetVerboseLevel(this->Internals->AppOptions.VerboseLevel, renderToStdout);
@@ -1095,7 +1100,7 @@ void F3DStarter::LoadFile(int index, bool relativeIndex)
         f3d::log::error("Could not load file: ", ex.what());
       }
 
-      if (!this->Internals->AppOptions.NoRender)
+      if (!this->Internals->AppOptions.cameraIndexPassed && !this->Internals->AppOptions.NoRender)
       {
         // Setup the camera according to options
         this->Internals->SetupCamera(this->Internals->AppOptions.CamConf);

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -675,7 +675,7 @@ int F3DStarter::Start(int argc, char** argv)
       f3d::options::parse<std::string>(cliOptionsDict["verbose"]);
   }
   this->Internals->AppOptions.cameraIndexPassed = false;
-  if(cliOptionsDict.find("camera-index") != cliOptionsDict.end())
+  if (cliOptionsDict.find("camera-index") != cliOptionsDict.end())
   {
     this->Internals->AppOptions.cameraIndexPassed = true;
   }

--- a/testing/baselines/TestCameraIndexConfiguration copy.png
+++ b/testing/baselines/TestCameraIndexConfiguration copy.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b05c80a105f945a3ed357c12bd5897e2650e02aaf7031c8d77867b53fa5c386
-size 1034

--- a/testing/baselines/TestCameraIndexConfiguration copy.png
+++ b/testing/baselines/TestCameraIndexConfiguration copy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b05c80a105f945a3ed357c12bd5897e2650e02aaf7031c8d77867b53fa5c386
+size 1034

--- a/testing/baselines/TestCameraIndexConfiguration.png
+++ b/testing/baselines/TestCameraIndexConfiguration.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7a2526caa6d4dfa9e222874b7429136c0da986c747a9ccc2d50c72846c6be4f
-size 1060
+oid sha256:0b05c80a105f945a3ed357c12bd5897e2650e02aaf7031c8d77867b53fa5c386
+size 1034


### PR DESCRIPTION
I have added an extra variable inside **F3DAppOptions** to track if `--camera-index` is passed through CLI arguments.

Fixes for: #1638 