### PR TITLE
escape quotes in dropped filenames

### DIFF
--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -434,8 +434,12 @@ public:
     {
       for (const std::string& command : commandsIt->second)
       {
-        const std::string commandWithArgs =
-          argsString.empty() ? command : command + " " + argsString;
+        std::string commandWithArgs = command;
+        if (!argsString.empty())
+        {
+          commandWithArgs.push_back(' ');
+          commandWithArgs.append(argsString);
+        };
         try
         {
           // XXX: Ignore the boolean return of triggerCommand,


### PR DESCRIPTION
`OnDropFiles()` needs to escape quotes in filenames before adding quotes around them.
Also `TriggerBinding()` should add a space between commands and first argument instead of expecting said space to be there already.