### PR TITLE
Feature: Support Wavefront OBJ files with TGA Textures

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -934,6 +934,7 @@ int F3DStarter::Start(int argc, char** argv)
   // Add all input files
   for (auto& file : inputFiles)
   {
+    f3d::log::info("[gapry][issues][1281][", __PRETTY_FUNCTION__, "] ", file);
     this->AddFile(fs::path(file));
   }
 
@@ -1081,6 +1082,8 @@ int F3DStarter::Start(int argc, char** argv)
 //----------------------------------------------------------------------------
 void F3DStarter::LoadFileGroup(int index, bool relativeIndex, bool forceClear)
 {
+  f3d::log::info("[gapry][issues][1281][", __PRETTY_FUNCTION__, "] ", index, relativeIndex, forceClear);
+
   int groupIndex = this->Internals->CurrentFilesGroupIndex;
   if (relativeIndex)
   {
@@ -1126,6 +1129,10 @@ void F3DStarter::LoadFileGroup(int index, bool relativeIndex, bool forceClear)
 void F3DStarter::LoadFileGroup(
   const std::vector<fs::path>& paths, bool clear, const std::string& groupIdx)
 {
+  for(auto& p: paths) {
+    f3d::log::info("[gapry][issues][1281][", __PRETTY_FUNCTION__, "] " , p.string(), clear, groupIdx);
+  }
+
   // Make sure the animation is stopped before trying to load any file
   if (!this->Internals->AppOptions.NoRender)
   {
@@ -1158,7 +1165,7 @@ void F3DStarter::LoadFileGroup(
     dynamicOptionsDict, fs::path(), "dynamic options");
 
   // Recover file information
-  f3d::scene& scene = this->Internals->Engine->getScene();
+  f3d::scene& scene = this->Internals->Engine->getScene(); // [gapry][issues][1281]
   bool unsupported = false;
 
   std::vector<fs::path> localPaths;
@@ -1210,6 +1217,7 @@ void F3DStarter::LoadFileGroup(
             }
             else
             {
+              f3d::log::info("[gapry][issues][1281][", __PRETTY_FUNCTION__, "] ", tmpPath.string());
               localPaths.emplace_back(tmpPath);
             }
           }
@@ -1224,7 +1232,7 @@ void F3DStarter::LoadFileGroup(
       if (!localPaths.empty())
       {
         // Add files to the scene
-        scene.add(localPaths);
+        scene.add(localPaths); // [gapry][issues][1281]
 
         // Update loaded files
         std::copy(

--- a/library/src/scene_impl.cxx
+++ b/library/src/scene_impl.cxx
@@ -89,6 +89,8 @@ public:
 
   void Load(const std::vector<vtkSmartPointer<vtkImporter>>& importers)
   {
+    log::info(std::string("[gapry][issues][1281][") + __PRETTY_FUNCTION__ + "]");
+
     for (const vtkSmartPointer<vtkImporter>& importer : importers)
     {
       this->MetaImporter->AddImporter(importer);
@@ -243,6 +245,8 @@ scene& scene_impl::add(const std::vector<fs::path>& filePaths)
       throw scene::load_failure_exception(filePath.string() + " does not exists");
     }
 
+    f3d::log::info("[gapry][issues][1281][", __PRETTY_FUNCTION__, "] ", filePath.string());
+
     // Recover the importer for the provided file path
     f3d::reader* reader = f3d::factory::instance()->getReader(filePath.string());
     if (reader)
@@ -259,14 +263,14 @@ scene& scene_impl::add(const std::vector<fs::path>& filePaths)
     if (!importer)
     {
       // XXX: F3D Plugin CMake logic ensure there is either a scene reader or a geometry reader
-      auto vtkReader = reader->createGeometryReader(filePath.string());
+      auto vtkReader = reader->createGeometryReader(filePath.string()); // [gapry][issues][1281]
       assert(vtkReader);
       vtkSmartPointer<vtkF3DGenericImporter> genericImporter =
         vtkSmartPointer<vtkF3DGenericImporter>::New();
       genericImporter->SetInternalReader(vtkReader);
       importer = genericImporter;
     }
-    importers.emplace_back(importer);
+    importers.emplace_back(importer); // [gapry][issues][1281]
   }
 
   log::debug("\nLoading files: ");

--- a/vtkext/private/module/vtkF3DGenericImporter.cxx
+++ b/vtkext/private/module/vtkF3DGenericImporter.cxx
@@ -172,6 +172,8 @@ void vtkF3DGenericImporter::ImportActors(vtkRenderer* ren)
 //----------------------------------------------------------------------------
 void vtkF3DGenericImporter::SetInternalReader(vtkAlgorithm* reader)
 {
+  F3DLog::Print(F3DLog::Severity::Info, std::string("[gapry][issues][1281][") + __PRETTY_FUNCTION__ + "]");
+
   if (reader)
   {
     this->Pimpl->Reader = reader;

--- a/vtkext/private/module/vtkF3DMetaImporter.cxx
+++ b/vtkext/private/module/vtkF3DMetaImporter.cxx
@@ -75,7 +75,9 @@ void vtkF3DMetaImporter::Clear()
 //----------------------------------------------------------------------------
 void vtkF3DMetaImporter::AddImporter(const vtkSmartPointer<vtkImporter>& importer)
 {
-  this->Pimpl->Importers.emplace_back(vtkF3DMetaImporter::Internals::ImporterPair {importer, false});
+  F3DLog::Print(F3DLog::Severity::Info, std::string("[gapry][issues][1281][") + __PRETTY_FUNCTION__ + "] ");
+
+  this->Pimpl->Importers.emplace_back(vtkF3DMetaImporter::Internals::ImporterPair {importer, false}); // [gapry][issues][1281]
   this->Modified();
 
   // Add a progress event observer


### PR DESCRIPTION
## Related Issue:
This work addresses the Issue: https://github.com/f3d-app/f3d/issues/1281

## Current Progress 

I download the free assets, [DarkSider Mercy Gun 3D Model](https://free3d.com/3d-model/darksider-mercy-gun-25661.html), as the input data to work the Issue: https://github.com/f3d-app/f3d/issues/1281

```
$ ./build/bin/f3d assets/DarkSiderGun/GUN_OBJ.obj
```

For now, I've written some tracing code to find out where to add the supported code. Here is the current tracing output.
```
[gapry][issues][1281][int F3DStarter::Start(int, char**)] assets/DarkSiderGun/GUN_OBJ.obj
[gapry][issues][1281][void F3DStarter::LoadFileGroup(int, bool, bool)] 000
[gapry][issues][1281][void F3DStarter::LoadFileGroup(const std::vector<std::filesystem::__cxx11::path>&, bool, const std::string&)] /home/gapry/Workspaces/f3d/assets/DarkSiderGun/GUN_OBJ.obj1(1/1)
[gapry][issues][1281][void F3DStarter::LoadFileGroup(const std::vector<std::filesystem::__cxx11::path>&, bool, const std::string&)] /home/gapry/Workspaces/f3d/assets/DarkSiderGun/GUN_OBJ.obj
[gapry][issues][1281][virtual f3d::scene& f3d::detail::scene_impl::add(const std::vector<std::filesystem::__cxx11::path>&)] /home/gapry/Workspaces/f3d/assets/DarkSiderGun/GUN_OBJ.obj
[gapry][issues][1281][void f3d::detail::scene_impl::internals::Load(const std::vector<vtkSmartPointer<vtkImporter> >&)]
[gapry][issues][1281][void vtkF3DMetaImporter::AddImporter(const vtkSmartPointer<vtkImporter>&)]
```

I'm sorry, I haven't finished yet. I will keep trying, I think the key is `this->Pimpl->Importers`. I think I need to know who used it.
```cpp
void vtkF3DMetaImporter::AddImporter(const vtkSmartPointer<vtkImporter>& importer)
{
  F3DLog::Print(F3DLog::Severity::Info, std::string("[gapry][issues][1281][") + __PRETTY_FUNCTION__ + "] ");

  this->Pimpl->Importers.emplace_back(vtkF3DMetaImporter::Internals::ImporterPair {importer, false}); // [gapry][issues][1281]
  
  ... 
}  
```