### PR TITLE
Improve ci graph

### DIFF
--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -25,28 +25,16 @@ runs:
         lfs_sha: ${{inputs.lfs_sha}}
         cache_postfix: cache-0 
 
-    - name: Dependencies Dir
-      shell: bash
-      working-directory: ${{github.workspace}}
-      run: |
-        mkdir dependencies
-        cd dependencies
-        mkdir install
-
-    - name: Install VTK dependencies
-      uses: ./source/.github/actions/vtk-dependencies
-
-    - name: Install Raytracing Dependencies
-      uses: ./source/.github/actions/ospray-sb-install-dep
+    - name: Install all F3D dependencies
+      uses: ./source/.github/actions/generic-dependencies
+      with:
+        raytracing_label: raytracing
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
         raytracing_label: raytracing
-
-    - name: Install F3D dependencies
-      uses: ./source/.github/actions/f3d-dependencies
 
     # coverage build is done in source as it seems to be required for codecov
     # CMAKE_MODULE_PATH is required because of

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -57,24 +57,11 @@ runs:
         lfs_sha: ${{inputs.lfs_sha}}
         cache_postfix: cache-0
 
-    - name: Dependencies Dir
-      shell: bash
-      working-directory: ${{github.workspace}}
-      run: |
-        mkdir dependencies
-        cd dependencies
-        mkdir install
-
-    - name: Install VTK dependencies
-      uses: ./source/.github/actions/vtk-dependencies
+    - name: Install all F3D dependencies
+      uses: ./source/.github/actions/generic-dependencies
       with:
         cpu: ${{inputs.cpu}}
-
-    - name: Install Raytracing Dependencies
-      if: inputs.raytracing_label == 'raytracing'
-      uses: ./source/.github/actions/ospray-sb-install-dep
-      with:
-        cpu: ${{inputs.cpu}}
+        raytracing_label: ${{inputs.raytracing_label}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
@@ -82,12 +69,6 @@ runs:
         vtk_version: ${{inputs.vtk_version}}
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
         raytracing_label: ${{inputs.raytracing_label}}
-        cpu: ${{inputs.cpu}}
-
-    - name: Install F3D dependencies
-      if: inputs.optional_deps_label == 'optional-deps'
-      uses: ./source/.github/actions/f3d-dependencies
-      with:
         cpu: ${{inputs.cpu}}
 
     # Python is part of VFX reference platform (CY2025: 3.11)

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -1,0 +1,44 @@
+name: 'Install F3D dependencies'
+description: 'Install all F3D Dependencies but VTK'
+inputs:
+  raytracing_label:
+    description: 'Label to control raytracing'
+    required: false
+    default: 'no-raytracing'
+  optional_deps_label:
+    description: 'Label to optional dependencies'
+    required: false
+    default: 'optional-deps'
+  cpu:
+    description: 'CPU architecture to build for'
+    required: false
+    default: 'x86_64'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Dependencies Dir
+      shell: bash
+      working-directory: ${{github.workspace}}
+      run: |
+        mkdir dependencies
+        cd dependencies
+        mkdir install
+
+    - name: Install VTK dependencies
+      uses: ./source/.github/actions/vtk-dependencies
+      with:
+        cpu: ${{inputs.cpu}}
+
+    - name: Install Raytracing Dependencies
+      if: inputs.raytracing_label == 'raytracing'
+      uses: ./source/.github/actions/ospray-sb-install-dep
+      with:
+        cpu: ${{inputs.cpu}}
+
+    - name: Install F3D dependencies
+      if: inputs.optional_deps_label == 'optional-deps'
+      uses: ./source/.github/actions/f3d-dependencies
+      with:
+        cpu: ${{inputs.cpu}}

--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: dependencies/occt_install
-        key: occt-V7_8_0-${{runner.os}}-${{inputs.cpu}}-3
+        key: occt-V7_8_1-${{runner.os}}-${{inputs.cpu}}-3
 
     - name: Checkout OCCT
       if: steps.cache-occt.outputs.cache-hit != 'true'
@@ -24,7 +24,7 @@ runs:
         repository: Open-Cascade-SAS/OCCT
         submodules: true
         path: './dependencies/occt'
-        ref: V7_8_0
+        ref: V7_8_1
 
     - name: Patch OCCT
       if: steps.cache-occt.outputs.cache-hit != 'true'

--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: dependencies/occt_install
-        key: occt-V7_8_1-${{runner.os}}-${{inputs.cpu}}-3
+        key: occt-V7_8_0-${{runner.os}}-${{inputs.cpu}}-3
 
     - name: Checkout OCCT
       if: steps.cache-occt.outputs.cache-hit != 'true'
@@ -24,7 +24,7 @@ runs:
         repository: Open-Cascade-SAS/OCCT
         submodules: true
         path: './dependencies/occt'
-        ref: V7_8_1
+        ref: V7_8_0
 
     - name: Patch OCCT
       if: steps.cache-occt.outputs.cache-hit != 'true'

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -24,24 +24,13 @@ runs:
         lfs_sha: ${{inputs.lfs_sha}}
         cache_postfix: cache-0 
 
-    - name: Dependencies Dir
-      shell: bash
-      working-directory: ${{github.workspace}}
-      run: |
-        mkdir dependencies
-        cd dependencies
-        mkdir install
-
-    - name: Install VTK dependencies
-      uses: ./source/.github/actions/vtk-dependencies
+    - name: Install all F3D dependencies
+      uses: ./source/.github/actions/generic-dependencies
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
-
-    - name: Install F3D dependencies
-      uses: ./source/.github/actions/f3d-dependencies
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -29,25 +29,14 @@ runs:
         lfs_sha: ${{inputs.lfs_sha}}
         cache_postfix: cache-0 
 
-    - name: Dependencies Dir
-      shell: bash
-      working-directory: ${{github.workspace}}
-      run: |
-        mkdir dependencies
-        cd dependencies
-        mkdir install
-
-    - name: Install VTK dependencies
-      uses: ./source/.github/actions/vtk-dependencies
+    - name: Install all F3D dependencies
+      uses: ./source/.github/actions/generic-dependencies
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
         vtk_version: ${{inputs.vtk_version}}
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
-
-    - name: Install F3D dependencies
-      uses: ./source/.github/actions/f3d-dependencies
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -22,24 +22,13 @@ runs:
         lfs_sha: ${{inputs.lfs_sha}}
         cache_postfix: cache-0 
 
-    - name: Dependencies Dir
-      shell: bash
-      working-directory: ${{github.workspace}}
-      run: |
-        mkdir dependencies
-        cd dependencies
-        mkdir install
-
-    - name: Install VTK dependencies
-      uses: ./source/.github/actions/vtk-dependencies
+    - name: Install all F3D dependencies
+      uses: ./source/.github/actions/generic-dependencies
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
-
-    - name: Install F3D dependencies
-      uses: ./source/.github/actions/f3d-dependencies
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-13, macos-14]
+        cpu: [x86_64]
         include:
