### PR TITLE
untrack the .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ _version.py
 
 # wasm process related
 node_modules
+
+# vscode related
+.vscode/


### PR DESCRIPTION
The `.vscode` directory typically contains settings that can vary between developers, such as debugging configurations and personal preferences (e.g. the build tasks). To avoid unnecessary conflicts and ensure flexibility, it is better to exclude this directory from the repository.