### PR TITLE
CI: Fixup nightly logic

### DIFF
--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -111,7 +111,7 @@ runs:
         -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing=${{ inputs.raytracing_label == 'raytracing' && 'YES' || 'DEFAULT' }}
         -DVTK_MODULE_ENABLE_VTK_RenderingVolumeOpenGL2=YES
         -DVTK_MODULE_ENABLE_VTK_TestingCore=YES
-        -DVTK_OPENGL_HAS_EGL=${{ inputs.vtk_version == 'commit' && 'ON' || 'OFF' }}
+        -DVTK_OPENGL_HAS_EGL=${{ inputs.vtk_version != 'v9.2.6' && inputs.vtk_version != 'v9.3.1' && 'ON' || 'OFF' }}
         -DVTK_SMP_IMPLEMENTATION_TYPE=TBB
         -DVTK_VERSIONED_INSTALL=OFF
         ${{ runner.os == 'macOS' && '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15' || null }}

--- a/.github/workflows/nightly_vtk_master.yml
+++ b/.github/workflows/nightly_vtk_master.yml
@@ -123,7 +123,6 @@ jobs:
         build_type: ${{matrix.build_type}}
         vtk_version: ${{needs.check_nightly.outputs.vtk_sha}}
         raytracing_label: 'raytracing'
-        exclude_deprecated_label: ${{matrix.exclude_deprecated_label}}
         rendering_backend: ${{matrix.rendering_backend}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
 


### PR DESCRIPTION
Fix nightly CI logic in VTK action and also remove useless label in nightly CI.
Chaning cache number not needed has there is no cache used for nightly.