-          - cpu: x86_64
           - os: macos-14
             cpu: arm64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
+    steps:
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
         cache_postfix: cache-0
 
 #----------------------------------------------------------------------------
-# Cache Dependencies: Checkout and compile all dependencies but VTK if not cached
+# Cache dependencies: Checkout dependencies data and update the cache to limit dependencies bandwidth
 #----------------------------------------------------------------------------
   cache_dependencies:
-    name: Cache dependencies
+    name: Update dependencies data cache
     strategy:
       fail-fast: false
       matrix:
@@ -52,18 +52,20 @@ jobs:
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
+    steps:
 
     - name: Checkout
       uses: actions/checkout@v4
       with:
         path: 'source'
         fetch-depth: 1
-        lfs: false
+        dependencies: false
 
-    - name: Generic Dependencies
-      uses: ./source/.github/actions/generic-dependencies
+    - name: Cache dependencies Data
+      id: dependencies_sha_recover
+      uses: f3d-app/lfs-data-cache-action@v1
       with:
-        raytracing_label: raytracing
+        cache_postfix: cache-0
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
         cache_postfix: cache-0
 
 #----------------------------------------------------------------------------
-# Cache dependencies: Checkout dependencies data and update the cache to limit dependencies bandwidth
+# Cache Dependencies: Checkout and compile all dependencies but VTK if not cached
 #----------------------------------------------------------------------------
   cache_dependencies:
-    name: Update dependencies data cache
+    name: Cache dependencies
     strategy:
       fail-fast: false
       matrix:
@@ -52,20 +52,18 @@ jobs:
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
-    steps:
 
     - name: Checkout
       uses: actions/checkout@v4
       with:
         path: 'source'
         fetch-depth: 1
-        dependencies: false
+        lfs: false
 
-    - name: Cache dependencies Data
-      id: dependencies_sha_recover
-      uses: f3d-app/lfs-data-cache-action@v1
+    - name: Generic Dependencies
+      uses: ./source/.github/actions/generic-dependencies
       with:
