### PR TITLE
prepare for `pybind11-stubgen`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "f3d"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 description = "F3D, a fast and minimalist 3D viewer"
 readme = "README.md"

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -294,6 +294,15 @@ PYBIND11_MODULE(pyf3d, module)
     .def("load_animation_time", &f3d::scene::loadAnimationTime)
     .def("animation_time_range", &f3d::scene::animationTimeRange);
 
+  py::class_<f3d::camera_state_t>(module, "CameraState")
+    .def(py::init<>())
+    .def(py::init<const f3d::point3_t&, const f3d::point3_t&, const f3d::vector3_t&,
+      const f3d::angle_deg_t&>())
+    .def_readwrite("pos", &f3d::camera_state_t::pos)
+    .def_readwrite("foc", &f3d::camera_state_t::foc)
+    .def_readwrite("up", &f3d::camera_state_t::up)
+    .def_readwrite("angle", &f3d::camera_state_t::angle);
+
   // f3d::camera
   py::class_<f3d::camera, std::unique_ptr<f3d::camera, py::nodelete>> camera(module, "Camera");
   camera //
@@ -319,15 +328,6 @@ PYBIND11_MODULE(pyf3d, module)
     .def("set_current_as_default", &f3d::camera::setCurrentAsDefault)
     .def("reset_to_default", &f3d::camera::resetToDefault)
     .def("reset_to_bounds", &f3d::camera::resetToBounds, py::arg("zoom_factor") = 0.9);
-
-  py::class_<f3d::camera_state_t>(module, "CameraState")
-    .def(py::init<>())
-    .def(py::init<const f3d::point3_t&, const f3d::point3_t&, const f3d::vector3_t&,
-      const f3d::angle_deg_t&>())
-    .def_readwrite("pos", &f3d::camera_state_t::pos)
-    .def_readwrite("foc", &f3d::camera_state_t::foc)
-    .def_readwrite("up", &f3d::camera_state_t::up)
-    .def_readwrite("angle", &f3d::camera_state_t::angle);
 
   // f3d::window
   py::class_<f3d::window, std::unique_ptr<f3d::window, py::nodelete>> window(module, "Window");
@@ -366,6 +366,28 @@ PYBIND11_MODULE(pyf3d, module)
       "Get world coordinate point from display coordinate")
     .def("get_display_from_world", &f3d::window::getDisplayFromWorld,
       "Get display coordinate point from world coordinate");
+
+  // libInformation
+  py::class_<f3d::engine::libInformation>(module, "LibInformation")
+    .def_readonly("version", &f3d::engine::libInformation::Version)
+    .def_readonly("version_full", &f3d::engine::libInformation::VersionFull)
+    .def_readonly("build_date", &f3d::engine::libInformation::BuildDate)
+    .def_readonly("build_system", &f3d::engine::libInformation::BuildSystem)
+    .def_readonly("compiler", &f3d::engine::libInformation::Compiler)
+    .def_readonly("modules", &f3d::engine::libInformation::Modules)
+    .def_readonly("vtk_version", &f3d::engine::libInformation::VTKVersion)
+    .def_readonly("copyrights", &f3d::engine::libInformation::Copyrights)
+    .def_readonly("license", &f3d::engine::libInformation::License);
+
+  // readerInformation
+  py::class_<f3d::engine::readerInformation>(module, "ReaderInformation")
+    .def_readonly("name", &f3d::engine::readerInformation::Name)
+    .def_readonly("description", &f3d::engine::readerInformation::Description)
+    .def_readonly("extensions", &f3d::engine::readerInformation::Extensions)
+    .def_readonly("mime_types", &f3d::engine::readerInformation::MimeTypes)
+    .def_readonly("plugin_name", &f3d::engine::readerInformation::PluginName)
+    .def_readonly("has_scene_reader", &f3d::engine::readerInformation::HasSceneReader)
+    .def_readonly("has_geometry_reader", &f3d::engine::readerInformation::HasGeometryReader);
 
   // f3d::engine
   py::class_<f3d::engine> engine(module, "Engine");
@@ -406,38 +428,8 @@ PYBIND11_MODULE(pyf3d, module)
     .def_static("get_lib_info", &f3d::engine::getLibInfo, py::return_value_policy::reference)
     .def_static("get_readers_info", &f3d::engine::getReadersInfo);
 
