### PR TITLE
Fix --help option priority

### DIFF
--- a/application/F3DOptionsTools.cxx
+++ b/application/F3DOptionsTools.cxx
@@ -492,36 +492,6 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
     cxxOptions.show_positional_help();
     auto result = cxxOptions.parse(argc, argv);
 
-    // Check for unknown options and log them
-    auto unmatched = result.unmatched();
-    bool foundUnknownOption = false;
-    for (const std::string& unknownOption : unmatched)
-    {
-      f3d::log::error("Unknown option '", unknownOption, "'");
-      foundUnknownOption = true;
-
-      // check if it's a long option
-      if (unknownOption.substr(0, 2) == "--")
-      {
-        const size_t equalPos = unknownOption.find('=');
-
-        // remove "--" and everything after the first "=" (if any)
-        const std::string unknownName =
-          unknownOption.substr(2, equalPos != std::string::npos ? equalPos - 2 : equalPos);
-
-        auto [closestName, dist] = F3DOptionsTools::GetClosestOption(unknownName);
-        const std::string closestOption =
-          equalPos == std::string::npos ? closestName : closestName + unknownOption.substr(equalPos);
-
-        f3d::log::error("Did you mean '--", closestOption, "'?");
-      }
-    }
-    if (foundUnknownOption)
-    {
-      f3d::log::waitForUser();
-      throw F3DExFailure("unknown options");
-    }
-
     // Check boolean options and log them if any
     if (result.count("help") > 0)
     {
@@ -550,6 +520,36 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
       F3DPluginsTools::LoadPlugins(plugins);
       ::PrintReadersList();
       throw F3DExNoProcess("reader list requested");
+    }
+
+    // Check for unknown options and log them
+    auto unmatched = result.unmatched();
+    bool foundUnknownOption = false;
+    for (const std::string& unknownOption : unmatched)
+    {
+      f3d::log::error("Unknown option '", unknownOption, "'");
+      foundUnknownOption = true;
+
+      // check if it's a long option
+      if (unknownOption.substr(0, 2) == "--")
+      {
+        const size_t equalPos = unknownOption.find('=');
+
+        // remove "--" and everything after the first "=" (if any)
+        const std::string unknownName =
+          unknownOption.substr(2, equalPos != std::string::npos ? equalPos - 2 : equalPos);
+
+        auto [closestName, dist] = F3DOptionsTools::GetClosestOption(unknownName);
+        const std::string closestOption =
+          equalPos == std::string::npos ? closestName : closestName + unknownOption.substr(equalPos);
+
+        f3d::log::error("Did you mean '--", closestOption, "'?");
+      }
+    }
+    if (foundUnknownOption)
+    {
+      f3d::log::waitForUser();
+      throw F3DExFailure("unknown options");
     }
 
     // Add each CLI options into a vector of string/string and return it

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -983,6 +983,12 @@ f3d_test(NAME TestBadRefNoOutput DATA cow.vtp ARGS --ref=${F3D_SOURCE_DIR}/testi
 # Test failure with a bad interaction play file, please do not create a dummy.log
 f3d_test(NAME TestPlayNoFile DATA cow.vtp ARGS --interaction-test-play=${CMAKE_BINARY_DIR}/Testing/Temporary/dummy.log WILL_FAIL)
 
+# Test that --help is displayed even when there is an unknown option
+f3d_test(NAME TestHelpPrecedenceWithUnknownOption ARGS --help --unknown REGEXP "F3D Command Line Help"  NO_BASELINE)
+
+# Test that --version is displayed even when there is an unknown option
+f3d_test(NAME TestVersionPrecedenceWithUnknownOption ARGS --version --unknown REGEXP "F3D Version" NO_BASELINE)
+
 # Test scan plugins
 if(NOT F3D_MACOS_BUNDLE)
   f3d_test(NAME TestScanPluginsCheckNative ARGS --scan-plugins NO_RENDER NO_BASELINE REGEXP " - native")

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -984,10 +984,10 @@ f3d_test(NAME TestBadRefNoOutput DATA cow.vtp ARGS --ref=${F3D_SOURCE_DIR}/testi
 f3d_test(NAME TestPlayNoFile DATA cow.vtp ARGS --interaction-test-play=${CMAKE_BINARY_DIR}/Testing/Temporary/dummy.log WILL_FAIL)
 
 # Test that --help is displayed even when there is an unknown option
-f3d_test(NAME TestHelpPrecedenceWithUnknownOption ARGS --help --unknown REGEXP "F3D Command Line Help"  NO_BASELINE)
+f3d_test(NAME TestHelpPrecedenceWithUnknownOption ARGS --help --unknown REGEXP "Usage:"  NO_BASELINE)
 
 # Test that --version is displayed even when there is an unknown option
-f3d_test(NAME TestVersionPrecedenceWithUnknownOption ARGS --version --unknown REGEXP "F3D Version" NO_BASELINE)
+f3d_test(NAME TestVersionPrecedenceWithUnknownOption ARGS --version --unknown REGEXP "Version:" NO_BASELINE)
 
 # Test scan plugins
 if(NOT F3D_MACOS_BUNDLE)


### PR DESCRIPTION
Fix [https://github.com/f3d-app/f3d/issues/1636](url)
Switched the order of checking for unknown and checking for help/version arguments. This ensures that if a user types something like f3d --help --unknown, the help message will be shown rather than just the error about the unknown option.