### PR TITLE
Use specific version of python in CI

### DIFF
--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.13'
 
     - name: Install Python dependencies
       shell: bash
@@ -89,11 +89,6 @@ runs:
         -DF3D_MODULE_EXR=ON;
         -DF3D_MODULE_UI=ON;
         -DF3D_WINDOWS_GUI=OFF" >> $GITHUB_ENV
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
 
     - name: Build wheel
       shell: bash


### PR DESCRIPTION
 - Use specific version of python in CI
 - Use 3.13 instead of 3.12
 - Remove useless setup-python step