-  // libInformation
-  py::class_<f3d::engine::libInformation>(module, "LibInformation")
-    .def_readonly("version", &f3d::engine::libInformation::Version)
-    .def_readonly("version_full", &f3d::engine::libInformation::VersionFull)
-    .def_readonly("build_date", &f3d::engine::libInformation::BuildDate)
-    .def_readonly("build_system", &f3d::engine::libInformation::BuildSystem)
-    .def_readonly("compiler", &f3d::engine::libInformation::Compiler)
-    .def_readonly("modules", &f3d::engine::libInformation::Modules)
-    .def_readonly("vtk_version", &f3d::engine::libInformation::VTKVersion)
-    .def_readonly("copyrights", &f3d::engine::libInformation::Copyrights)
-    .def_readonly("license", &f3d::engine::libInformation::License);
-
-  // readerInformation
-  py::class_<f3d::engine::readerInformation>(module, "ReaderInformation")
-    .def_readonly("name", &f3d::engine::readerInformation::Name)
-    .def_readonly("description", &f3d::engine::readerInformation::Description)
-    .def_readonly("extensions", &f3d::engine::readerInformation::Extensions)
-    .def_readonly("mime_types", &f3d::engine::readerInformation::MimeTypes)
-    .def_readonly("plugin_name", &f3d::engine::readerInformation::PluginName)
-    .def_readonly("has_scene_reader", &f3d::engine::readerInformation::HasSceneReader)
-    .def_readonly("has_geometry_reader", &f3d::engine::readerInformation::HasGeometryReader);
-
   // f3d::log
   py::class_<f3d::log> log(module, "Log");
-
-  log //
-    .def_static("set_verbose_level", &f3d::log::setVerboseLevel, py::arg("level"),
-      py::arg("force_std_err") = false)
-    .def_static("set_use_coloring", &f3d::log::setUseColoring)
-    .def_static("print",
-      [](f3d::log::VerboseLevel& level, const std::string& message)
-      { f3d::log::print(level, message); });
 
   py::enum_<f3d::log::VerboseLevel>(log, "VerboseLevel")
     .value("DEBUG", f3d::log::VerboseLevel::DEBUG)
@@ -446,4 +438,11 @@ PYBIND11_MODULE(pyf3d, module)
     .value("ERROR", f3d::log::VerboseLevel::ERROR)
     .value("QUIET", f3d::log::VerboseLevel::QUIET)
     .export_values();
+
+  log //
+    .def_static("set_verbose_level", &f3d::log::setVerboseLevel, py::arg("level"),
+      py::arg("force_std_err") = false)
+    .def_static("set_use_coloring", &f3d::log::setUseColoring)
+    .def_static("print", [](f3d::log::VerboseLevel& level, const std::string& message)
+      { f3d::log::print(level, message); });
 }

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -443,6 +443,7 @@ PYBIND11_MODULE(pyf3d, module)
     .def_static("set_verbose_level", &f3d::log::setVerboseLevel, py::arg("level"),
       py::arg("force_std_err") = false)
     .def_static("set_use_coloring", &f3d::log::setUseColoring)
-    .def_static("print", [](f3d::log::VerboseLevel& level, const std::string& message)
-      { f3d::log::print(level, message); });
+    .def_static("print",
+      [](f3d::log::VerboseLevel& level, const std::string& message)
+       { f3d::log::print(level, message); });
 }

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -445,5 +445,5 @@ PYBIND11_MODULE(pyf3d, module)
     .def_static("set_use_coloring", &f3d::log::setUseColoring)
     .def_static("print",
       [](f3d::log::VerboseLevel& level, const std::string& message)
-       { f3d::log::print(level, message); });
+      { f3d::log::print(level, message); });
 }

--- a/python/__init__.py.in
+++ b/python/__init__.py.in
@@ -2,10 +2,11 @@
 # Refer to python/__init__.py.in source file
 
 import os
-import sys
 import re
+import sys
 import warnings
 from pathlib import Path
