### PR TITLE
OnDropFiles: Add support for spaces, quotes and backslahes in filename

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -800,6 +800,7 @@ endif()
 f3d_test(NAME TestInteractionCycleAnimationNoAnimation DATA cow.vtp INTERACTION NO_BASELINE) #W
 
 f3d_test(NAME TestInteractionDropFiles ARGS -n INTERACTION_CONFIGURE)#X;DropEvent cow.vtp;DropEvent dragon.vtu suzanne.stl;
+f3d_test(NAME TestInteractionDropFileBackslashes ARGS -n INTERACTION_CONFIGURE)#X;DropEvent path\to\cow.vtp;
 f3d_test(NAME TestInteractionMultiFileDrop ARGS --multi-file-mode=all -e INTERACTION_CONFIGURE) #DropEvent mb_1_0.vtp mb_2_0.vtp
 f3d_test(NAME TestInteractionDropSameFiles ARGS -x INTERACTION_CONFIGURE)#DropEvent cow.vtp;#DropEvent dragon.vtu;#DropEvent cow.vtp#DropEvent cow.vtp;
 

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -800,12 +800,17 @@ endif()
 f3d_test(NAME TestInteractionCycleAnimationNoAnimation DATA cow.vtp INTERACTION NO_BASELINE) #W
 
 f3d_test(NAME TestInteractionDropFiles ARGS -n INTERACTION_CONFIGURE)#X;DropEvent cow.vtp;DropEvent dragon.vtu suzanne.stl;
-f3d_test(NAME TestInteractionDropFileBackslashes ARGS -n INTERACTION_CONFIGURE)#X;DropEvent path\to\cow.vtp;
 f3d_test(NAME TestInteractionMultiFileDrop ARGS --multi-file-mode=all -e INTERACTION_CONFIGURE) #DropEvent mb_1_0.vtp mb_2_0.vtp
 f3d_test(NAME TestInteractionDropSameFiles ARGS -x INTERACTION_CONFIGURE)#DropEvent cow.vtp;#DropEvent dragon.vtu;#DropEvent cow.vtp#DropEvent cow.vtp;
 
 # A proper test for this is not possible because of the double quotes
 f3d_test(NAME TestInteractionDropFileWithQuotes ARGS -n INTERACTION REGEXP "\"'`Quotes\"'`.stl does not exist" NO_BASELINE)#X;DropEvent "'`Quotes"'`.stl"; 
+
+if(WIN32)
+  # Windows specific drop test, force it on as Windows usually do not enabled LONG_TIMEOUT
+  f3d_test(NAME TestInteractionDropFileBackslashes ARGS -n INTERACTION_CONFIGURE)#X;DropEvent path\to\cow.vtp;
+  set_tests_properties(f3d::TestInteractionDropFileBackslashes PROPERTIES DISABLED OFF)
+endif()
 
 # HDRI test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9767
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20221220)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -803,6 +803,9 @@ f3d_test(NAME TestInteractionDropFiles ARGS -n INTERACTION_CONFIGURE)#X;DropEven
 f3d_test(NAME TestInteractionMultiFileDrop ARGS --multi-file-mode=all -e INTERACTION_CONFIGURE) #DropEvent mb_1_0.vtp mb_2_0.vtp
 f3d_test(NAME TestInteractionDropSameFiles ARGS -x INTERACTION_CONFIGURE)#DropEvent cow.vtp;#DropEvent dragon.vtu;#DropEvent cow.vtp#DropEvent cow.vtp;
 
+# A proper test for this is not possible because of the double quotes
+f3d_test(NAME TestInteractionDropFileWithQuotes ARGS -n INTERACTION REGEXP "\"'`Quotes\"'`.stl does not exist" NO_BASELINE)#X;DropEvent "'`Quotes"'`.stl"; 
+
 # HDRI test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9767
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20221220)
   f3d_test(NAME TestInteractionDropHDRI INTERACTION_CONFIGURE LONG_TIMEOUT)#X;DropEvent dragon.vtu;DropEven palermo.hdr;

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -807,9 +807,8 @@ f3d_test(NAME TestInteractionDropSameFiles ARGS -x INTERACTION_CONFIGURE)#DropEv
 f3d_test(NAME TestInteractionDropFileWithQuotes ARGS -n INTERACTION REGEXP "\"'`Quotes\"'`.stl does not exist" NO_BASELINE)#X;DropEvent "'`Quotes"'`.stl"; 
 
 if(WIN32)
