### PR TITLE
Use C++17 in context API

### DIFF
--- a/library/public/context.h
+++ b/library/public/context.h
@@ -64,7 +64,7 @@ public:
    * For example, `getSymbol("EGL", "eglGetProcAddress")` looks for the symbol
    * `eglGetProcAddress` in the library `libEGL.so` on Linux.
    */
-  [[nodiscard]] static function getSymbol(const std::string& lib, const std::string& func);
+  [[nodiscard]] static function getSymbol(std::string_view lib, std::string_view func);
 
   /**
    * An exception that can be thrown when the requested library cannot be loaded.

--- a/library/src/context.cxx
+++ b/library/src/context.cxx
@@ -16,7 +16,7 @@
 namespace f3d
 {
 //----------------------------------------------------------------------------
-context::function context::getSymbol(const std::string& lib, const std::string& func)
+context::function context::getSymbol(std::string_view lib, std::string_view func)
 {
   std::string libName = vtksys::DynamicLoader::LibPrefix();
   libName += lib;
@@ -26,16 +26,17 @@ context::function context::getSymbol(const std::string& lib, const std::string& 
 
   if (!handle)
   {
-    throw context::loading_exception("Cannot find " + lib + " library");
+    throw context::loading_exception("Cannot find " + std::string(lib) + " library");
   }
 
   using symbol = context::fptr (*)(const char*);
 
-  symbol address = reinterpret_cast<symbol>(vtksys::DynamicLoader::GetSymbolAddress(handle, func));
+  symbol address =
+    reinterpret_cast<symbol>(vtksys::DynamicLoader::GetSymbolAddress(handle, func.data()));
 
   if (!address)
   {
-    throw context::symbol_exception("Cannot find " + func + " symbol");
+    throw context::symbol_exception("Cannot find " + std::string(func) + " symbol");
   }
 
   return address;


### PR DESCRIPTION
` getSymbol(const std::string& lib, const std::string& func)` -> ` getSymbol(std::string_view lib, std::string_view func)` 

Part of https://github.com/f3d-app/f3d/issues/1624