### PR TITLE
Fix opening files by double clicking in macOS Finder

### DIFF
--- a/application/F3DNSDelegate.mm
+++ b/application/F3DNSDelegate.mm
@@ -25,7 +25,10 @@
 - (BOOL)application:(NSApplication*)theApplication openFile:(NSString*)filename
 {
   (void)theApplication;
-  if (ShouldHandleFileOpening)
+
+  NSArray *arguments = [[NSProcessInfo processInfo] arguments];
+
+  if (ShouldHandleFileOpening || arguments.count <= 1)
   {
     int index = Starter->AddFile([filename UTF8String]);
     if (index > -1)


### PR DESCRIPTION
When opening a file from Finder with the application closed, the file wasn't opened.  
Shortcut the current logic when the application is run without argument.