-        cache_postfix: cache-0
+        raytracing_label: raytracing
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-13, macos-14]
-        cpu: [x86_64]
         include:
+          - cpu: x86_64
           - os: macos-14
             cpu: arm64
 
@@ -65,6 +65,7 @@ jobs:
       uses: ./source/.github/actions/generic-dependencies
       with:
         raytracing_label: raytracing
+        cpu: ${{matrix.cpu}}
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,40 @@ jobs:
         cache_postfix: cache-0
 
 #----------------------------------------------------------------------------
+# Cache Dependencies: Checkout and compile all dependencies but VTK if not cached
+#----------------------------------------------------------------------------
+  cache_dependencies:
+    name: Cache dependencies
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-latest, macos-13, macos-14]
+        include:
+          - cpu: x86_64
+          - os: macos-14
+            cpu: arm64
+
+    runs-on: ${{matrix.os}}
+    container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        path: 'source'
+        fetch-depth: 1
+        lfs: false
+
+    - name: Generic Dependencies
+      uses: ./source/.github/actions/generic-dependencies
+      with:
+        raytracing_label: raytracing
+
+#----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix
 #----------------------------------------------------------------------------
   windows:
     if: github.event.pull_request.draft == false
-    needs: cache_lfs
+    needs: [cache_lfs, cache_dependencies]
 
     strategy:
       fail-fast: false
@@ -75,7 +104,7 @@ jobs:
 #----------------------------------------------------------------------------
   linux:
     if: github.event.pull_request.draft == false
-    needs: cache_lfs
+    needs: [cache_lfs, cache_dependencies]
 
     strategy:
       fail-fast: false
@@ -155,7 +184,7 @@ jobs:
 #----------------------------------------------------------------------------
   macos:
     if: github.event.pull_request.draft == false
-    needs: cache_lfs
+    needs: [cache_lfs, cache_dependencies]
     strategy:
       fail-fast: false
       matrix:
@@ -184,7 +213,7 @@ jobs:
 #----------------------------------------------------------------------------
   macos_arm:
     if: github.event.pull_request.draft == false
-    needs: cache_lfs
+    needs: [cache_lfs, cache_dependencies]
 
     strategy:
       fail-fast: false
@@ -225,7 +254,7 @@ jobs:
 #----------------------------------------------------------------------------
   python-packaging:
     if: github.event.pull_request.draft == false
-    needs: cache_lfs
+    needs: [cache_lfs, cache_dependencies]
 
     strategy:
       fail-fast: false
@@ -269,7 +298,7 @@ jobs:
 # Coverage: Build and test on linux with last VTK with coverage option
 #----------------------------------------------------------------------------
   coverage:
-    needs: cache_lfs
+    needs: [cache_lfs, cache_dependencies]
     if: github.event.pull_request.draft == false
 
     runs-on: ubuntu-22.04
@@ -302,7 +331,7 @@ jobs:
 # "memory" returns false positives in VTK:
 # https://stackoverflow.com/questions/60097307/memory-sanitizer-reports-use-of-uninitialized-value-in-global-object-constructio
   sanitizer:
-    needs: cache_lfs
+    needs: [cache_lfs, cache_dependencies]
     if: github.event.pull_request.draft == false
 
     strategy:
@@ -338,7 +367,7 @@ jobs:
 # static-analysis: Run static analysis on linux
 #----------------------------------------------------------------------------
   static-analysis:
-    needs: cache_lfs
+    needs: [cache_lfs, cache_dependencies]
     if: github.event.pull_request.draft == false
 
     strategy:


### PR DESCRIPTION
Add a cache_dependencies job for each platform so that all dependencies but VTK is cached.

Job where a dependency (OCCT 7_8_0) is rebuilt:
 - cache_dependencies: 29min14: https://github.com/f3d-app/f3d/actions/runs/12891637495/job/35944038822
 - any windows_ci: 15min: 
   - https://github.com/f3d-app/f3d/actions/runs/12891637495/job/35946831929
   - https://github.com/f3d-app/f3d/actions/runs/12891637495/job/35946832815
 
 Job where no dependency is rebuilt:
  - cache_dependencies: 59s: https://github.com/f3d-app/f3d/actions/runs/12890727504/job/35941005286
  - any windows_ci: 15min: https://github.com/f3d-app/f3d/actions/runs/12890727504/job/35941110620
  
  Fix: https://github.com/f3d-app/f3d/issues/1939
 