### PR TITLE
Fix wasm bindings

### DIFF
--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -100,7 +100,7 @@ EMSCRIPTEN_BINDINGS(f3d)
 
   // f3d::scene
   emscripten::class_<f3d::scene>("Scene")
-    .function("supported", &supported, emscripten::allow_raw_pointers())
+    .function("supports", &supports, emscripten::allow_raw_pointers())
     .function("add", &add, emscripten::allow_raw_pointers())
     .function("clear", &clear, emscripten::allow_raw_pointers());
 

--- a/webassembly/build.sh
+++ b/webassembly/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 cmake -S /src -B /build \
     -DBUILD_SHARED_LIBS=OFF \
     -DF3D_STRICT_BUILD=ON \


### PR DESCRIPTION
Fix the wasm build script to return the error code when a command is failing.  
Requires an update of the Docker image to fix the error: https://github.com/f3d-app/f3d-docker-images/pull/23  
Fix #1665 