### PR TITLE
Remove build step from static analysis

### DIFF
--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -71,12 +71,6 @@ runs:
         -DF3D_STRICT_BUILD=ON
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
-    # It's necessary to run the build step to generate F3DIcon.h
-    - name: Build
-      shell: bash
-      working-directory: ${{github.workspace}}/build
-      run: cmake --build . --parallel 2
-
     - name: Clang-tidy
       shell: bash
       working-directory: ${{github.workspace}}/source


### PR DESCRIPTION
F3DIcon.h is now generated at configure-time. The build step should not be necessary.