### PR TITLE
libf3d: Display N/A as a filename when empty

### DIFF
--- a/library/testing/CMakeLists.txt
+++ b/library/testing/CMakeLists.txt
@@ -4,6 +4,7 @@ list(APPEND libf3dSDKTests_list
      TestSDKCompareWithFile.cxx
      TestSDKDropZone.cxx
      TestSDKDynamicLightIntensity.cxx
+     TestSDKEmptyFilename.cxx
      TestSDKEngine.cxx
      TestSDKEngineExceptions.cxx
      TestSDKImage.cxx

--- a/library/testing/TestSDKEmptyFilename.cxx
+++ b/library/testing/TestSDKEmptyFilename.cxx
@@ -1,0 +1,25 @@
+#include <engine.h>
+#include <options.h>
+#include <scene.h>
+#include <window.h>
+
+#include "TestSDKHelpers.h"
+
+int TestSDKEmptyFilename(int argc, char* argv[])
+{
+  f3d::engine eng = f3d::engine::create(true);
+  f3d::scene& sce = eng.getScene();
+  f3d::window& win = eng.getWindow();
+  f3d::options& opt = eng.getOptions();
+  win.setSize(300, 300);
+  opt.ui.filename = true;
+
+  sce.add(std::string(argv[1]) + "/data/cow.vtp");
+
+  win.render();
+
+  return TestSDKHelpers::RenderTest(eng.getWindow(), std::string(argv[1]) + "baselines/",
+           std::string(argv[2]), "TestSDKEmptyFilename")
+    ? EXIT_SUCCESS
+    : EXIT_FAILURE;
+}

--- a/testing/baselines/TestSDKEmptyFilename.png
+++ b/testing/baselines/TestSDKEmptyFilename.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e6892fac90522c78ce3e20c98329b7901040145709402b26bd59ced1196eb2f
+size 19474

--- a/vtkext/private/module/vtkF3DImguiActor.cxx
+++ b/vtkext/private/module/vtkF3DImguiActor.cxx
@@ -285,10 +285,17 @@ vtkF3DImguiActor::~vtkF3DImguiActor() = default;
 //----------------------------------------------------------------------------
 void vtkF3DImguiActor::RenderFileName()
 {
+  // Make sure we always display something
+  std::string filename = "N/A";
+  if (!this->FileName.empty())
+  {
+    filename = this->FileName;
+  }
+
   ImGuiViewport* viewport = ImGui::GetMainViewport();
 
   constexpr float marginTop = 5.f;
-  ImVec2 winSize = ImGui::CalcTextSize(this->FileName.c_str());
+  ImVec2 winSize = ImGui::CalcTextSize(filename.c_str());
   winSize.x += 2.f * ImGui::GetStyle().WindowPadding.x;
   winSize.y += 2.f * ImGui::GetStyle().WindowPadding.y;
 
@@ -299,7 +306,7 @@ void vtkF3DImguiActor::RenderFileName()
     ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove;
 
   ImGui::Begin("FileName", nullptr, flags);
-  ImGui::TextUnformatted(this->FileName.c_str());
+  ImGui::TextUnformatted(filename.c_str());
   ImGui::End();
 }
 


### PR DESCRIPTION
 - Check for filename emptyness and set it to "N/A" in that case
 - Add a libf3d test
 - Fix https://github.com/f3d-app/f3d/issues/1532