### PR TITLE
Improve fps counter 

### DIFF
--- a/vtkext/private/module/Testing/CMakeLists.txt
+++ b/vtkext/private/module/Testing/CMakeLists.txt
@@ -8,6 +8,7 @@ set(test_sources
   TestF3DOpenGLGridMapper.cxx
   TestF3DRenderPass.cxx
   TestF3DRendererWithColoring.cxx
+  TestF3DFpsCounter.cxx
   )
 
 if(F3D_MODULE_EXR)

--- a/vtkext/private/module/Testing/TestF3DFpsCounter.cxx
+++ b/vtkext/private/module/Testing/TestF3DFpsCounter.cxx
@@ -1,0 +1,54 @@
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+
+#include "vtkF3DUIActor.h"
+
+#include <iostream>
+
+// subclass to retrieve internal protected values
+class vtkF3DTestUIActor : public vtkF3DUIActor
+{
+public:
+  static vtkF3DTestUIActor* New();
+  vtkTypeMacro(vtkF3DTestUIActor, vtkF3DUIActor);
+
+  size_t GetNumberOfFrameTimes() { return this->FrameTimes.size(); }
+  double GetTotalFrameTimes() { return this->TotalFrameTimes; }
+  int GetFpsValue() { return this->FpsValue; }
+};
+
+vtkObjectFactoryNewMacro(vtkF3DTestUIActor);
+
+int TestF3DFpsCounter(int argc, char* argv[])
+{
+  vtkNew<vtkF3DTestUIActor> uiActor;
+
+  // add 1000 frames at 0.01s
+  for (int i = 0; i < 1000; i++)
+  {
+    uiActor->UpdateFpsValue(0.01);
+  }
+
+  // make sure only the 100 last records are kept
+  if (uiActor->GetNumberOfFrameTimes() > 100)
+  {
+    std::cerr << "Number of frame times must be at most 100" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // make sure only the total time kept doesn't exceed 1 second
+  if (uiActor->GetTotalFrameTimes() > 1.0)
+  {
+    std::cerr << "Number of total frame times must be at most 1.0" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // make sure the FPS value is exactly 100
+  if (uiActor->GetFpsValue() != 100)
+  {
+    std::cerr << "Number of FPS value must be exactly 100" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1545,21 +1545,21 @@ void vtkF3DRenderer::Render()
 
   bool uiOnly = info->Get(vtkF3DRenderPass::RENDER_UI_ONLY());
 
-  if (! uiOnly)
+  if (!uiOnly)
   {
 	  // Get CPU frame time
-	  double elapsedTime = std::chrono::duration_cast<std::chrono::microseconds>(cpuElapsed).count() * 1e-6;
+    double elapsedTime = std::chrono::duration_cast<std::chrono::microseconds>(cpuElapsed).count() * 1e-6;
 
 #if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
-	  glEndQuery(GL_TIME_ELAPSED);
-	  GLint elapsed;
-	  glGetQueryObjectiv(this->Timer, GL_QUERY_RESULT, &elapsed);
+	glEndQuery(GL_TIME_ELAPSED);
+	GLint elapsed;
+	glGetQueryObjectiv(this->Timer, GL_QUERY_RESULT, &elapsed);
 
-	  // Get min between CPU frame time and GPU frame time
-	  elapsedTime = std::min(elapsedTime, elapsed * 1e-9);
+	// Get min between CPU frame time and GPU frame time
+	elapsedTime = std::min(elapsedTime, elapsed * 1e-9);
 #endif
 
-	  this->UIActor->UpdateFpsValue(elapsedTime);
+	this->UIActor->UpdateFpsValue(elapsedTime);
   }
 }
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1554,7 +1554,7 @@ void vtkF3DRenderer::Render()
   fps = std::min(fps, static_cast<int>(std::round(1.0 / (elapsed * 1e-9))));
 #endif
 
-  this->UIActor->SetFpsValue(fps);
+  this->UIActor->UpdateFpsValue(fps);
 }
 
 //----------------------------------------------------------------------------

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1547,19 +1547,19 @@ void vtkF3DRenderer::Render()
 
   if (!uiOnly)
   {
-	  // Get CPU frame time
-    double elapsedTime = std::chrono::duration_cast<std::chrono::microseconds>(cpuElapsed).count() * 1e-6;
+   // Get CPU frame time
+   double elapsedTime = std::chrono::duration_cast<std::chrono::microseconds>(cpuElapsed).count() * 1e-6;
 
 #if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
-	glEndQuery(GL_TIME_ELAPSED);
-	GLint elapsed;
-	glGetQueryObjectiv(this->Timer, GL_QUERY_RESULT, &elapsed);
+   glEndQuery(GL_TIME_ELAPSED);
+   GLint elapsed;
+   glGetQueryObjectiv(this->Timer, GL_QUERY_RESULT, &elapsed);
 
-	// Get min between CPU frame time and GPU frame time
-	elapsedTime = std::min(elapsedTime, elapsed * 1e-9);
+   // Get min between CPU frame time and GPU frame time
+   elapsedTime = std::min(elapsedTime, elapsed * 1e-9);
 #endif
 
-	this->UIActor->UpdateFpsValue(elapsedTime);
+   this->UIActor->UpdateFpsValue(elapsedTime);
   }
 }
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1547,20 +1547,19 @@ void vtkF3DRenderer::Render()
 
   if (! uiOnly)
   {
-  // Get CPU frame per seconds
-  int fps = static_cast<int>(std::round(
-    1.0 / (std::chrono::duration_cast<std::chrono::microseconds>(cpuElapsed).count() * 1e-6)));
+	  // Get CPU frame time
+	  double elapsedTime = std::chrono::duration_cast<std::chrono::microseconds>(cpuElapsed).count() * 1e-6;
 
 #if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
-  glEndQuery(GL_TIME_ELAPSED);
-  GLint elapsed;
-  glGetQueryObjectiv(this->Timer, GL_QUERY_RESULT, &elapsed);
+	  glEndQuery(GL_TIME_ELAPSED);
+	  GLint elapsed;
+	  glGetQueryObjectiv(this->Timer, GL_QUERY_RESULT, &elapsed);
 
-  // Get min between CPU frame per seconds and GPU frame per seconds
-  fps = std::min(fps, static_cast<int>(std::round(1.0 / (elapsed * 1e-9))));
+	  // Get min between CPU frame time and GPU frame time
+	  elapsedTime = std::min(elapsedTime, elapsed * 1e-9);
 #endif
 
-  this->UIActor->UpdateFpsValue(fps);
+	  this->UIActor->UpdateFpsValue(elapsedTime);
   }
 }
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1541,6 +1541,12 @@ void vtkF3DRenderer::Render()
 
   auto cpuElapsed = std::chrono::high_resolution_clock::now() - cpuStart;
 
