### PR TITLE
Feature: add a PDAL plugin

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -3,6 +3,7 @@ option(F3D_PLUGIN_BUILD_ASSIMP "Assimp plugin (FBX, OFF, DAE, DXF, X and 3MF fil
 option(F3D_PLUGIN_BUILD_DRACO "Draco plugin (DRC files)" OFF)
 option(F3D_PLUGIN_BUILD_EXODUS "ExodusII plugin (EX2 files)" ON)
 option(F3D_PLUGIN_BUILD_OCCT "OpenCASCADE plugin (STEP and IGES files)" OFF)
+option(F3D_PLUGIN_BUILD_PDAL "PDAL plugin (Point cloud files)" OFF)
 option(F3D_PLUGIN_BUILD_USD "Universal Scene Description plugin (USD files)" OFF)
 option(F3D_PLUGIN_BUILD_VDB "VDB plugin, using OpenVDB (VDB files)" OFF)
 
@@ -26,6 +27,10 @@ endif()
 
 if (F3D_PLUGIN_BUILD_OCCT)
   add_subdirectory(occt)
+endif()
+
+if (F3D_PLUGIN_BUILD_PDAL)
+  add_subdirectory(pdal)
 endif()
 
 if (F3D_PLUGIN_BUILD_USD)

--- a/plugins/pdal/CMakeLists.txt
+++ b/plugins/pdal/CMakeLists.txt
@@ -14,3 +14,20 @@ endif()
 message(STATUS "[Gapry][PoC] Plugin: PDAL found")
 
 f3d_plugin_init()
+
+f3d_plugin_declare_reader(
+  NAME PDAL
+  EXTENSIONS bpf matlab npy pgpointcloud tiledb
+  MIMETYPES
+  VTK_IMPORTER vtkF3DPDALReader
+  FORMAT_DESCRIPTION "Point Cloud Data"
+)
+
+f3d_plugin_build(
+  NAME pdal
+  VERSION 1.0
+  DESCRIPTION "PDAL support"
+  VTK_MODULES IOPDAL
+  FREEDESKTOP
+)
+

--- a/plugins/pdal/CMakeLists.txt
+++ b/plugins/pdal/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(f3d-plugin-pdal)
+
+include(GNUInstallDirs)
+
+# Check if the plugin is built externally
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  find_package(f3d REQUIRED COMPONENTS pluginsdk)
+else()
+  include(${CMAKE_SOURCE_DIR}/cmake/f3dPlugin.cmake)
+endif()
+
+message(STATUS "[Gapry][PoC] Plugin: PDAL found")
+
+f3d_plugin_init()

--- a/plugins/pdal/module/CMakeLists.txt
+++ b/plugins/pdal/module/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(classes
+  vtkF3DPDALReader
+  )
+
+vtk_module_add_module(f3d::vtkF3DPDALReader
+  FORCE_STATIC
+  CLASSES ${classes})
+
+vtk_module_link(f3d::vtkF3DPDALReader PRIVATE ${PXR_LIBRARIES})
+
+vtk_module_include(f3d::vtkF3DPDALReader PRIVATE ${PXR_INCLUDE_DIRS})
+
+vtk_module_set_properties(f3d::vtkF3DPDALReader CXX_STANDARD 17)

--- a/plugins/pdal/module/vtk.module
+++ b/plugins/pdal/module/vtk.module
@@ -1,0 +1,6 @@
+NAME
+  f3d::vtkextPDAL
+DESCRIPTION
+  A VTK module for the PDAL plugin
+DEPENDS
+  VTK::IOPDAL

--- a/plugins/pdal/module/vtkF3DPDALReader.cxx
+++ b/plugins/pdal/module/vtkF3DPDALReader.cxx
@@ -1,0 +1,1 @@
+#include "vtkF3DPDALReader.h"

--- a/plugins/pdal/module/vtkF3DPDALReader.h
+++ b/plugins/pdal/module/vtkF3DPDALReader.h
@@ -1,0 +1,11 @@
+#ifndef vtkF3DPDALReader_h
+#define vtkF3DPDALReader_h
+
+#include "vtkPDALReader";
+
+class vtkF3DPDALReader : public vtkPDALReader {
+public:
+
+};
+
+#endif


### PR DESCRIPTION
## Related Issue:
This work addresses the Issue: https://github.com/f3d-app/f3d/issues/201

## How To Test the Plugin
```
rm -rf build
mkdir build
cd build
cmake -GNinja -DCMAKE_PREFIX_PATH="../vtk/install" -DF3D_MODULE_UI=OFF -DF3D_PLUGIN_BUILD_PDAL=ON ../src
ninja
```

## Current Issue:
1. Can not find the `VTK::IOPDAL` package  
   According to the VTK document, https://docs.vtk.org/en/latest/modules/index.html, I know I need to use `VTK::IOPDAL` so I define it in the `DEPENDS` section in the [vtk.module](https://github.com/gapry/f3d/blob/512bd4145183841fcecd1e98c9fe0e747bd546f4/plugins/pdal/module/vtk.module), but still can not compile, it occurs the following error. Any idea to help? Thanks
   ```
   Could not find the VTK package with the following required components:
   IOPDAL.
   ```
2. EXTENSIONS and MIMETYPES
   I refer to the USD Plugin [CMakeLists.txt](https://github.com/gapry/f3d/blob/master/plugins/usd/CMakeLists.txt) to write the PDAL Plugin [CMakeLists.txt](https://github.com/gapry/f3d/blob/512bd4145183841fcecd1e98c9fe0e747bd546f4/plugins/pdal/CMakeLists.txt)
   
   (a) I want to confirm if the **EXTENSIONS** `bpf matlab npy pgpointcloud tiledb` as listed in the [PDAL Reader document](https://pdal.io/en/stable/stages/readers.html), are considered plugin goals?

   (b) According to the USD Plugin [CMakeLists.txt](https://github.com/gapry/f3d/blob/master/plugins/usd/CMakeLists.txt), I need to locate files whose types are defined in the `MIMETYPES` for each category (e.g. application, model). Should all these files comply with the Creative Commons license? If yes, which types are required? https://creativecommons.org/share-your-work/cclicenses/