### PR TITLE
vtkext: Fix a small issue with CollapseFullPath usage in hdri-file an…

### DIFF
--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -637,8 +637,8 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
 void vtkF3DRenderer::SetHDRIFile(const std::optional<std::string>& hdriFile)
 {
   // Check HDRI is different than current one
-  std::optional<std::string> collapsedHdriFile;
-  if (hdriFile.has_value())
+  std::string collapsedHdriFile;
+  if (hdriFile.has_value() && !hdriFile.value().empty())
   {
     collapsedHdriFile = vtksys::SystemTools::CollapseFullPath(hdriFile.value());
   }
@@ -770,25 +770,25 @@ void vtkF3DRenderer::ConfigureHDRIReader()
   {
     this->UseDefaultHDRI = false;
     this->HDRIReader = nullptr;
-    if (this->HDRIFile.has_value())
+    if (!this->HDRIFile.empty())
     {
-      if (!vtksys::SystemTools::FileExists(this->HDRIFile.value(), true))
+      if (!vtksys::SystemTools::FileExists(this->HDRIFile, true))
       {
         F3DLog::Print(
-          F3DLog::Severity::Warning, std::string("HDRI file does not exist ") + this->HDRIFile.value());
+          F3DLog::Severity::Warning, std::string("HDRI file does not exist ") + this->HDRIFile);
       }
       else
       {
         this->HDRIReader = vtkSmartPointer<vtkImageReader2>::Take(
-          vtkImageReader2Factory::CreateImageReader2(this->HDRIFile.value().c_str()));
+          vtkImageReader2Factory::CreateImageReader2(this->HDRIFile.c_str()));
         if (this->HDRIReader)
         {
-          this->HDRIReader->SetFileName(this->HDRIFile.value().c_str());
+          this->HDRIReader->SetFileName(this->HDRIFile.c_str());
         }
         else
         {
           F3DLog::Print(F3DLog::Severity::Warning,
-            std::string("Cannot open HDRI file ") + this->HDRIFile.value() +
+            std::string("Cannot open HDRI file ") + this->HDRIFile +
               std::string(". Using default HDRI"));
         }
       }
@@ -821,8 +821,8 @@ void vtkF3DRenderer::ConfigureHDRIHash()
     }
     else
     {
-      // Compute HDRI MD5, here we know the HDRIFile has a value
-      this->HDRIHash = ::ComputeFileHash(this->HDRIFile.value());
+      // Compute HDRI MD5, here we know the HDRIFile is not empty
+      this->HDRIHash = ::ComputeFileHash(this->HDRIFile);
     }
     this->HasValidHDRIHash = true;
     this->CreateCacheDirectory();
@@ -1080,7 +1080,7 @@ void vtkF3DRenderer::ConfigureTextActors()
 
   // Font
   this->DropZoneActor->GetTextProperty()->SetFontFamilyToCourier();
-  if (this->FontFile.has_value())
+  if (this->FontFile.has_value() && !this->FontFile.value().empty())
   {
     std::string tmpFontFile = vtksys::SystemTools::CollapseFullPath(this->FontFile.value());
     if (vtksys::SystemTools::FileExists(tmpFontFile, true))

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -527,7 +527,7 @@ private:
   int GridSubdivisions = 10;
   double GridColor[3] = { 0.0, 0.0, 0.0 };
 
-  std::optional<std::string> HDRIFile;
+  std::string HDRIFile;
   vtkSmartPointer<vtkImageReader2> HDRIReader;
   bool HasValidHDRIReader = false;
   bool UseDefaultHDRI = false;


### PR DESCRIPTION
…d font-file

 - Avoid an issue where CollapseFullPath would generate a path to current directory with the empty string
 - Refactor the HDRI file to simplify it