+from typing import Any, Iterable, Mapping, Union
 
 F3D_ABSOLUTE_DLLS = [
     # @F3D_ABSOLUTE_DLLS_FIXUP@
@@ -32,7 +33,9 @@ __version__ = "@F3D_VERSION@"
 # monkey patch `options.update`
 
 
-def f3d_options_update(self, arg):
+def _f3d_options_update(
+    self, arg: Union[Mapping[str, Any], Iterable[tuple[str, Any]]]
+) -> None:
     try:
         for k, v in arg.items():
             self[k] = v
@@ -47,17 +50,17 @@ def f3d_options_update(self, arg):
     except AttributeError:
         pass
 
-    raise ValueError(f"cannot update {self} from {args}")
+    raise ValueError(f"cannot update {self} from {arg}")
 
 
-Options.update = f3d_options_update
+Options.update = _f3d_options_update
 
 
 ################################################################################
 # add deprecated warnings
 
 
-def deprecated_decorator(f, reason):
+def _deprecated_decorator(f, reason):
     def g(*args, **kwargs):
         warnings.warn(reason, DeprecationWarning, 2)
         return f(*args, **kwargs)
@@ -65,7 +68,7 @@ def deprecated_decorator(f, reason):
     return g
 
 
-def add_deprecation_warnings():
+def _add_deprecation_warnings():
     for f3d_class in (
         Camera,
         Scene,
@@ -73,6 +76,7 @@ def add_deprecation_warnings():
         Interactor,
         Engine,
         Window,
+        Image,
     ):
         for name, member in f3d_class.__dict__.items():
             if callable(member) and member.__doc__:
@@ -80,7 +84,7 @@ def add_deprecation_warnings():
                 if m:
                     reason = m.group(1) or ""
                     msg = f"{f3d_class.__qualname__}.{name} is deprecated{reason}"
-                    setattr(f3d_class, name, deprecated_decorator(member, msg))
+                    setattr(f3d_class, name, _deprecated_decorator(member, msg))
 
 
-add_deprecation_warnings()
+_add_deprecation_warnings()

--- a/python/__init__.py.in
+++ b/python/__init__.py.in
@@ -28,10 +28,6 @@ Engine.autoload_plugins()
 __version__ = "@F3D_VERSION@"
 
 
-point3_t = tuple[float, float, float]
-vector3_t = tuple[float, float, float]
-
-
 ################################################################################
 # monkey patch `options.update`
 

--- a/python/__init__.py.in
+++ b/python/__init__.py.in
@@ -28,6 +28,10 @@ Engine.autoload_plugins()
 __version__ = "@F3D_VERSION@"
 
 
+point3_t = tuple[float, float, float]
+vector3_t = tuple[float, float, float]
+
+
 ################################################################################
 # monkey patch `options.update`
 

--- a/python/generate_stubs.py
+++ b/python/generate_stubs.py
@@ -1,0 +1,85 @@
+import re
+import subprocess
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+from tempfile import TemporaryDirectory, gettempdir
+
+
+def main():
+    argparser = ArgumentParser()
+    argparser.add_argument(
+        "-o",
+        "--into",
+        help="output directory for the post-processed stubs",
+        default=gettempdir(),
+    )
+    args = argparser.parse_args()
+
+    with TemporaryDirectory() as tmp_dir:
+        run_pybind11_stubgen(tmp_dir)
+        postprocess_generated_stubs(tmp_dir, args.into)
+
+
+def run_pybind11_stubgen(out_dir: str):
+    stubgen_cmd = (
+        # use current python interpreter to run stubs generation for the `f3d` module
+        *(sys.executable, "-m", "pybind11_stubgen", "f3d"),
+        # fix enum for default values in `Image.save()` and `Image.save_buffer()`
+        *("--enum-class-locations", "SaveFormat:Image"),
+        # ignore `f3d.vector3_t` and `f3d.point3_t` as we dont actually map them
+        # but let them auto-convert from and to `tuple[float, float, float]`
+        # (all occurrences will be postprocessed later)
+        *("--ignore-unresolved-names", r"f3d\.(vector3_t|point3_t)"),
+        # output in temporary directory as we're going to post process
+        *("--output-dir", out_dir),
+    )
+    subprocess.check_call(stubgen_cmd)
+
+
+def postprocess_generated_stubs(stubs_dir: str, into: str):
+    replacements = [
+        (
+            # change `point3_t` and `vector3_t` parameter annotations and return types
+            # to `tuple[float, float, float]`
+            r"((:|->)\s*)f3d\.(vector3_t|point3_t)",
+            r"\1tuple[float, float, float]",
+        ),
+        (
+            # remove `point3_t` and `vector3_t` being imported `as tuple`
+            r"from builtins import tuple as (vector3_t|point3_t)[\n\r]+",
+            r"",
+        ),
+        (
+            # add missing template parameter to raw `os.PathLike` (`os.PathLike[str | bytes]`)
+            r"(PathLike)(?!\[)",
+            r"\1[str | bytes]",
+        ),
+        (
+            # remove `_pybind11_conduit_v1_` static methods
+            r"^\s+@staticmethod[\n\r]+\s+def _pybind11_conduit_v1_\(\*args, \*\*kwargs\):[\n\r]+\s+\.\.\.[\n\r]",
+            "",
+        ),
+    ]
+
+    tmp_dir = Path(stubs_dir)
+    out_dir = Path(into)
+
+    for tmp_fn in tmp_dir.glob("**/*.pyi"):
+        rel_fn = tmp_fn.relative_to(tmp_dir)
+        out_fn = out_dir / rel_fn
+        out_fn.parent.mkdir(exist_ok=True, parents=True)
+
+        src = tmp_fn.read_text()
+        for pattern, repl in replacements:
+            src = re.sub(pattern, repl, src, flags=re.MULTILINE)
+        out_fn.write_text(src)
+
+        try:
+            subprocess.call(["diff", "-u", str(tmp_fn), str(out_fn)])
+        except IOError:
+            pass  # no `diff` executable
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
It seems like https://github.com/sizmailov/pybind11-stubgen is now mature enough to generate the `f3d` bindings stubs automatically.

In order to properly generate the stubs we need to:
- reorder some bindings declaration so that everything is known before it is referenced
- use `----ignore-unresolved-names` to ignore `f3d::point3_t` and `f3d::vector3_t` as we don't actually map them but let them auto-convert to and from `tuple[float, float, float]`
- use `--enum-class-locations SaveFormat:Image` to allow proper identification of the default value for the `format` parameters of `Image.save()` and `Image.save_buffer()`
- do some post-processing to clean up a few thing

With this PR's changes we can run the new `generate_stubs.py` script to generate the `.pyi` files