+  vtkInformation *info = this->GetInformation();
+
+  bool uiOnly = info->Get(vtkF3DRenderPass::RENDER_UI_ONLY());
+
+  if (! uiOnly)
+  {
   // Get CPU frame per seconds
   int fps = static_cast<int>(std::round(
     1.0 / (std::chrono::duration_cast<std::chrono::microseconds>(cpuElapsed).count() * 1e-6)));
@@ -1555,6 +1561,7 @@ void vtkF3DRenderer::Render()
 #endif
 
   this->UIActor->UpdateFpsValue(fps);
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/vtkext/private/module/vtkF3DUIActor.cxx
+++ b/vtkext/private/module/vtkF3DUIActor.cxx
@@ -72,7 +72,7 @@ void vtkF3DUIActor::UpdateFpsValue(int fps)
   this->AccumulatedFpsValue += fps;
   this->FramesAccumulated++;
 
-  if (this->FramesAccumulated == vtkF3DUI::FramesToAverage)
+  if (this->FramesAccumulated == vtkF3DUIActor::FramesToAverage)
   {
 	  this->FpsValue = static_cast<int>(this->AccumulatedFpsValue / this->FramesAccumulated);
 

--- a/vtkext/private/module/vtkF3DUIActor.cxx
+++ b/vtkext/private/module/vtkF3DUIActor.cxx
@@ -71,16 +71,17 @@ void vtkF3DUIActor::SetFpsCounterVisibility(bool show)
 //----------------------------------------------------------------------------
 void vtkF3DUIActor::UpdateFpsValue(const double elapsedFrameTime)
 {
+	this->TotalFrameTimes += elapsedFrameTime;
 	this->FrameTimes.push_back(elapsedFrameTime);
 
-	// add window size check here
-	if (this->FrameTimes.size() == 6)
+	while (this->TotalFrameTimes > 1.0)
 	{
+		double t = this->FrameTimes.front();
 		this->FrameTimes.pop_front();
+		this->TotalFrameTimes -= t;
 	}
 
-	double averageFrameTime = std::accumulate(this->FrameTimes.begin(), this->FrameTimes.end(), 0.0) / this->FrameTimes.size();
-
+	double averageFrameTime = this->TotalFrameTimes / this->FrameTimes.size();
 	this->FpsValue = static_cast<int>(std::round(1.0 / averageFrameTime));
 }
 

--- a/vtkext/private/module/vtkF3DUIActor.cxx
+++ b/vtkext/private/module/vtkF3DUIActor.cxx
@@ -77,7 +77,7 @@ void vtkF3DUIActor::UpdateFpsValue(const double elapsedFrameTime)
     double oldestFrameTime = this->FrameTimes.front();
 
     this->FrameTimes.pop_front();
-	this->TotalFrameTimes -= oldestFrameTime;
+    this->TotalFrameTimes -= oldestFrameTime;
   }
 
   double averageFrameTime = this->TotalFrameTimes / this->FrameTimes.size();

--- a/vtkext/private/module/vtkF3DUIActor.cxx
+++ b/vtkext/private/module/vtkF3DUIActor.cxx
@@ -69,18 +69,19 @@ void vtkF3DUIActor::SetFpsCounterVisibility(bool show)
 //----------------------------------------------------------------------------
 void vtkF3DUIActor::UpdateFpsValue(const double elapsedFrameTime)
 {
-	this->TotalFrameTimes += elapsedFrameTime;
-	this->FrameTimes.push_back(elapsedFrameTime);
+  this->TotalFrameTimes += elapsedFrameTime;
+  this->FrameTimes.push_back(elapsedFrameTime);
 
-	while (this->TotalFrameTimes > 1.0)
-	{
-		double t = this->FrameTimes.front();
-		this->FrameTimes.pop_front();
-		this->TotalFrameTimes -= t;
-	}
+  while (this->TotalFrameTimes > 1.0)
+  {
+    double oldestFrameTime = this->FrameTimes.front();
 
-	double averageFrameTime = this->TotalFrameTimes / this->FrameTimes.size();
-	this->FpsValue = static_cast<int>(std::round(1.0 / averageFrameTime));
+    this->FrameTimes.pop_front();
+	this->TotalFrameTimes -= oldestFrameTime;
+  }
+
+  double averageFrameTime = this->TotalFrameTimes / this->FrameTimes.size();
+  this->FpsValue = static_cast<int>(std::round(1.0 / averageFrameTime));
 }
 
 //----------------------------------------------------------------------------

--- a/vtkext/private/module/vtkF3DUIActor.cxx
+++ b/vtkext/private/module/vtkF3DUIActor.cxx
@@ -4,8 +4,6 @@
 #include <vtkOpenGLRenderWindow.h>
 #include <vtkViewport.h>
 
-#include <numeric>
-
 vtkObjectFactoryNewMacro(vtkF3DUIActor);
 
 //----------------------------------------------------------------------------

--- a/vtkext/private/module/vtkF3DUIActor.cxx
+++ b/vtkext/private/module/vtkF3DUIActor.cxx
@@ -4,6 +4,8 @@
 #include <vtkOpenGLRenderWindow.h>
 #include <vtkViewport.h>
 
+#include <numeric>
+
 vtkObjectFactoryNewMacro(vtkF3DUIActor);
 
 //----------------------------------------------------------------------------
@@ -67,18 +69,19 @@ void vtkF3DUIActor::SetFpsCounterVisibility(bool show)
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DUIActor::UpdateFpsValue(int fps)
+void vtkF3DUIActor::UpdateFpsValue(const double elapsedMicroSeconds)
 {
-  this->AccumulatedFpsValue += fps;
-  this->FramesAccumulated++;
+	this->FrameTimes.push_back(elapsedMicroSeconds);
 
-  if (this->FramesAccumulated == vtkF3DUIActor::FramesToAverage)
-  {
-	  this->FpsValue = static_cast<int>(this->AccumulatedFpsValue / this->FramesAccumulated);
+	// add window size check here
+	if (this->FrameTimes.size() == 6)
+	{
+		this->FrameTimes.pop_front();
+	}
 
-	  this->AccumulatedFpsValue = 0;
-	  this->FramesAccumulated = 0;
-  }
+	double averageFrameTime = std::accumulate(this->FrameTimes.begin(), this->FrameTimes.end(), 0.0) / this->FrameTimes.size();
+
+	this->FpsValue = static_cast<int>(std::round(1.0 / averageFrameTime));
 }
 
 //----------------------------------------------------------------------------

--- a/vtkext/private/module/vtkF3DUIActor.cxx
+++ b/vtkext/private/module/vtkF3DUIActor.cxx
@@ -69,9 +69,9 @@ void vtkF3DUIActor::SetFpsCounterVisibility(bool show)
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DUIActor::UpdateFpsValue(const double elapsedMicroSeconds)
+void vtkF3DUIActor::UpdateFpsValue(const double elapsedFrameTime)
 {
-	this->FrameTimes.push_back(elapsedMicroSeconds);
+	this->FrameTimes.push_back(elapsedFrameTime);
 
 	// add window size check here
 	if (this->FrameTimes.size() == 6)

--- a/vtkext/private/module/vtkF3DUIActor.cxx
+++ b/vtkext/private/module/vtkF3DUIActor.cxx
@@ -67,9 +67,18 @@ void vtkF3DUIActor::SetFpsCounterVisibility(bool show)
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DUIActor::SetFpsValue(int fps)
+void vtkF3DUIActor::UpdateFpsValue(int fps)
 {
-  this->FpsValue = fps;
+  this->AccumulatedFpsValue += fps;
+  this->FramesAccumulated++;
+
+  if (this->FramesAccumulated == vtkF3DUI::FramesToAverage)
+  {
+	  this->FpsValue = static_cast<int>(this->AccumulatedFpsValue / this->FramesAccumulated);
+
+	  this->AccumulatedFpsValue = 0;
+	  this->FramesAccumulated = 0;
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/vtkext/private/module/vtkF3DUIActor.h
+++ b/vtkext/private/module/vtkF3DUIActor.h
@@ -9,6 +9,7 @@
 #define vtkF3DUIActor_h
 
 #include <vtkProp.h>
+#include <deque>
 
 class vtkOpenGLRenderWindow;
 
@@ -84,7 +85,7 @@ public:
    * Updates the fps value
    * 0 by default
    */
-  void UpdateFpsValue(int fps);
+  void UpdateFpsValue(const double elapsedMicroSeconds);
 
   /**
    * Set the font file path
@@ -160,10 +161,9 @@ protected:
 
   bool FpsCounterVisible = false;
 
-  static const int FramesToAverage = 5;
-  int FramesAccumulated = 0;
+  // deque instead of queue to allow for iteration
+  std::deque<double> FrameTimes;
 
-  int AccumulatedFpsValue = 0;
   int FpsValue = 0;
 
   std::string FontFile = "";

--- a/vtkext/private/module/vtkF3DUIActor.h
+++ b/vtkext/private/module/vtkF3DUIActor.h
@@ -81,10 +81,10 @@ public:
   void SetFpsCounterVisibility(bool show);
 
   /**
-   * Set the fps value
+   * Updates the fps value
    * 0 by default
    */
-  void SetFpsValue(int fps);
+  void UpdateFpsValue(int fps);
 
   /**
    * Set the font file path
@@ -159,6 +159,11 @@ protected:
   bool ConsoleBadgeEnabled = false;
 
   bool FpsCounterVisible = false;
+
+  static const int FramesToAverage = 5;
+  int FramesAccumulated = 0;
+
+  int AccumulatedFpsValue = 0;
   int FpsValue = 0;
 
   std::string FontFile = "";

--- a/vtkext/private/module/vtkF3DUIActor.h
+++ b/vtkext/private/module/vtkF3DUIActor.h
@@ -85,7 +85,7 @@ public:
    * Updates the fps value
    * 0 by default
    */
-  void UpdateFpsValue(const double elapsedMicroSeconds);
+  void UpdateFpsValue(const double elapsedFrameTime);
 
   /**
    * Set the font file path

--- a/vtkext/private/module/vtkF3DUIActor.h
+++ b/vtkext/private/module/vtkF3DUIActor.h
@@ -164,6 +164,7 @@ protected:
   // deque instead of queue to allow for iteration
   std::deque<double> FrameTimes;
 
+  double TotalFrameTimes = 0.0;
   int FpsValue = 0;
 
   std::string FontFile = "";


### PR DESCRIPTION
> Accumulate it over a few frames to give an average instead of showing the last frame performance only

- In vtkF3DUIActor I changed `SetFpsValue()` to `UpdateFpsValue()` which will automatically accumulate fps values before setting the display value to the average. The number of frames it waits to average is decided by the static member variable `vtkF3DUIActor::FramesToAverage`

> Updating it only when the whole scene is rendered

- In the `vtkF3DRenderer::Render()` function I updated it to check if its information has `vtkF3DRenderPass::RENDER_UI_ONLY()` set to 1 If it does it calculates the fps value and calls the UI Actor's `UpdateFpsValue()`

Let me know what you think the number of frames to average should be (currently set to 5).

From building it and using some of the example models it seems that the render UI only is working however I may be wrong.

Seeing this is my first time contributing I'm starting a pull request to get some advice.