-  # Windows specific drop test, force it on as Windows usually do not enabled LONG_TIMEOUT
+  # Windows specific drop test, using backslashes
   f3d_test(NAME TestInteractionDropFileBackslashes ARGS -n INTERACTION_CONFIGURE)#X;DropEvent path\to\cow.vtp;
-  set_tests_properties(f3d::TestInteractionDropFileBackslashes PROPERTIES DISABLED OFF)
 endif()
 
 # HDRI test needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9767

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -245,7 +245,7 @@ public:
   {
     internals* self = static_cast<internals*>(clientData);
     vtkStringArray* filesArr = static_cast<vtkStringArray*>(callData);
-    const std::regex charsToEscape("([\"\\\\])");
+    const std::regex charsToEscape(R"(([\"\\]))");
     std::string filesString;
     for (int i = 0; i < filesArr->GetNumberOfTuples(); i++)
     {

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -448,8 +448,7 @@ public:
         }
         catch (const f3d::interactor::command_runtime_exception& ex)
         {
-          log::error("Interaction: error running command:\"", commandWithArgs, "\":");
-          log::error(ex.what());
+          log::error("Interaction: error running command: \"" + commandWithArgs + "\": " + ex.what());
         }
       }
     }

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -245,7 +245,7 @@ public:
   {
     internals* self = static_cast<internals*>(clientData);
     vtkStringArray* filesArr = static_cast<vtkStringArray*>(callData);
-    const std::regex charsToEscape(R"(([\"\\]))");
+    const std::regex charsToEscape(R"((["\\]))");
     std::string filesString;
     for (int i = 0; i < filesArr->GetNumberOfTuples(); i++)
     {

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -448,7 +448,8 @@ public:
         }
         catch (const f3d::interactor::command_runtime_exception& ex)
         {
-          log::error("Interaction: error running command: \"" + commandWithArgs + "\": " + ex.what());
+          log::error(
+            "Interaction: error running command: \"" + commandWithArgs + "\": " + ex.what());
         }
       }
     }

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -245,7 +245,7 @@ public:
   {
     internals* self = static_cast<internals*>(clientData);
     vtkStringArray* filesArr = static_cast<vtkStringArray*>(callData);
-    const std::regex charsToEscape("([\"])");
+    const std::regex charsToEscape("([\"\\\\])");
     std::string filesString;
     for (int i = 0; i < filesArr->GetNumberOfTuples(); i++)
     {

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -434,8 +434,12 @@ public:
     {
       for (const std::string& command : commandsIt->second)
       {
-        const std::string commandWithArgs =
-          argsString.empty() ? command : command + " " + argsString;
+        std::string commandWithArgs = command;
+        if (!argsString.empty())
+        {
+          commandWithArgs.push_back(' ');
+          commandWithArgs.append(argsString);
+        };
         try
         {
           // XXX: Ignore the boolean return of triggerCommand,

--- a/library/src/utils.cxx
+++ b/library/src/utils.cxx
@@ -34,12 +34,8 @@ std::vector<std::string> utils::tokenize(std::string_view str)
         if (escaped)
         {
           accumulate(c);
-          escaped = false;
         }
-        else
-        {
-          escaped = true;
-        }
+        escaped = !escaped;
         break;
       case ' ':
         if (!escaped && !quoted)

--- a/library/src/utils.cxx
+++ b/library/src/utils.cxx
@@ -31,7 +31,15 @@ std::vector<std::string> utils::tokenize(std::string_view str)
     switch (c)
     {
       case '\\':
-        escaped = true;
+	if (escaped)
+        {
+          accumulate(c);
+          escaped = false;
+        }
+	else
+        {
+          escaped = true;
+        }
         break;
       case ' ':
         if (!escaped && !quoted)

--- a/library/src/utils.cxx
+++ b/library/src/utils.cxx
@@ -31,12 +31,12 @@ std::vector<std::string> utils::tokenize(std::string_view str)
     switch (c)
     {
       case '\\':
-	if (escaped)
+        if (escaped)
         {
           accumulate(c);
           escaped = false;
         }
-	else
+        else
         {
           escaped = true;
         }

--- a/library/testing/TestSDKUtils.cxx
+++ b/library/testing/TestSDKUtils.cxx
@@ -50,6 +50,10 @@ int TestSDKUtils(int argc, char* argv[])
     f3d::utils::tokenize(R"(set render.hdri.file file\ pa\th\ esc\ape)") ==
       std::vector<std::string>{ "set", "render.hdri.file", "file path escape" });
 
+  test("tokenize backslashes",
+    f3d::utils::tokenize(R"(set render.hdri.file file\\pa\\th\\backsl\\ashes)") ==
+      std::vector<std::string>{ "set", "render.hdri.file", R"(file\pa\th\backsl\ashes)" });
+
   test.expect<f3d::utils::tokenize_exception>("tokenize_exception with incomplete quotes",
     [&]() { f3d::utils::tokenize(R"(set render.hdri.file "file path back)"); });
 

--- a/testing/baselines/TestInteractionDropFileBackslashes.png
+++ b/testing/baselines/TestInteractionDropFileBackslashes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:462e52a090d2754bde9ac10eace164ddc729678bfbc7585a354dab6117898cd8
+size 22524

--- a/testing/recordings/TestInteractionDropFileBackslashes.log.in
+++ b/testing/recordings/TestInteractionDropFileBackslashes.log.in
@@ -1,0 +1,16 @@
+# StreamVersion 1.2
+ExposeEvent 0 599 0 0 0 0 0
+RenderEvent 0 599 0 0 0 0 0
+KeyPressEvent -475 76 0 120 1 x 0
+CharEvent -475 76 0 120 1 x 0
+TimerEvent -475 76 0 120 1 x 0
+TimerEvent -475 76 0 120 1 x 0
+KeyReleaseEvent -475 76 0 120 1 x 0
+KeyPressEvent 677 699 0 0 1 Super_L 0
+CharEvent 677 699 0 0 1 Super_L 0
+UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
+EnterEvent 781 494 0 0 0 Super_L 0
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 ${F3D_SOURCE_DIR}\testing\data\cow.vtp
+RenderEvent 781 494 0 0 0 Super_L 0
+MouseMoveEvent 781 498 0 0 0 Super_L 0
+LeaveEvent 751 614 0 0 0 Super_L 0

--- a/testing/recordings/TestInteractionDropFileWithQuotes.log
+++ b/testing/recordings/TestInteractionDropFileWithQuotes.log
@@ -1,0 +1,16 @@
+# StreamVersion 1.2
+ExposeEvent 0 599 0 0 0 0 0
+RenderEvent 0 599 0 0 0 0 0
+KeyPressEvent -475 76 0 120 1 x 0
+CharEvent -475 76 0 120 1 x 0
+TimerEvent -475 76 0 120 1 x 0
+TimerEvent -475 76 0 120 1 x 0
+KeyReleaseEvent -475 76 0 120 1 x 0
+KeyPressEvent 677 699 0 0 1 Super_L 0
+CharEvent 677 699 0 0 1 Super_L 0
+UpdateDropLocationEvent 677 699 0 0 1 Super_L 0
+EnterEvent 781 494 0 0 0 Super_L 0
+DropFilesEvent 781 494 0 0 0 Super_L 1 1 "'`Quotes"'`.stl
+RenderEvent 781 494 0 0 0 Super_L 0
+MouseMoveEvent 781 498 0 0 0 Super_L 0
+LeaveEvent 751 614 0 0 0 Super_L 0


### PR DESCRIPTION
`OnDropFiles()` needs to escape quotes and backslashes in filenames before adding quotes around them.
Also `TriggerBinding()` should add a space between commands and first argument instead of expecting said space to be there already.

Test for spaces in filename is not supported by the interaction testing mechanism.
Test for quotes in filename is supported but github actions do not like quotes in filenames, so testing is limited.
Test for backslashes in filename is supported on Windows

Superseed https://github.com/f3d-app/f3d/pull/1725