### PR TITLE
Add a mindeps CI and update minimum versions

### DIFF
--- a/.github/actions/alembic-install-dep/action.yml
+++ b/.github/actions/alembic-install-dep/action.yml
@@ -5,18 +5,25 @@ inputs:
     description: 'CPU architecture to build for'
     required: false
     default: 'x86_64'
-    
+  version:
+    description: 'Version of alembic to build'
+    required: true
+
 runs:
   using: "composite"
   steps:
 
-    # Alembic is part of VFX reference platform (CY2025: 1.8.x)
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+
     - name: Cache Alembic
       id: cache-alembic
       uses: actions/cache@v4
       with:
         path: dependencies/alembic_install
-        key: alembic-v1.8.8-${{runner.os}}-${{inputs.cpu}}-0
+        key: alembic-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
 
     - name: Checkout Alembic
       if: steps.cache-alembic.outputs.cache-hit != 'true'
@@ -24,7 +31,7 @@ runs:
       with:
         repository: alembic/alembic
         path: './dependencies/alembic'
-        ref: 1.8.8
+        ref: ${{inputs.version}}
 
     - name: Setup Alembic
       if: steps.cache-alembic.outputs.cache-hit != 'true'

--- a/.github/actions/assimp-install-dep/action.yml
+++ b/.github/actions/assimp-install-dep/action.yml
@@ -5,17 +5,25 @@ inputs:
     description: 'CPU architecture to build for'
     required: false
     default: 'x86_64'
+  version:
+    description: 'Version of assimp to build'
+    required: true
 
 runs:
   using: "composite"
   steps:
+
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
 
     - name: Cache ASSIMP
       id: cache-assimp
       uses: actions/cache@v4
       with:
         path: dependencies/assimp_install
-        key: assimp-v5.4.3-${{runner.os}}-${{inputs.cpu}}-0
+        key: assimp-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
 
     - name: Checkout ASSIMP
       if: steps.cache-assimp.outputs.cache-hit != 'true'
@@ -23,11 +31,16 @@ runs:
       with:
         repository: assimp/assimp
         path: './dependencies/assimp'
-        ref: v5.4.3
+        ref: ${{inputs.version}}
 
-    # Revert https://github.com/assimp/assimp/pull/5349
+    # Revert: https://github.com/assimp/assimp/pull/5349
+    # Issue: https://github.com/assimp/assimp/issues/5449
+    # Fix: https://github.com/assimp/assimp/pull/5751
+    # This impact 5.4.3 and should be fixed in next release (5.5 or 5.4.4)
     - name: Patch ASSIMP
-      if: steps.cache-assimp.outputs.cache-hit != 'true'
+      if: |
+        steps.cache-assimp.outputs.cache-hit != 'true' &&
+        inputs.version == 'v5.4.3'
       working-directory: ${{github.workspace}}/dependencies/assimp
       shell: bash
       run: patch -p1 < $GITHUB_ACTION_PATH/assimp-revert-fbx-bone-anim.patch

--- a/.github/actions/blosc-install-dep/action.yml
+++ b/.github/actions/blosc-install-dep/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: dependencies/blosc_install
-        key: blosc-1.21.6-${{runner.os}}-${{inputs.cpu}}-0
+        key: blosc-v1.21.6-${{runner.os}}-${{inputs.cpu}}-0
 
     # Dependents: openvdb vtk
     - name: Checkout blosc

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -23,6 +23,9 @@ inputs:
   openexr_version:
     description: 'Version of openexr to build'
     required: true
+  openvdb_version:
+    description: 'Version of openvdb to build'
+    required: true
 
 runs:
   using: "composite"
@@ -49,6 +52,7 @@ runs:
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -14,6 +14,9 @@ inputs:
   assimp_version:
     description: 'Version of assimp to build'
     required: true
+  draco_version:
+    description: 'Version of draco to build'
+    required: true
 
 runs:
   using: "composite"
@@ -37,6 +40,7 @@ runs:
         raytracing_label: raytracing
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
+        draco_version: ${{inputs.draco_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -26,6 +26,9 @@ inputs:
   openvdb_version:
     description: 'Version of openvdb to build'
     required: true
+  pybind11_version:
+    description: 'Version of pybind11 to build'
+    required: true
 
 runs:
   using: "composite"
@@ -53,6 +56,7 @@ runs:
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
+        pybind11_version: ${{inputs.pybind11_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'Codecov token, needed for non-forked workflows'
     required: false
     default: ''
+  alembic_version:
+    description: 'Version of alembic to build'
+    required: true
 
 runs:
   using: "composite"
@@ -29,6 +32,7 @@ runs:
       uses: ./source/.github/actions/generic-dependencies
       with:
         raytracing_label: raytracing
+        alembic_version: ${{inputs.alembic_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -29,6 +29,9 @@ inputs:
   pybind11_version:
     description: 'Version of pybind11 to build'
     required: true
+  usd_version:
+    description: 'Version of usd to build'
+    required: true
 
 runs:
   using: "composite"
@@ -57,6 +60,7 @@ runs:
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
         pybind11_version: ${{inputs.pybind11_version}}
+        usd_version: ${{inputs.usd_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -20,6 +20,9 @@ inputs:
   occt_version:
     description: 'Version of occt to build'
     required: true
+  openexr_version:
+    description: 'Version of openexr to build'
+    required: true
 
 runs:
   using: "composite"
@@ -45,6 +48,7 @@ runs:
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
+        openexr_version: ${{inputs.openexr_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -11,6 +11,9 @@ inputs:
   alembic_version:
     description: 'Version of alembic to build'
     required: true
+  assimp_version:
+    description: 'Version of assimp to build'
+    required: true
 
 runs:
   using: "composite"
@@ -33,6 +36,7 @@ runs:
       with:
         raytracing_label: raytracing
         alembic_version: ${{inputs.alembic_version}}
+        assimp_version: ${{inputs.assimp_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -17,6 +17,9 @@ inputs:
   draco_version:
     description: 'Version of draco to build'
     required: true
+  occt_version:
+    description: 'Version of occt to build'
+    required: true
 
 runs:
   using: "composite"
@@ -41,6 +44,7 @@ runs:
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
+        occt_version: ${{inputs.occt_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/draco-install-dep/action.yml
+++ b/.github/actions/draco-install-dep/action.yml
@@ -5,17 +5,25 @@ inputs:
     description: 'CPU architecture to build for'
     required: false
     default: 'x86_64'
+  version:
+    description: 'Version of draco to build'
+    required: true
 
 runs:
   using: "composite"
   steps:
+
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
 
     - name: Cache Draco
       id: cache-draco
       uses: actions/cache@v4
       with:
         path: dependencies/draco_install
-        key: draco-1.5.7-${{runner.os}}-${{inputs.cpu}}-3
+        key: draco-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-3
 
     - name: Checkout Draco
       if: steps.cache-draco.outputs.cache-hit != 'true'
@@ -23,7 +31,7 @@ runs:
       with:
         repository: google/draco
         path: './dependencies/draco'
-        ref: 1.5.7
+        ref: ${{inputs.version}}
 
     - name: Setup Draco
       if: steps.cache-draco.outputs.cache-hit != 'true'

--- a/.github/actions/external-build-ci/action.yml
+++ b/.github/actions/external-build-ci/action.yml
@@ -1,5 +1,9 @@
 name: 'External build CI'
 description: 'External build CI'
+inputs:
+  openvdb_version:
+    description: 'Version of openvdb to build'
+    required: true
 
 runs:
   using: "composite"
@@ -22,6 +26,7 @@ runs:
       uses: ./source/f3d/.github/actions/vtk-dependencies
       with:
         source_dir: ./source/f3d
+        openvdb_version: ${{inputs.openvdb_version}}
  
     - name: Install VTK dependency
       uses: ./source/f3d/.github/actions/vtk-install-dep

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: 'CPU architecture to build for'
     required: false
     default: 'x86_64'
+  alembic_version:
+    description: 'Version of alembic to build'
+    required: true
 
 runs:
   using: "composite"
@@ -45,6 +48,7 @@ runs:
       uses: ./source/.github/actions/alembic-install-dep
       with:
         cpu: ${{inputs.cpu}}
+        version: ${{inputs.alembic_version}}
 
     - name: Install pybind11 dependency
       uses: ./source/.github/actions/pybind11-install-dep

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -31,12 +31,6 @@ runs:
   using: "composite"
   steps:
 
-    - name: Setup JDK
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-
     - name: Install OCCT dependency
       uses: ./source/.github/actions/occt-install-dep
       with:

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -20,6 +20,9 @@ inputs:
   openexr_version:
     description: 'Version of openexr to build'
     required: true
+  pybind11_version:
+    description: 'Version of pybind11 to build'
+    required: true
 
 runs:
   using: "composite"
@@ -68,6 +71,8 @@ runs:
 
     - name: Install pybind11 dependency
       uses: ./source/.github/actions/pybind11-install-dep
+      with:
+        version: ${{inputs.pybind11_version}}
 
     - name: Install USD dependency
       uses: ./source/.github/actions/usd-install-dep

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -23,6 +23,9 @@ inputs:
   pybind11_version:
     description: 'Version of pybind11 to build'
     required: true
+  usd_version:
+    description: 'Version of usd to build'
+    required: true
 
 runs:
   using: "composite"
@@ -78,3 +81,4 @@ runs:
       uses: ./source/.github/actions/usd-install-dep
       with:
         cpu: ${{inputs.cpu}}
+        version: ${{inputs.usd_version}}

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -17,6 +17,9 @@ inputs:
   occt_version:
     description: 'Version of occt to build'
     required: true
+  openexr_version:
+    description: 'Version of openexr to build'
+    required: true
 
 runs:
   using: "composite"
@@ -55,6 +58,7 @@ runs:
       uses: ./source/.github/actions/openexr-install-dep
       with:
         cpu: ${{inputs.cpu}}
+        version: ${{inputs.openexr_version}}
 
     - name: Install Alembic dependency
       uses: ./source/.github/actions/alembic-install-dep

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -14,6 +14,9 @@ inputs:
   draco_version:
     description: 'Version of draco to build'
     required: true
+  occt_version:
+    description: 'Version of occt to build'
+    required: true
 
 runs:
   using: "composite"
@@ -29,6 +32,7 @@ runs:
       uses: ./source/.github/actions/occt-install-dep
       with:
         cpu: ${{inputs.cpu}}
+        version: ${{inputs.occt_version}}
 
     - name: Install Assimp dependency
       uses: ./source/.github/actions/assimp-install-dep

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -11,6 +11,9 @@ inputs:
   assimp_version:
     description: 'Version of assimp to build'
     required: true
+  draco_version:
+    description: 'Version of draco to build'
+    required: true
 
 runs:
   using: "composite"
@@ -37,6 +40,7 @@ runs:
       uses: ./source/.github/actions/draco-install-dep
       with:
         cpu: ${{inputs.cpu}}
+        version: ${{inputs.draco_version}}
 
     - name: Install Imath dependency
       uses: ./source/.github/actions/imath-install-dep

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -8,6 +8,9 @@ inputs:
   alembic_version:
     description: 'Version of alembic to build'
     required: true
+  assimp_version:
+    description: 'Version of assimp to build'
+    required: true
 
 runs:
   using: "composite"
@@ -28,6 +31,7 @@ runs:
       uses: ./source/.github/actions/assimp-install-dep
       with:
         cpu: ${{inputs.cpu}}
+        version: ${{inputs.assimp_version}}
 
     - name: Install Draco dependency
       uses: ./source/.github/actions/draco-install-dep

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -52,6 +52,9 @@ inputs:
   occt_version:
     description: 'Version of occt to build'
     required: true
+  openexr_version:
+    description: 'Version of openexr to build'
+    required: true
 
 runs:
   using: "composite"
@@ -78,6 +81,7 @@ runs:
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
+        openexr_version: ${{inputs.openexr_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -49,6 +49,9 @@ inputs:
   draco_version:
     description: 'Version of draco to build'
     required: true
+  occt_version:
+    description: 'Version of occt to build'
+    required: true
 
 runs:
   using: "composite"
@@ -74,6 +77,7 @@ runs:
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
+        occt_version: ${{inputs.occt_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -46,6 +46,9 @@ inputs:
   assimp_version:
     description: 'Version of assimp to build'
     required: true
+  draco_version:
+    description: 'Version of draco to build'
+    required: true
 
 runs:
   using: "composite"
@@ -70,6 +73,7 @@ runs:
         raytracing_label: ${{inputs.raytracing_label}}
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
+        draco_version: ${{inputs.draco_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -58,6 +58,9 @@ inputs:
   openvdb_version:
     description: 'Version of openvdb to build'
     required: true
+  pybind11_version:
+    description: 'Version of pybind11 to build'
+    required: true
 
 runs:
   using: "composite"
@@ -86,6 +89,7 @@ runs:
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
+        pybind11_version: ${{inputs.pybind11_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -64,6 +64,9 @@ inputs:
   python_version:
     description: 'Version of python to install'
     required: true
+  usd_version:
+    description: 'Version of usd to build'
+    required: true
 
 runs:
   using: "composite"
@@ -94,6 +97,7 @@ runs:
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
         pybind11_version: ${{inputs.pybind11_version}}
+        usd_version: ${{inputs.usd_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -67,6 +67,9 @@ inputs:
   usd_version:
     description: 'Version of usd to build'
     required: true
+  java_version:
+    description: 'Version of java to install'
+    required: true
 
 runs:
   using: "composite"
@@ -77,6 +80,7 @@ runs:
       run: |
         [[ "${{ inputs.lfs_sha }}" ]] || { echo "lfs_sha input is empty" ; exit 1; }
         [[ "${{ inputs.python_version }}" ]] || { echo "python_version input is empty" ; exit 1; }
+        [[ "${{ inputs.java_version }}" ]] || { echo "java_version input is empty" ; exit 1; }
 
     - name: Recover LFS Data
       uses: f3d-app/lfs-data-cache-action@v1
@@ -120,6 +124,12 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install pytest==8.0.0
         python -m pip install pybind11_stubgen
+
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{inputs.java_version}}
 
     - name: Setup Directories
       shell: bash

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -55,6 +55,9 @@ inputs:
   openexr_version:
     description: 'Version of openexr to build'
     required: true
+  openvdb_version:
+    description: 'Version of openvdb to build'
+    required: true
 
 runs:
   using: "composite"
@@ -82,6 +85,7 @@ runs:
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -40,6 +40,9 @@ inputs:
   lfs_sha:
     description: 'Cache LFS sha'
     required: true
+  alembic_version:
+    description: 'Version of alembic to build'
+    required: true
 
 runs:
   using: "composite"
@@ -62,6 +65,7 @@ runs:
       with:
         cpu: ${{inputs.cpu}}
         raytracing_label: ${{inputs.raytracing_label}}
+        alembic_version: ${{inputs.alembic_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -43,6 +43,9 @@ inputs:
   alembic_version:
     description: 'Version of alembic to build'
     required: true
+  assimp_version:
+    description: 'Version of assimp to build'
+    required: true
 
 runs:
   using: "composite"
@@ -66,6 +69,7 @@ runs:
         cpu: ${{inputs.cpu}}
         raytracing_label: ${{inputs.raytracing_label}}
         alembic_version: ${{inputs.alembic_version}}
+        assimp_version: ${{inputs.assimp_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -61,6 +61,9 @@ inputs:
   pybind11_version:
     description: 'Version of pybind11 to build'
     required: true
+  python_version:
+    description: 'Version of python to install'
+    required: true
 
 runs:
   using: "composite"
@@ -70,6 +73,7 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.lfs_sha }}" ]] || { echo "lfs_sha input is empty" ; exit 1; }
+        [[ "${{ inputs.python_version }}" ]] || { echo "python_version input is empty" ; exit 1; }
 
     - name: Recover LFS Data
       uses: f3d-app/lfs-data-cache-action@v1
@@ -99,12 +103,11 @@ runs:
         raytracing_label: ${{inputs.raytracing_label}}
         cpu: ${{inputs.cpu}}
 
-    # Python is part of VFX reference platform (CY2025: 3.11)
     - name: Set up Python
       if: inputs.optional_deps_label == 'optional-deps'
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: ${{inputs.python_version}}
 
     - name: Install Python dependencies
       if: inputs.optional_deps_label == 'optional-deps'

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -31,6 +31,9 @@ inputs:
   openvdb_version:
     description: 'Version of openvdb to build'
     required: true
+  pybind11_version:
+    description: 'Version of pybind11 to build'
+    required: true
 
 runs:
   using: "composite"
@@ -45,6 +48,7 @@ runs:
         [[ "${{ inputs.occt_version }}" ]] || { echo "occt_version input is empty" ; exit 1; }
         [[ "${{ inputs.openexr_version }}" ]] || { echo "openexr_version input is empty" ; exit 1; }
         [[ "${{ inputs.openvdb_version }}" ]] || { echo "openvdb_version input is empty" ; exit 1; }
+        [[ "${{ inputs.pybind11_version }}" ]] || { echo "pybind11_version input is empty" ; exit 1; }
 
     - name: Dependencies Dir
       shell: bash
@@ -76,3 +80,4 @@ runs:
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
+        pybind11_version: ${{inputs.pybind11_version}}

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -13,10 +13,18 @@ inputs:
     description: 'CPU architecture to build for'
     required: false
     default: 'x86_64'
+  alembic_version:
+    description: 'Version of alembic to build'
+    required: true
 
 runs:
   using: "composite"
   steps:
+
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.alembic_version }}" ]] || { echo "alembic_version input is empty" ; exit 1; }
 
     - name: Dependencies Dir
       shell: bash
@@ -42,3 +50,4 @@ runs:
       uses: ./source/.github/actions/f3d-dependencies
       with:
         cpu: ${{inputs.cpu}}
+        alembic_version: ${{inputs.alembic_version}}

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -19,6 +19,9 @@ inputs:
   assimp_version:
     description: 'Version of assimp to build'
     required: true
+  draco_version:
+    description: 'Version of draco to build'
+    required: true
 
 runs:
   using: "composite"
@@ -29,6 +32,7 @@ runs:
       run: |
         [[ "${{ inputs.alembic_version }}" ]] || { echo "alembic_version input is empty" ; exit 1; }
         [[ "${{ inputs.assimp_version }}" ]] || { echo "assimp_version input is empty" ; exit 1; }
+        [[ "${{ inputs.draco_version }}" ]] || { echo "draco_version input is empty" ; exit 1; }
 
     - name: Dependencies Dir
       shell: bash
@@ -56,3 +60,4 @@ runs:
         cpu: ${{inputs.cpu}}
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
+        draco_version: ${{inputs.draco_version}}

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -28,6 +28,9 @@ inputs:
   openexr_version:
     description: 'Version of openexr to build'
     required: true
+  openvdb_version:
+    description: 'Version of openvdb to build'
+    required: true
 
 runs:
   using: "composite"
@@ -41,6 +44,7 @@ runs:
         [[ "${{ inputs.draco_version }}" ]] || { echo "draco_version input is empty" ; exit 1; }
         [[ "${{ inputs.occt_version }}" ]] || { echo "occt_version input is empty" ; exit 1; }
         [[ "${{ inputs.openexr_version }}" ]] || { echo "openexr_version input is empty" ; exit 1; }
+        [[ "${{ inputs.openvdb_version }}" ]] || { echo "openvdb_version input is empty" ; exit 1; }
 
     - name: Dependencies Dir
       shell: bash
@@ -54,6 +58,7 @@ runs:
       uses: ./source/.github/actions/vtk-dependencies
       with:
         cpu: ${{inputs.cpu}}
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Install Raytracing Dependencies
       if: inputs.raytracing_label == 'raytracing'

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -16,6 +16,9 @@ inputs:
   alembic_version:
     description: 'Version of alembic to build'
     required: true
+  assimp_version:
+    description: 'Version of assimp to build'
+    required: true
 
 runs:
   using: "composite"
@@ -25,6 +28,7 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.alembic_version }}" ]] || { echo "alembic_version input is empty" ; exit 1; }
+        [[ "${{ inputs.assimp_version }}" ]] || { echo "assimp_version input is empty" ; exit 1; }
 
     - name: Dependencies Dir
       shell: bash
@@ -51,3 +55,4 @@ runs:
       with:
         cpu: ${{inputs.cpu}}
         alembic_version: ${{inputs.alembic_version}}
+        assimp_version: ${{inputs.assimp_version}}

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -34,6 +34,9 @@ inputs:
   pybind11_version:
     description: 'Version of pybind11 to build'
     required: true
+  usd_version:
+    description: 'Version of usd to build'
+    required: true
 
 runs:
   using: "composite"
@@ -49,6 +52,7 @@ runs:
         [[ "${{ inputs.openexr_version }}" ]] || { echo "openexr_version input is empty" ; exit 1; }
         [[ "${{ inputs.openvdb_version }}" ]] || { echo "openvdb_version input is empty" ; exit 1; }
         [[ "${{ inputs.pybind11_version }}" ]] || { echo "pybind11_version input is empty" ; exit 1; }
+        [[ "${{ inputs.usd_version }}" ]] || { echo "usd_version input is empty" ; exit 1; }
 
     - name: Dependencies Dir
       shell: bash
@@ -81,3 +85,4 @@ runs:
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
         pybind11_version: ${{inputs.pybind11_version}}
+        usd_version: ${{inputs.usd_version}}

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -25,6 +25,9 @@ inputs:
   occt_version:
     description: 'Version of occt to build'
     required: true
+  openexr_version:
+    description: 'Version of openexr to build'
+    required: true
 
 runs:
   using: "composite"
@@ -37,6 +40,7 @@ runs:
         [[ "${{ inputs.assimp_version }}" ]] || { echo "assimp_version input is empty" ; exit 1; }
         [[ "${{ inputs.draco_version }}" ]] || { echo "draco_version input is empty" ; exit 1; }
         [[ "${{ inputs.occt_version }}" ]] || { echo "occt_version input is empty" ; exit 1; }
+        [[ "${{ inputs.openexr_version }}" ]] || { echo "openexr_version input is empty" ; exit 1; }
 
     - name: Dependencies Dir
       shell: bash
@@ -66,3 +70,4 @@ runs:
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
+        openexr_version: ${{inputs.openexr_version}}

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -22,6 +22,9 @@ inputs:
   draco_version:
     description: 'Version of draco to build'
     required: true
+  occt_version:
+    description: 'Version of occt to build'
+    required: true
 
 runs:
   using: "composite"
@@ -33,6 +36,7 @@ runs:
         [[ "${{ inputs.alembic_version }}" ]] || { echo "alembic_version input is empty" ; exit 1; }
         [[ "${{ inputs.assimp_version }}" ]] || { echo "assimp_version input is empty" ; exit 1; }
         [[ "${{ inputs.draco_version }}" ]] || { echo "draco_version input is empty" ; exit 1; }
+        [[ "${{ inputs.occt_version }}" ]] || { echo "occt_version input is empty" ; exit 1; }
 
     - name: Dependencies Dir
       shell: bash
@@ -61,3 +65,4 @@ runs:
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
+        occt_version: ${{inputs.occt_version}}

--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -5,17 +5,25 @@ inputs:
     description: 'CPU architecture to build for'
     required: false
     default: 'x86_64'
+  version:
+    description: 'Version of occt to build'
+    required: true
 
 runs:
   using: "composite"
   steps:
+
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
 
     - name: Cache OCCT
       id: cache-occt
       uses: actions/cache@v4
       with:
         path: dependencies/occt_install
-        key: occt-V7_8_1-${{runner.os}}-${{inputs.cpu}}-3
+        key: occt-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-4
 
     - name: Checkout OCCT
       if: steps.cache-occt.outputs.cache-hit != 'true'
@@ -24,14 +32,21 @@ runs:
         repository: Open-Cascade-SAS/OCCT
         submodules: true
         path: './dependencies/occt'
-        ref: V7_8_1
+        ref: ${{inputs.version}}
 
-    - name: Patch OCCT
+    - name: Patch OCCT all versions
       if: steps.cache-occt.outputs.cache-hit != 'true'
       working-directory: ${{github.workspace}}/dependencies/occt
       shell: bash
+      run: patch -p1 < $GITHUB_ACTION_PATH/0001-Adding-INSTALL_RPATH-Linux.patch
+
+    - name: Patch OCCT current version
+      if: |
+        steps.cache-occt.outputs.cache-hit != 'true' &&
+        inputs.version != 'V7_6_3'
+      working-directory: ${{github.workspace}}/dependencies/occt
+      shell: bash
       run: |
-        patch -p1 < $GITHUB_ACTION_PATH/0001-Adding-INSTALL_RPATH-Linux.patch
         patch -p1 < $GITHUB_ACTION_PATH/occt-remove-unneeded-includes.patch
         patch -p1 < $GITHUB_ACTION_PATH/occt-remove-unneeded-quotes-warning-msvc.patch
 
@@ -39,12 +54,14 @@ runs:
       if: steps.cache-occt.outputs.cache-hit != 'true'
       working-directory: ${{github.workspace}}/dependencies
       shell: bash
-      run: |
+      run:
         mkdir occt_build
         mkdir occt_install
 
-    - name: Configure OCCT
-      if: steps.cache-occt.outputs.cache-hit != 'true'
+    - name: Configure OCCT current version
+      if: |
+        steps.cache-occt.outputs.cache-hit != 'true' &&
+        inputs.version != 'V7_6_3'
       working-directory: ${{github.workspace}}/dependencies/occt_build
       shell: bash
       run: >
@@ -66,6 +83,33 @@ runs:
         -DINSTALL_DIR_BIN:PATH=bin
         -DUSE_FREETYPE=OFF
         ${{ runner.os == 'macOS' && '-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0' || null }}
+        ${{ runner.os == 'Windows' && '-Ax64 -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL' || null }}
+
+    - name: Configure OCCT min version
+      if: |
+        steps.cache-occt.outputs.cache-hit != 'true' &&
+        inputs.version == 'V7_6_3'
+      working-directory: ${{github.workspace}}/dependencies/occt_build
+      shell: bash
+      run: >
+        cmake ../occt
+        -DBUILD_ADDITIONAL_TOOLKITS="TKSTEP;TKIGES;TKMesh;TKXDESTEP;TKXDEIGES;TKBinXCAF"
+        -DBUILD_DOC_Overview=OFF
+        -DBUILD_LIBRARY_TYPE=Shared
+        -DBUILD_MODULE_ApplicationFramework=OFF
+        -DBUILD_MODULE_DataExchange=OFF
+        -DBUILD_MODULE_Draw=OFF
+        -DBUILD_MODULE_FoundationClasses=OFF
+        -DBUILD_MODULE_ModelingAlgorithms=OFF
+        -DBUILD_MODULE_ModelingData=OFF
+        -DBUILD_MODULE_Visualization=OFF
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_INSTALL_PREFIX:PATH=../occt_install
+        -DCMAKE_INSTALL_NAME_DIR:PATH=${{github.workspace}}/dependencies/install/lib
+        -DINSTALL_DIR_BIN:PATH=bin
+        -DUSE_FREETYPE=OFF
+        -DCMAKE_OSX_ARCHITECTURES=${{ inputs.cpu }}
+        ${{ runner.os == 'macOS' && '-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15' || null }}
         ${{ runner.os == 'Windows' && '-Ax64 -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL' || null }}
 
     - name: Build OCCT

--- a/.github/actions/openexr-install-dep/action.yml
+++ b/.github/actions/openexr-install-dep/action.yml
@@ -5,18 +5,25 @@ inputs:
     description: 'CPU architecture to build for'
     required: false
     default: 'x86_64'
+  version:
+    description: 'Version of openexr to build'
+    required: true
 
 runs:
   using: "composite"
   steps:
 
-    # OpenEXR is part of VFX reference platform (CY2025: 3.3.x)
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+
     - name: Cache OpenEXR
       id: cache-openexr
       uses: actions/cache@v4
       with:
         path: dependencies/openexr_install
-        key: openexr-v3.3.2-${{runner.os}}-${{inputs.cpu}}-0
+        key: openexr-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
 
     # Dependents: usd
     - name: Checkout OpenEXR
@@ -25,7 +32,7 @@ runs:
       with:
         repository: AcademySoftwareFoundation/openexr
         path: './dependencies/openexr'
-        ref: v3.3.2
+        ref: ${{inputs.version}}
 
     - name: Setup OpenEXR
       if: steps.cache-openexr.outputs.cache-hit != 'true'

--- a/.github/actions/openvdb-install-dep/action.yml
+++ b/.github/actions/openvdb-install-dep/action.yml
@@ -5,18 +5,25 @@ inputs:
     description: 'CPU architecture to build for'
     required: false
     default: 'x86_64'
+  version:
+    description: 'Version of openvdb to build'
+    required: true
 
 runs:
   using: "composite"
   steps:
 
-    # OpenVDB is part of VFX reference platform (CY2025: 12.x)
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+
     - name: Cache OpenVDB
       id: cache-openvdb
       uses: actions/cache@v4
       with:
         path: dependencies/openvdb_install
-        key: openvdb-12.0.0-${{runner.os}}-${{inputs.cpu}}-0
+        key: openvdb-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
 
     # Dependents: vtk
     - name: Checkout OpenVDB
@@ -25,7 +32,7 @@ runs:
       with:
         repository: AcademySoftwareFoundation/openvdb
         path: './dependencies/openvdb'
-        ref: v12.0.0
+        ref: ${{inputs.version}}
 
     - name: Setup OpenVDB
       if: steps.cache-openvdb.outputs.cache-hit != 'true'

--- a/.github/actions/pybind11-install-dep/action.yml
+++ b/.github/actions/pybind11-install-dep/action.yml
@@ -1,5 +1,10 @@
 name: 'Install pybind11 Dependency'
 description: 'Install pybind11 Dependency using cache when possible'
+inputs:
+  version:
+    description: 'Version of pybind11 to build'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -9,9 +14,8 @@ runs:
       uses: actions/cache@v4
       with:
         path: dependencies/pybind11_install
-        key: pybind11-v2.13.6-${{runner.os}}-0
+        key: pybind11-${{inputs.version}}-${{runner.os}}-0
 
-    # v2.13 doesn't support python36 which is needed in common-superbuild for now
     - name: Checkout pybind11
       if: steps.cache-pybind11.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
@@ -19,7 +23,7 @@ runs:
         repository: pybind/pybind11
         submodules: true
         path: './dependencies/pybind11'
-        ref: v2.13.6
+        ref: ${{inputs.version}}
 
     - name: Setup pybind11
       if: steps.cache-pybind11.outputs.cache-hit != 'true'

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -22,6 +22,9 @@ inputs:
   openexr_version:
     description: 'Version of openexr to build'
     required: true
+  openvdb_version:
+    description: 'Version of openvdb to build'
+    required: true
 
 runs:
   using: "composite"
@@ -47,6 +50,7 @@ runs:
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -10,6 +10,9 @@ inputs:
   alembic_version:
     description: 'Version of alembic to build'
     required: true
+  assimp_version:
+    description: 'Version of assimp to build'
+    required: true
 
 runs:
   using: "composite"
@@ -31,6 +34,7 @@ runs:
       uses: ./source/.github/actions/generic-dependencies
       with:
         alembic_version: ${{inputs.alembic_version}}
+        assimp_version: ${{inputs.assimp_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -16,6 +16,9 @@ inputs:
   draco_version:
     description: 'Version of draco to build'
     required: true
+  occt_version:
+    description: 'Version of occt to build'
+    required: true
 
 runs:
   using: "composite"
@@ -39,6 +42,7 @@ runs:
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
+        occt_version: ${{inputs.occt_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -19,6 +19,9 @@ inputs:
   occt_version:
     description: 'Version of occt to build'
     required: true
+  openexr_version:
+    description: 'Version of openexr to build'
+    required: true
 
 runs:
   using: "composite"
@@ -43,6 +46,7 @@ runs:
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
+        openexr_version: ${{inputs.openexr_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -37,6 +37,7 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.lfs_sha }}" ]] || { echo "lfs_sha input is empty" ; exit 1; }
+        [[ "${{ inputs.python_version }}" ]] || { echo "python input is empty" ; exit 1; }
 
     - name: Recover LFS Data
       uses: f3d-app/lfs-data-cache-action@v1

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -25,6 +25,9 @@ inputs:
   openvdb_version:
     description: 'Version of openvdb to build'
     required: true
+  pybind11_version:
+    description: 'Version of pybind11 to build'
+    required: true
 
 runs:
   using: "composite"
@@ -51,6 +54,7 @@ runs:
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
+        pybind11_version: ${{inputs.pybind11_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -28,6 +28,9 @@ inputs:
   pybind11_version:
     description: 'Version of pybind11 to build'
     required: true
+  usd_version:
+    description: 'Version of usd to build'
+    required: true
 
 runs:
   using: "composite"
@@ -56,6 +59,7 @@ runs:
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
         pybind11_version: ${{inputs.pybind11_version}}
+        usd_version: ${{inputs.usd_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -7,6 +7,9 @@ inputs:
   python_version:
     description: 'Python version'
     required: true
+  alembic_version:
+    description: 'Version of alembic to build'
+    required: true
 
 runs:
   using: "composite"
@@ -26,6 +29,8 @@ runs:
 
     - name: Install all F3D dependencies
       uses: ./source/.github/actions/generic-dependencies
+      with:
+        alembic_version: ${{inputs.alembic_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -13,6 +13,9 @@ inputs:
   assimp_version:
     description: 'Version of assimp to build'
     required: true
+  draco_version:
+    description: 'Version of draco to build'
+    required: true
 
 runs:
   using: "composite"
@@ -35,6 +38,7 @@ runs:
       with:
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
+        draco_version: ${{inputs.draco_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -17,6 +17,9 @@ inputs:
   assimp_version:
     description: 'Version of assimp to build'
     required: true
+  draco_version:
+    description: 'Version of draco to build'
+    required: true
 
 runs:
   using: "composite"
@@ -40,6 +43,7 @@ runs:
       with:
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
+        draco_version: ${{inputs.draco_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -23,6 +23,9 @@ inputs:
   occt_version:
     description: 'Version of occt to build'
     required: true
+  openexr_version:
+    description: 'Version of openexr to build'
+    required: true
 
 runs:
   using: "composite"
@@ -48,6 +51,7 @@ runs:
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
+        openexr_version: ${{inputs.openexr_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -29,6 +29,9 @@ inputs:
   openvdb_version:
     description: 'Version of openvdb to build'
     required: true
+  pybind11_version:
+    description: 'Version of pybind11 to build'
+    required: true
 
 runs:
   using: "composite"
@@ -56,6 +59,7 @@ runs:
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
+        pybind11_version: ${{inputs.pybind11_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -14,6 +14,9 @@ inputs:
   alembic_version:
     description: 'Version of alembic to build'
     required: true
+  assimp_version:
+    description: 'Version of assimp to build'
+    required: true
 
 runs:
   using: "composite"
@@ -36,6 +39,7 @@ runs:
       uses: ./source/.github/actions/generic-dependencies
       with:
         alembic_version: ${{inputs.alembic_version}}
+        assimp_version: ${{inputs.assimp_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -11,6 +11,9 @@ inputs:
   lfs_sha:
     description: 'Cache LFS sha'
     required: true
+  alembic_version:
+    description: 'Version of alembic to build'
+    required: true
 
 runs:
   using: "composite"
@@ -31,6 +34,8 @@ runs:
 
     - name: Install all F3D dependencies
       uses: ./source/.github/actions/generic-dependencies
+      with:
+        alembic_version: ${{inputs.alembic_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -26,6 +26,9 @@ inputs:
   openexr_version:
     description: 'Version of openexr to build'
     required: true
+  openvdb_version:
+    description: 'Version of openvdb to build'
+    required: true
 
 runs:
   using: "composite"
@@ -52,6 +55,7 @@ runs:
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -32,6 +32,9 @@ inputs:
   pybind11_version:
     description: 'Version of pybind11 to build'
     required: true
+  usd_version:
+    description: 'Version of usd to build'
+    required: true
 
 runs:
   using: "composite"
@@ -60,6 +63,7 @@ runs:
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
         pybind11_version: ${{inputs.pybind11_version}}
+        usd_version: ${{inputs.usd_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -20,6 +20,9 @@ inputs:
   draco_version:
     description: 'Version of draco to build'
     required: true
+  occt_version:
+    description: 'Version of occt to build'
+    required: true
 
 runs:
   using: "composite"
@@ -44,6 +47,7 @@ runs:
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
+        occt_version: ${{inputs.occt_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -16,6 +16,9 @@ inputs:
   occt_version:
     description: 'Version of occt to build'
     required: true
+  openexr_version:
+    description: 'Version of openexr to build'
+    required: true
 
 runs:
   using: "composite"
@@ -41,6 +44,7 @@ runs:
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
+        openexr_version: ${{inputs.openexr_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -13,6 +13,9 @@ inputs:
   draco_version:
     description: 'Version of draco to build'
     required: true
+  occt_version:
+    description: 'Version of occt to build'
+    required: true
 
 runs:
   using: "composite"
@@ -37,6 +40,7 @@ runs:
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
         draco_version: ${{inputs.draco_version}}
+        occt_version: ${{inputs.occt_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -10,6 +10,9 @@ inputs:
   assimp_version:
     description: 'Version of assimp to build'
     required: true
+  draco_version:
+    description: 'Version of draco to build'
+    required: true
 
 runs:
   using: "composite"
@@ -33,6 +36,7 @@ runs:
       with:
         alembic_version: ${{inputs.alembic_version}}
         assimp_version: ${{inputs.assimp_version}}
+        draco_version: ${{inputs.draco_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -4,6 +4,9 @@ inputs:
   lfs_sha:
     description: 'Cache LFS sha'
     required: true
+  alembic_version:
+    description: 'Version of alembic to build'
+    required: true
 
 runs:
   using: "composite"
@@ -24,6 +27,8 @@ runs:
 
     - name: Install all F3D dependencies
       uses: ./source/.github/actions/generic-dependencies
+      with:
+        alembic_version: ${{inputs.alembic_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -22,6 +22,9 @@ inputs:
   openvdb_version:
     description: 'Version of openvdb to build'
     required: true
+  pybind11_version:
+    description: 'Version of pybind11 to build'
+    required: true
 
 runs:
   using: "composite"
@@ -49,6 +52,7 @@ runs:
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
+        pybind11_version: ${{inputs.pybind11_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -19,6 +19,9 @@ inputs:
   openexr_version:
     description: 'Version of openexr to build'
     required: true
+  openvdb_version:
+    description: 'Version of openvdb to build'
+    required: true
 
 runs:
   using: "composite"
@@ -45,6 +48,7 @@ runs:
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -25,6 +25,9 @@ inputs:
   pybind11_version:
     description: 'Version of pybind11 to build'
     required: true
+  usd_version:
+    description: 'Version of usd to build'
+    required: true
 
 runs:
   using: "composite"
@@ -53,6 +56,7 @@ runs:
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
         pybind11_version: ${{inputs.pybind11_version}}
+        usd_version: ${{inputs.usd_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -7,6 +7,9 @@ inputs:
   alembic_version:
     description: 'Version of alembic to build'
     required: true
+  assimp_version:
+    description: 'Version of assimp to build'
+    required: true
 
 runs:
   using: "composite"
@@ -29,6 +32,7 @@ runs:
       uses: ./source/.github/actions/generic-dependencies
       with:
         alembic_version: ${{inputs.alembic_version}}
+        assimp_version: ${{inputs.assimp_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: 'CPU architecture to build for'
     required: false
     default: 'x86_64'
+  version:
+    description: 'Version of usd to build'
+    required: true
 
 runs:
   using: "composite"
@@ -15,7 +18,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: dependencies/usd_install
-        key: usd-v24.11-${{runner.os}}-${{inputs.cpu}}-3
+        key: usd-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-3
 
     - name: Checkout USD
       if: steps.cache-usd.outputs.cache-hit != 'true'
@@ -23,7 +26,7 @@ runs:
       with:
         repository: PixarAnimationStudios/USD
         path: './dependencies/usd'
-        ref: v24.11
+        ref: ${{inputs.version}}
 
    # Upstream issue: https://github.com/PixarAnimationStudios/OpenUSD/issues/2490
     - name: Patch USD

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: dependencies/usd_install
-        key: usd-v24.11-${{runner.os}}-${{inputs.cpu}}-2
+        key: usd-v24.11-${{runner.os}}-${{inputs.cpu}}-3
 
     - name: Checkout USD
       if: steps.cache-usd.outputs.cache-hit != 'true'

--- a/.github/actions/vtk-dependencies/action.yml
+++ b/.github/actions/vtk-dependencies/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: 'Source directory for actions'
     required: false
     default: './source'
+  openvdb_version:
+    description: 'Version of openvdb to build'
+    required: true
 
 runs:
   using: "composite"
@@ -40,3 +43,4 @@ runs:
       uses: ./.actions/openvdb-install-dep
       with:
         cpu: ${{inputs.cpu}}
+        version: ${{inputs.openvdb_version}}

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -43,7 +43,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: dependencies/vtk_install
-        key: vtk-${{env.VTK_SHA_OR_TAG}}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-6
+        key: vtk-${{env.VTK_SHA_OR_TAG}}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-8
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'

--- a/.github/actions/zlib-install-dep/action.yml
+++ b/.github/actions/zlib-install-dep/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: dependencies/zlib_install
-        key: zlib-1.3.1-${{runner.os}}-${{inputs.cpu}}-4
+        key: zlib-v1.3.1-${{runner.os}}-${{inputs.cpu}}-4
 
     # Dependents: blosc openvdb vtk
     - name: Checkout zlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,14 @@ jobs:
       occt_min_version: ${{ steps.set_default_versions.outputs.occt_min_version }}
       openexr_version: ${{ steps.set_default_versions.outputs.openexr_version }}
       openexr_min_version: ${{ steps.set_default_versions.outputs.openexr_min_version }}
+      openvdb_version: ${{ steps.set_default_versions.outputs.openvdb_version }}
+      openvdb_min_version: ${{ steps.set_default_versions.outputs.openvdb_min_version }}
     steps:
 
     # Alembic is part of VFX reference platform (CY2025: 1.8.x)
     # OpenEXR is part of VFX reference platform (CY2025: 3.3.x)
+    # OpenVDB is part of VFX reference platform (CY2025: 12.x)
+    # OpenVDB min version is not enforced by F3D code and missing from VTK code
     - name: Set default versions output
       id: set_default_versions
       shell: bash
@@ -48,6 +52,8 @@ jobs:
         echo "occt_min_version=V7_6_3" >> $GITHUB_OUTPUT
         echo "openexr_version=v3.3.2" >> $GITHUB_OUTPUT
         echo "openexr_min_version=v3.0.1" >> $GITHUB_OUTPUT
+        echo "openvdb_version=v12.0.0" >> $GITHUB_OUTPUT
+        echo "openvdb_min_version=v12.0.0" >> $GITHUB_OUTPUT
 
 #----------------------------------------------------------------------------
 # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
@@ -92,6 +98,7 @@ jobs:
           - draco_version: ${{needs.default_versions.outputs.draco_version}}
           - occt_version: ${{needs.default_versions.outputs.occt_version}}
           - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+          - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - build_type: mindeps
             os: ubuntu-22.04
             cpu: x86_64
@@ -100,6 +107,7 @@ jobs:
             draco_version: ${{needs.default_versions.outputs.draco_min_version}}
             occt_version: ${{needs.default_versions.outputs.occt_min_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_min_version}}
+            openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -122,6 +130,7 @@ jobs:
         draco_version: ${{matrix.draco_version}}
         occt_version: ${{matrix.occt_version}}
         openexr_version: ${{matrix.openexr_version}}
+        openvdb_version: ${{matrix.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix
@@ -161,6 +170,7 @@ jobs:
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+        openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # Linux CI: Build and test, cross-vtk build matrix
@@ -185,6 +195,7 @@ jobs:
           - draco_version: ${{needs.default_versions.outputs.draco_version}}
           - occt_version: ${{needs.default_versions.outputs.occt_version}}
           - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+          - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - build_type: egl
             vtk_version: commit
             raytracing_label: raytracing
@@ -197,6 +208,7 @@ jobs:
             draco_version: ${{needs.default_versions.outputs.draco_version}}
             occt_version: ${{needs.default_versions.outputs.occt_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - build_type: osmesa
             vtk_version: commit
             raytracing_label: raytracing
@@ -209,6 +221,7 @@ jobs:
             draco_version: ${{needs.default_versions.outputs.draco_version}}
             occt_version: ${{needs.default_versions.outputs.occt_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
@@ -221,6 +234,7 @@ jobs:
             draco_version: ${{needs.default_versions.outputs.draco_version}}
             occt_version: ${{needs.default_versions.outputs.occt_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -233,6 +247,7 @@ jobs:
             draco_version: ${{needs.default_versions.outputs.draco_version}}
             occt_version: ${{needs.default_versions.outputs.occt_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -245,6 +260,7 @@ jobs:
             draco_version: ${{needs.default_versions.outputs.draco_version}}
             occt_version: ${{needs.default_versions.outputs.occt_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - build_type: mindeps
             vtk_version: commit
             raytracing_label: raytracing
@@ -257,6 +273,7 @@ jobs:
             draco_version: ${{needs.default_versions.outputs.draco_min_version}}
             occt_version: ${{needs.default_versions.outputs.occt_min_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_min_version}}
+            openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -288,6 +305,7 @@ jobs:
         draco_version: ${{matrix.draco_version}}
         occt_version: ${{matrix.occt_version}}
         openexr_version: ${{matrix.openexr_version}}
+        openvdb_version: ${{matrix.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # MacOS CI: Build and test, cross-vtk build matrix
@@ -322,6 +340,7 @@ jobs:
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+        openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -368,6 +387,7 @@ jobs:
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+        openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel
@@ -418,6 +438,7 @@ jobs:
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+        openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # Coverage: Build and test on linux with last VTK with coverage option
@@ -453,6 +474,7 @@ jobs:
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+        openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -497,6 +519,7 @@ jobs:
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+        openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # static-analysis: Run static analysis on linux
@@ -533,11 +556,13 @@ jobs:
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
+        openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # external-build: Check build of F3D as sub-project
 #----------------------------------------------------------------------------
   external-build:
+    needs: [cache_dependencies, default_versions]
     if: github.event.pull_request.draft == false
 
     strategy:
@@ -557,6 +582,8 @@ jobs:
 
     - name: External build CI
       uses: ./source/f3d/.github/actions/external-build-ci
+      with:
+        openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # android: Check build of F3D for android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,15 @@ jobs:
       openvdb_min_version: ${{ steps.set_default_versions.outputs.openvdb_min_version }}
       pybind11_version: ${{ steps.set_default_versions.outputs.pybind11_version }}
       pybind11_min_version: ${{ steps.set_default_versions.outputs.pybind11_min_version }}
+      python_version: ${{ steps.set_default_versions.outputs.python_version }}
+      python_min_version: ${{ steps.set_default_versions.outputs.python_min_version }}
     steps:
 
     # Alembic is part of VFX reference platform (CY2025: 1.8.x)
     # OpenEXR is part of VFX reference platform (CY2025: 3.3.x)
     # OpenVDB is part of VFX reference platform (CY2025: 12.x)
     # OpenVDB min version is not enforced by F3D code and missing from VTK code
+    # Python is part of VFX reference platform (CY2025: 3.11)
     - name: Set default versions output
       id: set_default_versions
       shell: bash
@@ -58,6 +61,8 @@ jobs:
         echo "openvdb_min_version=v12.0.0" >> $GITHUB_OUTPUT
         echo "pybind11_version=v2.13.6" >> $GITHUB_OUTPUT
         echo "pybind11_min_version=v2.9.2" >> $GITHUB_OUTPUT
+        echo "python_version=3.11" >> $GITHUB_OUTPUT
+        echo "python_min_version=3.9" >> $GITHUB_OUTPUT
 
 #----------------------------------------------------------------------------
 # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
@@ -179,6 +184,7 @@ jobs:
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+        python_version: ${{needs.default_versions.outputs.python_version}}
 
 #----------------------------------------------------------------------------
 # Linux CI: Build and test, cross-vtk build matrix
@@ -205,6 +211,7 @@ jobs:
           - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+          - python_version: ${{needs.default_versions.outputs.python_version}}
           - build_type: egl
             vtk_version: commit
             raytracing_label: raytracing
@@ -219,6 +226,7 @@ jobs:
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+            python_version: ${{needs.default_versions.outputs.python_version}}
           - build_type: osmesa
             vtk_version: commit
             raytracing_label: raytracing
@@ -233,6 +241,7 @@ jobs:
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+            python_version: ${{needs.default_versions.outputs.python_version}}
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
@@ -247,6 +256,7 @@ jobs:
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+            python_version: ${{needs.default_versions.outputs.python_version}}
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -261,6 +271,7 @@ jobs:
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+            python_version: ${{needs.default_versions.outputs.python_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -275,6 +286,7 @@ jobs:
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+            python_version: ${{needs.default_versions.outputs.python_version}}
           - build_type: mindeps
             vtk_version: commit
             raytracing_label: raytracing
@@ -289,6 +301,7 @@ jobs:
             openexr_version: ${{needs.default_versions.outputs.openexr_min_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_min_version}}
+            python_version: ${{needs.default_versions.outputs.python_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -322,6 +335,7 @@ jobs:
         openexr_version: ${{matrix.openexr_version}}
         openvdb_version: ${{matrix.openvdb_version}}
         pybind11_version: ${{matrix.pybind11_version}}
+        python_version: ${{matrix.python_version}}
 
 #----------------------------------------------------------------------------
 # MacOS CI: Build and test, cross-vtk build matrix
@@ -358,6 +372,7 @@ jobs:
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+        python_version: ${{needs.default_versions.outputs.python_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -406,6 +421,7 @@ jobs:
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+        python_version: ${{needs.default_versions.outputs.python_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
       pybind11_min_version: ${{ steps.set_default_versions.outputs.pybind11_min_version }}
       python_version: ${{ steps.set_default_versions.outputs.python_version }}
       python_min_version: ${{ steps.set_default_versions.outputs.python_min_version }}
+      usd_version: ${{ steps.set_default_versions.outputs.usd_version }}
+      usd_min_version: ${{ steps.set_default_versions.outputs.usd_min_version }}
     steps:
 
     # Alembic is part of VFX reference platform (CY2025: 1.8.x)
@@ -63,6 +65,8 @@ jobs:
         echo "pybind11_min_version=v2.9.2" >> $GITHUB_OUTPUT
         echo "python_version=3.11" >> $GITHUB_OUTPUT
         echo "python_min_version=3.9" >> $GITHUB_OUTPUT
+        echo "usd_version=v24.11" >> $GITHUB_OUTPUT
+        echo "usd_min_version=v24.08" >> $GITHUB_OUTPUT
 
 #----------------------------------------------------------------------------
 # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
@@ -109,6 +113,7 @@ jobs:
           - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+          - usd_version: ${{needs.default_versions.outputs.usd_version}}
           - build_type: mindeps
             os: ubuntu-22.04
             cpu: x86_64
@@ -119,6 +124,7 @@ jobs:
             openexr_version: ${{needs.default_versions.outputs.openexr_min_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_min_version}}
+            usd_version: ${{needs.default_versions.outputs.usd_min_version}}
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -143,6 +149,7 @@ jobs:
         openexr_version: ${{matrix.openexr_version}}
         openvdb_version: ${{matrix.openvdb_version}}
         pybind11_version: ${{matrix.pybind11_version}}
+        usd_version: ${{matrix.usd_version}}
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix
@@ -185,6 +192,7 @@ jobs:
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
         python_version: ${{needs.default_versions.outputs.python_version}}
+        usd_version: ${{needs.default_versions.outputs.usd_version}}
 
 #----------------------------------------------------------------------------
 # Linux CI: Build and test, cross-vtk build matrix
@@ -211,6 +219,7 @@ jobs:
           - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+          - usd_version: ${{needs.default_versions.outputs.usd_version}}
           - python_version: ${{needs.default_versions.outputs.python_version}}
           - build_type: egl
             vtk_version: commit
@@ -227,6 +236,7 @@ jobs:
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
             python_version: ${{needs.default_versions.outputs.python_version}}
+            usd_version: ${{needs.default_versions.outputs.usd_version}}
           - build_type: osmesa
             vtk_version: commit
             raytracing_label: raytracing
@@ -242,6 +252,7 @@ jobs:
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
             python_version: ${{needs.default_versions.outputs.python_version}}
+            usd_version: ${{needs.default_versions.outputs.usd_version}}
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
@@ -257,6 +268,7 @@ jobs:
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
             python_version: ${{needs.default_versions.outputs.python_version}}
+            usd_version: ${{needs.default_versions.outputs.usd_version}}
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -272,6 +284,7 @@ jobs:
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
             python_version: ${{needs.default_versions.outputs.python_version}}
+            usd_version: ${{needs.default_versions.outputs.usd_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -287,6 +300,7 @@ jobs:
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
             python_version: ${{needs.default_versions.outputs.python_version}}
+            usd_version: ${{needs.default_versions.outputs.usd_version}}
           - build_type: mindeps
             vtk_version: commit
             raytracing_label: raytracing
@@ -302,6 +316,7 @@ jobs:
             openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
             pybind11_version: ${{needs.default_versions.outputs.pybind11_min_version}}
             python_version: ${{needs.default_versions.outputs.python_min_version}}
+            usd_version: ${{needs.default_versions.outputs.usd_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -336,6 +351,7 @@ jobs:
         openvdb_version: ${{matrix.openvdb_version}}
         pybind11_version: ${{matrix.pybind11_version}}
         python_version: ${{matrix.python_version}}
+        usd_version: ${{matrix.usd_version}}
 
 #----------------------------------------------------------------------------
 # MacOS CI: Build and test, cross-vtk build matrix
@@ -373,6 +389,7 @@ jobs:
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
         python_version: ${{needs.default_versions.outputs.python_version}}
+        usd_version: ${{needs.default_versions.outputs.usd_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -422,6 +439,7 @@ jobs:
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
         python_version: ${{needs.default_versions.outputs.python_version}}
+        usd_version: ${{needs.default_versions.outputs.usd_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel
@@ -474,6 +492,7 @@ jobs:
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+        usd_version: ${{needs.default_versions.outputs.usd_version}}
 
 #----------------------------------------------------------------------------
 # Coverage: Build and test on linux with last VTK with coverage option
@@ -511,6 +530,7 @@ jobs:
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+        usd_version: ${{needs.default_versions.outputs.usd_version}}
 
 #----------------------------------------------------------------------------
 # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -557,6 +577,7 @@ jobs:
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+        usd_version: ${{needs.default_versions.outputs.usd_version}}
 
 #----------------------------------------------------------------------------
 # static-analysis: Run static analysis on linux
@@ -595,6 +616,7 @@ jobs:
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
+        usd_version: ${{needs.default_versions.outputs.usd_version}}
 
 #----------------------------------------------------------------------------
 # external-build: Check build of F3D as sub-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       assimp_min_version: ${{ steps.set_default_versions.outputs.assimp_min_version }}
       draco_version: ${{ steps.set_default_versions.outputs.draco_version }}
       draco_min_version: ${{ steps.set_default_versions.outputs.draco_min_version }}
+      occt_version: ${{ steps.set_default_versions.outputs.occt_version }}
+      occt_min_version: ${{ steps.set_default_versions.outputs.occt_min_version }}
     steps:
 
     # Alembic is part of VFX reference platform (CY2025: 1.8.x)
@@ -39,6 +41,8 @@ jobs:
         echo "assimp_min_version=v5.4.0" >> $GITHUB_OUTPUT
         echo "draco_version=1.5.7" >> $GITHUB_OUTPUT
         echo "draco_min_version=1.5.6" >> $GITHUB_OUTPUT
+        echo "occt_version=V7_8_1" >> $GITHUB_OUTPUT
+        echo "occt_min_version=V7_6_3" >> $GITHUB_OUTPUT
 
 #----------------------------------------------------------------------------
 # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
@@ -81,12 +85,14 @@ jobs:
           - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
           - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - draco_version: ${{needs.default_versions.outputs.draco_version}}
+          - occt_version: ${{needs.default_versions.outputs.occt_version}}
           - build_type: mindeps
             os: ubuntu-22.04
             cpu: x86_64
             alembic_version: ${{needs.default_versions.outputs.alembic_min_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_min_version}}
             draco_version: ${{needs.default_versions.outputs.draco_min_version}}
+            occt_version: ${{needs.default_versions.outputs.occt_min_version}}
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -107,6 +113,7 @@ jobs:
         alembic_version: ${{matrix.alembic_version}}
         assimp_version: ${{matrix.assimp_version}}
         draco_version: ${{matrix.draco_version}}
+        occt_version: ${{matrix.occt_version}}
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix
@@ -144,6 +151,7 @@ jobs:
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
+        occt_version: ${{needs.default_versions.outputs.occt_version}}
 
 #----------------------------------------------------------------------------
 # Linux CI: Build and test, cross-vtk build matrix
@@ -166,6 +174,7 @@ jobs:
           - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
           - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - draco_version: ${{needs.default_versions.outputs.draco_version}}
+          - occt_version: ${{needs.default_versions.outputs.occt_version}}
           - build_type: egl
             vtk_version: commit
             raytracing_label: raytracing
@@ -176,6 +185,7 @@ jobs:
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
             draco_version: ${{needs.default_versions.outputs.draco_version}}
+            occt_version: ${{needs.default_versions.outputs.occt_version}}
           - build_type: osmesa
             vtk_version: commit
             raytracing_label: raytracing
@@ -186,6 +196,7 @@ jobs:
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
             draco_version: ${{needs.default_versions.outputs.draco_version}}
+            occt_version: ${{needs.default_versions.outputs.occt_version}}
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
@@ -196,6 +207,7 @@ jobs:
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
             draco_version: ${{needs.default_versions.outputs.draco_version}}
+            occt_version: ${{needs.default_versions.outputs.occt_version}}
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -206,6 +218,7 @@ jobs:
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
             draco_version: ${{needs.default_versions.outputs.draco_version}}
+            occt_version: ${{needs.default_versions.outputs.occt_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -216,6 +229,7 @@ jobs:
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
             draco_version: ${{needs.default_versions.outputs.draco_version}}
+            occt_version: ${{needs.default_versions.outputs.occt_version}}
           - build_type: mindeps
             vtk_version: commit
             raytracing_label: raytracing
@@ -226,6 +240,7 @@ jobs:
             alembic_version: ${{needs.default_versions.outputs.alembic_min_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_min_version}}
             draco_version: ${{needs.default_versions.outputs.draco_min_version}}
+            occt_version: ${{needs.default_versions.outputs.occt_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -255,6 +270,7 @@ jobs:
         alembic_version: ${{matrix.alembic_version}}
         assimp_version: ${{matrix.assimp_version}}
         draco_version: ${{matrix.draco_version}}
+        occt_version: ${{matrix.occt_version}}
 
 #----------------------------------------------------------------------------
 # MacOS CI: Build and test, cross-vtk build matrix
@@ -287,6 +303,7 @@ jobs:
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
+        occt_version: ${{needs.default_versions.outputs.occt_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -331,6 +348,7 @@ jobs:
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
+        occt_version: ${{needs.default_versions.outputs.occt_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel
@@ -379,6 +397,7 @@ jobs:
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
+        occt_version: ${{needs.default_versions.outputs.occt_version}}
 
 #----------------------------------------------------------------------------
 # Coverage: Build and test on linux with last VTK with coverage option
@@ -412,6 +431,7 @@ jobs:
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
+        occt_version: ${{needs.default_versions.outputs.occt_version}}
 
 #----------------------------------------------------------------------------
 # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -454,6 +474,7 @@ jobs:
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
+        occt_version: ${{needs.default_versions.outputs.occt_version}}
 
 #----------------------------------------------------------------------------
 # static-analysis: Run static analysis on linux
@@ -488,6 +509,7 @@ jobs:
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
+        occt_version: ${{needs.default_versions.outputs.occt_version}}
 
 #----------------------------------------------------------------------------
 # external-build: Check build of F3D as sub-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     outputs:
       alembic_version: ${{ steps.set_default_versions.outputs.alembic_version }}
       alembic_min_version: ${{ steps.set_default_versions.outputs.alembic_min_version }}
+      assimp_version: ${{ steps.set_default_versions.outputs.assimp_version }}
+      assimp_min_version: ${{ steps.set_default_versions.outputs.assimp_min_version }}
     steps:
 
     # Alembic is part of VFX reference platform (CY2025: 1.8.x)
@@ -31,6 +33,8 @@ jobs:
       run: |
         echo "alembic_version=1.8.8" >> $GITHUB_OUTPUT
         echo "alembic_min_version=1.8.5" >> $GITHUB_OUTPUT
+        echo "assimp_version=v5.4.3" >> $GITHUB_OUTPUT
+        echo "assimp_min_version=v5.4.0" >> $GITHUB_OUTPUT
 
 #----------------------------------------------------------------------------
 # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
@@ -71,10 +75,12 @@ jobs:
           - os: macos-14
             cpu: arm64
           - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+          - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - build_type: mindeps
             os: ubuntu-22.04
             cpu: x86_64
             alembic_version: ${{needs.default_versions.outputs.alembic_min_version}}
+            assimp_version: ${{needs.default_versions.outputs.assimp_min_version}}
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -93,6 +99,7 @@ jobs:
         raytracing_label: raytracing
         cpu: ${{matrix.cpu}}
         alembic_version: ${{matrix.alembic_version}}
+        assimp_version: ${{matrix.assimp_version}}
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix
@@ -128,6 +135,7 @@ jobs:
         static_label: ${{matrix.static_label}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+        assimp_version: ${{needs.default_versions.outputs.assimp_version}}
 
 #----------------------------------------------------------------------------
 # Linux CI: Build and test, cross-vtk build matrix
@@ -148,6 +156,7 @@ jobs:
           - rendering_backend: auto
           - static_label: no-static
           - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+          - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - build_type: egl
             vtk_version: commit
             raytracing_label: raytracing
@@ -156,6 +165,7 @@ jobs:
             rendering_backend: egl
             static_label: no-static
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+            assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - build_type: osmesa
             vtk_version: commit
             raytracing_label: raytracing
@@ -164,6 +174,7 @@ jobs:
             rendering_backend: osmesa
             static_label: no-static
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+            assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
@@ -172,6 +183,7 @@ jobs:
             rendering_backend: auto
             static_label: no-static
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+            assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -180,6 +192,7 @@ jobs:
             rendering_backend: auto
             static_label: no-static
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+            assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -188,6 +201,7 @@ jobs:
             rendering_backend: auto
             static_label: static
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+            assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - build_type: mindeps
             vtk_version: commit
             raytracing_label: raytracing
@@ -196,6 +210,7 @@ jobs:
             rendering_backend: auto
             static_label: no-static
             alembic_version: ${{needs.default_versions.outputs.alembic_min_version}}
+            assimp_version: ${{needs.default_versions.outputs.assimp_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -223,6 +238,7 @@ jobs:
         static_label: ${{matrix.static_label}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{matrix.alembic_version}}
+        assimp_version: ${{matrix.assimp_version}}
 
 #----------------------------------------------------------------------------
 # MacOS CI: Build and test, cross-vtk build matrix
@@ -253,6 +269,7 @@ jobs:
         cpu: x86_64
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+        assimp_version: ${{needs.default_versions.outputs.assimp_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -295,6 +312,7 @@ jobs:
         cpu: arm64
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+        assimp_version: ${{needs.default_versions.outputs.assimp_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel
@@ -341,6 +359,7 @@ jobs:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         python_version: ${{matrix.python_version}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+        assimp_version: ${{needs.default_versions.outputs.assimp_version}}
 
 #----------------------------------------------------------------------------
 # Coverage: Build and test on linux with last VTK with coverage option
@@ -372,6 +391,7 @@ jobs:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         codecov_token: ${{secrets.CODECOV_TOKEN}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+        assimp_version: ${{needs.default_versions.outputs.assimp_version}}
 
 #----------------------------------------------------------------------------
 # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -412,6 +432,7 @@ jobs:
         sanitizer_type: ${{matrix.sanitizer_type}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+        assimp_version: ${{needs.default_versions.outputs.assimp_version}}
 
 #----------------------------------------------------------------------------
 # static-analysis: Run static analysis on linux
@@ -444,6 +465,7 @@ jobs:
       with:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+        assimp_version: ${{needs.default_versions.outputs.assimp_version}}
 
 #----------------------------------------------------------------------------
 # external-build: Check build of F3D as sub-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       python_min_version: ${{ steps.set_default_versions.outputs.python_min_version }}
       usd_version: ${{ steps.set_default_versions.outputs.usd_version }}
       usd_min_version: ${{ steps.set_default_versions.outputs.usd_min_version }}
+      java_version: ${{ steps.set_default_versions.outputs.java_version }}
+      java_min_version: ${{ steps.set_default_versions.outputs.java_min_version }}
     steps:
 
     # Alembic is part of VFX reference platform (CY2025: 1.8.x)
@@ -67,6 +69,8 @@ jobs:
         echo "python_min_version=3.9" >> $GITHUB_OUTPUT
         echo "usd_version=v24.11" >> $GITHUB_OUTPUT
         echo "usd_min_version=v24.08" >> $GITHUB_OUTPUT
+        echo "java_version=21" >> $GITHUB_OUTPUT
+        echo "java_min_version=17" >> $GITHUB_OUTPUT
 
 #----------------------------------------------------------------------------
 # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
@@ -193,6 +197,7 @@ jobs:
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
         python_version: ${{needs.default_versions.outputs.python_version}}
         usd_version: ${{needs.default_versions.outputs.usd_version}}
+        java_version: ${{needs.default_versions.outputs.java_version}}
 
 #----------------------------------------------------------------------------
 # Linux CI: Build and test, cross-vtk build matrix
@@ -219,8 +224,9 @@ jobs:
           - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          - usd_version: ${{needs.default_versions.outputs.usd_version}}
           - python_version: ${{needs.default_versions.outputs.python_version}}
+          - usd_version: ${{needs.default_versions.outputs.usd_version}}
+          - java_version: ${{needs.default_versions.outputs.java_version}}
           - build_type: egl
             vtk_version: commit
             raytracing_label: raytracing
@@ -237,6 +243,7 @@ jobs:
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
             python_version: ${{needs.default_versions.outputs.python_version}}
             usd_version: ${{needs.default_versions.outputs.usd_version}}
+            java_version: ${{needs.default_versions.outputs.java_version}}
           - build_type: osmesa
             vtk_version: commit
             raytracing_label: raytracing
@@ -253,6 +260,7 @@ jobs:
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
             python_version: ${{needs.default_versions.outputs.python_version}}
             usd_version: ${{needs.default_versions.outputs.usd_version}}
+            java_version: ${{needs.default_versions.outputs.java_version}}
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
@@ -269,6 +277,7 @@ jobs:
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
             python_version: ${{needs.default_versions.outputs.python_version}}
             usd_version: ${{needs.default_versions.outputs.usd_version}}
+            java_version: ${{needs.default_versions.outputs.java_version}}
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -285,6 +294,7 @@ jobs:
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
             python_version: ${{needs.default_versions.outputs.python_version}}
             usd_version: ${{needs.default_versions.outputs.usd_version}}
+            java_version: ${{needs.default_versions.outputs.java_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -301,6 +311,7 @@ jobs:
             pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
             python_version: ${{needs.default_versions.outputs.python_version}}
             usd_version: ${{needs.default_versions.outputs.usd_version}}
+            java_version: ${{needs.default_versions.outputs.java_version}}
           - build_type: mindeps
             vtk_version: commit
             raytracing_label: raytracing
@@ -317,6 +328,7 @@ jobs:
             pybind11_version: ${{needs.default_versions.outputs.pybind11_min_version}}
             python_version: ${{needs.default_versions.outputs.python_min_version}}
             usd_version: ${{needs.default_versions.outputs.usd_min_version}}
+            java_version: ${{needs.default_versions.outputs.java_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -352,6 +364,7 @@ jobs:
         pybind11_version: ${{matrix.pybind11_version}}
         python_version: ${{matrix.python_version}}
         usd_version: ${{matrix.usd_version}}
+        java_version: ${{matrix.java_version}}
 
 #----------------------------------------------------------------------------
 # MacOS CI: Build and test, cross-vtk build matrix
@@ -390,6 +403,7 @@ jobs:
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
         python_version: ${{needs.default_versions.outputs.python_version}}
         usd_version: ${{needs.default_versions.outputs.usd_version}}
+        java_version: ${{needs.default_versions.outputs.java_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -440,6 +454,7 @@ jobs:
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
         python_version: ${{needs.default_versions.outputs.python_version}}
         usd_version: ${{needs.default_versions.outputs.usd_version}}
+        java_version: ${{needs.default_versions.outputs.java_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       openexr_min_version: ${{ steps.set_default_versions.outputs.openexr_min_version }}
       openvdb_version: ${{ steps.set_default_versions.outputs.openvdb_version }}
       openvdb_min_version: ${{ steps.set_default_versions.outputs.openvdb_min_version }}
+      pybind11_version: ${{ steps.set_default_versions.outputs.pybind11_version }}
+      pybind11_min_version: ${{ steps.set_default_versions.outputs.pybind11_min_version }}
     steps:
 
     # Alembic is part of VFX reference platform (CY2025: 1.8.x)
@@ -54,6 +56,8 @@ jobs:
         echo "openexr_min_version=v3.0.1" >> $GITHUB_OUTPUT
         echo "openvdb_version=v12.0.0" >> $GITHUB_OUTPUT
         echo "openvdb_min_version=v12.0.0" >> $GITHUB_OUTPUT
+        echo "pybind11_version=v2.13.6" >> $GITHUB_OUTPUT
+        echo "pybind11_min_version=v2.9.2" >> $GITHUB_OUTPUT
 
 #----------------------------------------------------------------------------
 # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
@@ -99,6 +103,7 @@ jobs:
           - occt_version: ${{needs.default_versions.outputs.occt_version}}
           - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+          - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
           - build_type: mindeps
             os: ubuntu-22.04
             cpu: x86_64
@@ -108,6 +113,7 @@ jobs:
             occt_version: ${{needs.default_versions.outputs.occt_min_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_min_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
+            pybind11_version: ${{needs.default_versions.outputs.pybind11_min_version}}
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -131,6 +137,7 @@ jobs:
         occt_version: ${{matrix.occt_version}}
         openexr_version: ${{matrix.openexr_version}}
         openvdb_version: ${{matrix.openvdb_version}}
+        pybind11_version: ${{matrix.pybind11_version}}
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix
@@ -171,6 +178,7 @@ jobs:
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+        pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
 
 #----------------------------------------------------------------------------
 # Linux CI: Build and test, cross-vtk build matrix
@@ -196,6 +204,7 @@ jobs:
           - occt_version: ${{needs.default_versions.outputs.occt_version}}
           - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+          - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
           - build_type: egl
             vtk_version: commit
             raytracing_label: raytracing
@@ -209,6 +218,7 @@ jobs:
             occt_version: ${{needs.default_versions.outputs.occt_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+            pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
           - build_type: osmesa
             vtk_version: commit
             raytracing_label: raytracing
@@ -222,6 +232,7 @@ jobs:
             occt_version: ${{needs.default_versions.outputs.occt_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+            pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
@@ -235,6 +246,7 @@ jobs:
             occt_version: ${{needs.default_versions.outputs.occt_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+            pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -248,6 +260,7 @@ jobs:
             occt_version: ${{needs.default_versions.outputs.occt_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+            pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -261,6 +274,7 @@ jobs:
             occt_version: ${{needs.default_versions.outputs.occt_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+            pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
           - build_type: mindeps
             vtk_version: commit
             raytracing_label: raytracing
@@ -274,6 +288,7 @@ jobs:
             occt_version: ${{needs.default_versions.outputs.occt_min_version}}
             openexr_version: ${{needs.default_versions.outputs.openexr_min_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
+            pybind11_version: ${{needs.default_versions.outputs.pybind11_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -306,6 +321,7 @@ jobs:
         occt_version: ${{matrix.occt_version}}
         openexr_version: ${{matrix.openexr_version}}
         openvdb_version: ${{matrix.openvdb_version}}
+        pybind11_version: ${{matrix.pybind11_version}}
 
 #----------------------------------------------------------------------------
 # MacOS CI: Build and test, cross-vtk build matrix
@@ -341,6 +357,7 @@ jobs:
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+        pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -388,6 +405,7 @@ jobs:
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+        pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel
@@ -439,6 +457,7 @@ jobs:
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+        pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
 
 #----------------------------------------------------------------------------
 # Coverage: Build and test on linux with last VTK with coverage option
@@ -475,6 +494,7 @@ jobs:
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+        pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
 
 #----------------------------------------------------------------------------
 # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -520,6 +540,7 @@ jobs:
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+        pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
 
 #----------------------------------------------------------------------------
 # static-analysis: Run static analysis on linux
@@ -557,6 +578,7 @@ jobs:
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+        pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
 
 #----------------------------------------------------------------------------
 # external-build: Check build of F3D as sub-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,25 @@ concurrency:
 jobs:
 
 #----------------------------------------------------------------------------
+# Default versions: Set default version for all dependencies
+#----------------------------------------------------------------------------
+  default_versions:
+    runs-on: ubuntu-22.04
+    name: Set default versions
+    outputs:
+      alembic_version: ${{ steps.set_default_versions.outputs.alembic_version }}
+      alembic_min_version: ${{ steps.set_default_versions.outputs.alembic_min_version }}
+    steps:
+
+    # Alembic is part of VFX reference platform (CY2025: 1.8.x)
+    - name: Set default versions output
+      id: set_default_versions
+      shell: bash
+      run: |
+        echo "alembic_version=1.8.8" >> $GITHUB_OUTPUT
+        echo "alembic_min_version=1.8.5" >> $GITHUB_OUTPUT
+
+#----------------------------------------------------------------------------
 # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
 #----------------------------------------------------------------------------
   cache_lfs:
@@ -41,14 +60,21 @@ jobs:
 #----------------------------------------------------------------------------
   cache_dependencies:
     name: Cache dependencies
+    needs: default_versions
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-13, macos-14]
+        build_type: [standard]
         include:
           - cpu: x86_64
           - os: macos-14
             cpu: arm64
+          - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+          - build_type: mindeps
+            os: ubuntu-22.04
+            cpu: x86_64
+            alembic_version: ${{needs.default_versions.outputs.alembic_min_version}}
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -66,13 +92,14 @@ jobs:
       with:
         raytracing_label: raytracing
         cpu: ${{matrix.cpu}}
+        alembic_version: ${{matrix.alembic_version}}
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix
 #----------------------------------------------------------------------------
   windows:
     if: github.event.pull_request.draft == false
-    needs: [cache_lfs, cache_dependencies]
+    needs: [cache_lfs, cache_dependencies, default_versions]
 
     strategy:
       fail-fast: false
@@ -100,13 +127,14 @@ jobs:
         raytracing_label: raytracing
         static_label: ${{matrix.static_label}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        alembic_version: ${{needs.default_versions.outputs.alembic_version}}
 
 #----------------------------------------------------------------------------
 # Linux CI: Build and test, cross-vtk build matrix
 #----------------------------------------------------------------------------
   linux:
     if: github.event.pull_request.draft == false
-    needs: [cache_lfs, cache_dependencies]
+    needs: [cache_lfs, cache_dependencies, default_versions]
 
     strategy:
       fail-fast: false
@@ -119,6 +147,7 @@ jobs:
           - optional_deps_label: optional-deps
           - rendering_backend: auto
           - static_label: no-static
+          - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
           - build_type: egl
             vtk_version: commit
             raytracing_label: raytracing
@@ -126,6 +155,7 @@ jobs:
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: egl
             static_label: no-static
+            alembic_version: ${{needs.default_versions.outputs.alembic_version}}
           - build_type: osmesa
             vtk_version: commit
             raytracing_label: raytracing
@@ -133,6 +163,7 @@ jobs:
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: osmesa
             static_label: no-static
+            alembic_version: ${{needs.default_versions.outputs.alembic_version}}
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
@@ -140,6 +171,7 @@ jobs:
             exclude_deprecated_label: exclude-deprecated
             rendering_backend: auto
             static_label: no-static
+            alembic_version: ${{needs.default_versions.outputs.alembic_version}}
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -147,6 +179,7 @@ jobs:
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: auto
             static_label: no-static
+            alembic_version: ${{needs.default_versions.outputs.alembic_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -154,6 +187,15 @@ jobs:
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: auto
             static_label: static
+            alembic_version: ${{needs.default_versions.outputs.alembic_version}}
+          - build_type: mindeps
+            vtk_version: commit
+            raytracing_label: raytracing
+            optional_deps_label: optional-deps
+            exclude_deprecated_label: no-exclude-deprecated
+            rendering_backend: auto
+            static_label: no-static
+            alembic_version: ${{needs.default_versions.outputs.alembic_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -180,13 +222,14 @@ jobs:
         exclude_deprecated_label: ${{matrix.exclude_deprecated_label}}
         static_label: ${{matrix.static_label}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        alembic_version: ${{matrix.alembic_version}}
 
 #----------------------------------------------------------------------------
 # MacOS CI: Build and test, cross-vtk build matrix
 #----------------------------------------------------------------------------
   macos:
     if: github.event.pull_request.draft == false
-    needs: [cache_lfs, cache_dependencies]
+    needs: [cache_lfs, cache_dependencies, default_versions]
     strategy:
       fail-fast: false
       matrix:
@@ -209,13 +252,14 @@ jobs:
         raytracing_label: raytracing
         cpu: x86_64
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        alembic_version: ${{needs.default_versions.outputs.alembic_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
 #----------------------------------------------------------------------------
   macos_arm:
     if: github.event.pull_request.draft == false
-    needs: [cache_lfs, cache_dependencies]
+    needs: [cache_lfs, cache_dependencies, default_versions]
 
     strategy:
       fail-fast: false
@@ -250,13 +294,14 @@ jobs:
         static_label: ${{matrix.static_label}}
         cpu: arm64
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        alembic_version: ${{needs.default_versions.outputs.alembic_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel
 #----------------------------------------------------------------------------
   python-packaging:
     if: github.event.pull_request.draft == false
-    needs: [cache_lfs, cache_dependencies]
+    needs: [cache_lfs, cache_dependencies, default_versions]
 
     strategy:
       fail-fast: false
@@ -295,12 +340,13 @@ jobs:
       with:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         python_version: ${{matrix.python_version}}
+        alembic_version: ${{needs.default_versions.outputs.alembic_version}}
 
 #----------------------------------------------------------------------------
 # Coverage: Build and test on linux with last VTK with coverage option
 #----------------------------------------------------------------------------
   coverage:
-    needs: [cache_lfs, cache_dependencies]
+    needs: [cache_lfs, cache_dependencies, default_versions]
     if: github.event.pull_request.draft == false
 
     runs-on: ubuntu-22.04
@@ -325,6 +371,7 @@ jobs:
       with:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         codecov_token: ${{secrets.CODECOV_TOKEN}}
+        alembic_version: ${{needs.default_versions.outputs.alembic_version}}
 
 #----------------------------------------------------------------------------
 # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -333,7 +380,7 @@ jobs:
 # "memory" returns false positives in VTK:
 # https://stackoverflow.com/questions/60097307/memory-sanitizer-reports-use-of-uninitialized-value-in-global-object-constructio
   sanitizer:
-    needs: [cache_lfs, cache_dependencies]
+    needs: [cache_lfs, cache_dependencies, default_versions]
     if: github.event.pull_request.draft == false
 
     strategy:
@@ -364,12 +411,13 @@ jobs:
       with:
         sanitizer_type: ${{matrix.sanitizer_type}}
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        alembic_version: ${{needs.default_versions.outputs.alembic_version}}
 
 #----------------------------------------------------------------------------
 # static-analysis: Run static analysis on linux
 #----------------------------------------------------------------------------
   static-analysis:
-    needs: [cache_lfs, cache_dependencies]
+    needs: [cache_lfs, cache_dependencies, default_versions]
     if: github.event.pull_request.draft == false
 
     strategy:
@@ -395,6 +443,7 @@ jobs:
       uses: ./source/.github/actions/static-analysis-ci
       with:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+        alembic_version: ${{needs.default_versions.outputs.alembic_version}}
 
 #----------------------------------------------------------------------------
 # external-build: Check build of F3D as sub-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,12 @@ jobs:
       draco_min_version: ${{ steps.set_default_versions.outputs.draco_min_version }}
       occt_version: ${{ steps.set_default_versions.outputs.occt_version }}
       occt_min_version: ${{ steps.set_default_versions.outputs.occt_min_version }}
+      openexr_version: ${{ steps.set_default_versions.outputs.openexr_version }}
+      openexr_min_version: ${{ steps.set_default_versions.outputs.openexr_min_version }}
     steps:
 
     # Alembic is part of VFX reference platform (CY2025: 1.8.x)
+    # OpenEXR is part of VFX reference platform (CY2025: 3.3.x)
     - name: Set default versions output
       id: set_default_versions
       shell: bash
@@ -43,6 +46,8 @@ jobs:
         echo "draco_min_version=1.5.6" >> $GITHUB_OUTPUT
         echo "occt_version=V7_8_1" >> $GITHUB_OUTPUT
         echo "occt_min_version=V7_6_3" >> $GITHUB_OUTPUT
+        echo "openexr_version=v3.3.2" >> $GITHUB_OUTPUT
+        echo "openexr_min_version=v3.0.1" >> $GITHUB_OUTPUT
 
 #----------------------------------------------------------------------------
 # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
@@ -86,6 +91,7 @@ jobs:
           - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - draco_version: ${{needs.default_versions.outputs.draco_version}}
           - occt_version: ${{needs.default_versions.outputs.occt_version}}
+          - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - build_type: mindeps
             os: ubuntu-22.04
             cpu: x86_64
@@ -93,6 +99,7 @@ jobs:
             assimp_version: ${{needs.default_versions.outputs.assimp_min_version}}
             draco_version: ${{needs.default_versions.outputs.draco_min_version}}
             occt_version: ${{needs.default_versions.outputs.occt_min_version}}
+            openexr_version: ${{needs.default_versions.outputs.openexr_min_version}}
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -114,6 +121,7 @@ jobs:
         assimp_version: ${{matrix.assimp_version}}
         draco_version: ${{matrix.draco_version}}
         occt_version: ${{matrix.occt_version}}
+        openexr_version: ${{matrix.openexr_version}}
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix
@@ -152,6 +160,7 @@ jobs:
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
+        openexr_version: ${{needs.default_versions.outputs.openexr_version}}
 
 #----------------------------------------------------------------------------
 # Linux CI: Build and test, cross-vtk build matrix
@@ -175,6 +184,7 @@ jobs:
           - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
           - draco_version: ${{needs.default_versions.outputs.draco_version}}
           - occt_version: ${{needs.default_versions.outputs.occt_version}}
+          - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - build_type: egl
             vtk_version: commit
             raytracing_label: raytracing
@@ -186,6 +196,7 @@ jobs:
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
             draco_version: ${{needs.default_versions.outputs.draco_version}}
             occt_version: ${{needs.default_versions.outputs.occt_version}}
+            openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - build_type: osmesa
             vtk_version: commit
             raytracing_label: raytracing
@@ -197,6 +208,7 @@ jobs:
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
             draco_version: ${{needs.default_versions.outputs.draco_version}}
             occt_version: ${{needs.default_versions.outputs.occt_version}}
+            openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
@@ -208,6 +220,7 @@ jobs:
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
             draco_version: ${{needs.default_versions.outputs.draco_version}}
             occt_version: ${{needs.default_versions.outputs.occt_version}}
+            openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -219,6 +232,7 @@ jobs:
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
             draco_version: ${{needs.default_versions.outputs.draco_version}}
             occt_version: ${{needs.default_versions.outputs.occt_version}}
+            openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -230,6 +244,7 @@ jobs:
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
             draco_version: ${{needs.default_versions.outputs.draco_version}}
             occt_version: ${{needs.default_versions.outputs.occt_version}}
+            openexr_version: ${{needs.default_versions.outputs.openexr_version}}
           - build_type: mindeps
             vtk_version: commit
             raytracing_label: raytracing
@@ -241,6 +256,7 @@ jobs:
             assimp_version: ${{needs.default_versions.outputs.assimp_min_version}}
             draco_version: ${{needs.default_versions.outputs.draco_min_version}}
             occt_version: ${{needs.default_versions.outputs.occt_min_version}}
+            openexr_version: ${{needs.default_versions.outputs.openexr_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -271,6 +287,7 @@ jobs:
         assimp_version: ${{matrix.assimp_version}}
         draco_version: ${{matrix.draco_version}}
         occt_version: ${{matrix.occt_version}}
+        openexr_version: ${{matrix.openexr_version}}
 
 #----------------------------------------------------------------------------
 # MacOS CI: Build and test, cross-vtk build matrix
@@ -304,6 +321,7 @@ jobs:
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
+        openexr_version: ${{needs.default_versions.outputs.openexr_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -349,6 +367,7 @@ jobs:
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
+        openexr_version: ${{needs.default_versions.outputs.openexr_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel
@@ -398,6 +417,7 @@ jobs:
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
+        openexr_version: ${{needs.default_versions.outputs.openexr_version}}
 
 #----------------------------------------------------------------------------
 # Coverage: Build and test on linux with last VTK with coverage option
@@ -432,6 +452,7 @@ jobs:
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
+        openexr_version: ${{needs.default_versions.outputs.openexr_version}}
 
 #----------------------------------------------------------------------------
 # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -475,6 +496,7 @@ jobs:
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
+        openexr_version: ${{needs.default_versions.outputs.openexr_version}}
 
 #----------------------------------------------------------------------------
 # static-analysis: Run static analysis on linux
@@ -510,6 +532,7 @@ jobs:
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
+        openexr_version: ${{needs.default_versions.outputs.openexr_version}}
 
 #----------------------------------------------------------------------------
 # external-build: Check build of F3D as sub-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       alembic_min_version: ${{ steps.set_default_versions.outputs.alembic_min_version }}
       assimp_version: ${{ steps.set_default_versions.outputs.assimp_version }}
       assimp_min_version: ${{ steps.set_default_versions.outputs.assimp_min_version }}
+      draco_version: ${{ steps.set_default_versions.outputs.draco_version }}
+      draco_min_version: ${{ steps.set_default_versions.outputs.draco_min_version }}
     steps:
 
     # Alembic is part of VFX reference platform (CY2025: 1.8.x)
@@ -35,6 +37,8 @@ jobs:
         echo "alembic_min_version=1.8.5" >> $GITHUB_OUTPUT
         echo "assimp_version=v5.4.3" >> $GITHUB_OUTPUT
         echo "assimp_min_version=v5.4.0" >> $GITHUB_OUTPUT
+        echo "draco_version=1.5.7" >> $GITHUB_OUTPUT
+        echo "draco_min_version=1.5.6" >> $GITHUB_OUTPUT
 
 #----------------------------------------------------------------------------
 # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
@@ -76,11 +80,13 @@ jobs:
             cpu: arm64
           - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
           - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+          - draco_version: ${{needs.default_versions.outputs.draco_version}}
           - build_type: mindeps
             os: ubuntu-22.04
             cpu: x86_64
             alembic_version: ${{needs.default_versions.outputs.alembic_min_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_min_version}}
+            draco_version: ${{needs.default_versions.outputs.draco_min_version}}
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -100,6 +106,7 @@ jobs:
         cpu: ${{matrix.cpu}}
         alembic_version: ${{matrix.alembic_version}}
         assimp_version: ${{matrix.assimp_version}}
+        draco_version: ${{matrix.draco_version}}
 
 #----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix
@@ -136,6 +143,7 @@ jobs:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+        draco_version: ${{needs.default_versions.outputs.draco_version}}
 
 #----------------------------------------------------------------------------
 # Linux CI: Build and test, cross-vtk build matrix
@@ -157,6 +165,7 @@ jobs:
           - static_label: no-static
           - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
           - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+          - draco_version: ${{needs.default_versions.outputs.draco_version}}
           - build_type: egl
             vtk_version: commit
             raytracing_label: raytracing
@@ -166,6 +175,7 @@ jobs:
             static_label: no-static
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+            draco_version: ${{needs.default_versions.outputs.draco_version}}
           - build_type: osmesa
             vtk_version: commit
             raytracing_label: raytracing
@@ -175,6 +185,7 @@ jobs:
             static_label: no-static
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+            draco_version: ${{needs.default_versions.outputs.draco_version}}
           - build_type: exclude_deprecated
             vtk_version: commit
             raytracing_label: raytracing
@@ -184,6 +195,7 @@ jobs:
             static_label: no-static
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+            draco_version: ${{needs.default_versions.outputs.draco_version}}
           - build_type: no_optional_deps
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -193,6 +205,7 @@ jobs:
             static_label: no-static
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+            draco_version: ${{needs.default_versions.outputs.draco_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -202,6 +215,7 @@ jobs:
             static_label: static
             alembic_version: ${{needs.default_versions.outputs.alembic_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+            draco_version: ${{needs.default_versions.outputs.draco_version}}
           - build_type: mindeps
             vtk_version: commit
             raytracing_label: raytracing
@@ -211,6 +225,7 @@ jobs:
             static_label: no-static
             alembic_version: ${{needs.default_versions.outputs.alembic_min_version}}
             assimp_version: ${{needs.default_versions.outputs.assimp_min_version}}
+            draco_version: ${{needs.default_versions.outputs.draco_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -239,6 +254,7 @@ jobs:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{matrix.alembic_version}}
         assimp_version: ${{matrix.assimp_version}}
+        draco_version: ${{matrix.draco_version}}
 
 #----------------------------------------------------------------------------
 # MacOS CI: Build and test, cross-vtk build matrix
@@ -270,6 +286,7 @@ jobs:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+        draco_version: ${{needs.default_versions.outputs.draco_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -313,6 +330,7 @@ jobs:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+        draco_version: ${{needs.default_versions.outputs.draco_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel
@@ -360,6 +378,7 @@ jobs:
         python_version: ${{matrix.python_version}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+        draco_version: ${{needs.default_versions.outputs.draco_version}}
 
 #----------------------------------------------------------------------------
 # Coverage: Build and test on linux with last VTK with coverage option
@@ -392,6 +411,7 @@ jobs:
         codecov_token: ${{secrets.CODECOV_TOKEN}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+        draco_version: ${{needs.default_versions.outputs.draco_version}}
 
 #----------------------------------------------------------------------------
 # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -433,6 +453,7 @@ jobs:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+        draco_version: ${{needs.default_versions.outputs.draco_version}}
 
 #----------------------------------------------------------------------------
 # static-analysis: Run static analysis on linux
@@ -466,6 +487,7 @@ jobs:
         lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
         alembic_version: ${{needs.default_versions.outputs.alembic_version}}
         assimp_version: ${{needs.default_versions.outputs.assimp_version}}
+        draco_version: ${{needs.default_versions.outputs.draco_version}}
 
 #----------------------------------------------------------------------------
 # external-build: Check build of F3D as sub-project

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -601,8 +601,6 @@ if(F3D_PLUGIN_BUILD_ASSIMP)
     f3d_test(NAME TestDXF DATA PinkEggFromLW.dxf ARGS --background-color=1,1,1 -p --load-plugins=assimp)
   endif()
 
-  f3d_test(NAME TestFBXBone DATA animation_with_skeleton.fbx ARGS --load-plugins=assimp --camera-position=1.90735e-06,0,11007.8 --camera-focal-point=1.90735e-06,0,-8.9407e-08)
-  f3d_test(NAME TestFBXBoneAnimation DATA animation_with_skeleton.fbx ARGS --load-plugins=assimp --camera-position=1.90735e-06,0,11007.8 --camera-focal-point=1.90735e-06,0,-8.9407e-08 --animation-time=0.5 --animation-progress)
   f3d_test(NAME TestFBXSkinningAnimation DATA punch.fbx ARGS --load-plugins=assimp --animation-time=1 --animation-progress)
   f3d_test(NAME TestVerboseAssimp DATA duck.fbx ARGS --verbose --load-plugins=assimp NO_BASELINE REGEXP "LOD3sp")
   f3d_test(NAME TestVerboseAssimpAnimationIndexError DATA animatedLights.fbx ARGS --load-plugins=assimp --animation-index=48 NO_BASELINE REGEXP "Specified animation index is greater than the highest possible animation index, enabling the first animation.")
@@ -611,19 +609,22 @@ if(F3D_PLUGIN_BUILD_ASSIMP)
   f3d_test(NAME TestDAE DATA duck.dae ARGS --load-plugins=assimp)
   f3d_test(NAME TestX DATA anim_test.x ARGS --load-plugins=assimp)
 
-  f3d_test(NAME TestInteractionAnimationFBXBone DATA animation_with_skeleton.fbx ARGS --load-plugins=assimp --camera-position=0,0,14000 --camera-focal-point=0,0,0 INTERACTION PREVENT_SKIP_FRAME)#Space;Wait;Space;
 
   # This test baseline is incorrect because of https://github.com/f3d-app/f3d/issues/603
   # It will need to be changed when fixed
   f3d_test(NAME TestFBXNormalMapping DATA normalMapping.fbx ARGS --load-plugins=assimp)
 
-  # Embedded texture are only working with assimp 5.1.X
-  if("${F3D_ASSIMP_VERSION}" VERSION_GREATER_EQUAL "5.1.0")
-    f3d_test(NAME TestEmbeddedTextureFBX DATA texturedCube.fbx ARGS --load-plugins=assimp)
-    f3d_test(NAME TestFBXAnimation DATA animatedWorld.fbx ARGS --load-plugins=assimp --animation-time=2 --animation-progress)
-    f3d_test(NAME TestFBXAnimationLights DATA animatedLights.fbx ARGS --load-plugins=assimp --animation-time=1.8 --animation-progress)
-    f3d_test(NAME TestFBXAnimationCamera DATA animatedCamera.fbx ARGS --load-plugins=assimp --camera-index=0 --animation-index=0 --animation-time=3 --animation-progress)
-    f3d_test(NAME TestDAEAnimationLights DATA animatedLights.dae ARGS --load-plugins=assimp --animation-time=1.8 --animation-progress)
+  # Tests using embedded textures
+  f3d_test(NAME TestEmbeddedTextureFBX DATA texturedCube.fbx ARGS --load-plugins=assimp)
+  f3d_test(NAME TestFBXAnimation DATA animatedWorld.fbx ARGS --load-plugins=assimp --animation-time=2 --animation-progress)
+  f3d_test(NAME TestFBXAnimationLights DATA animatedLights.fbx ARGS --load-plugins=assimp --animation-time=1.8 --animation-progress)
+  f3d_test(NAME TestFBXAnimationCamera DATA animatedCamera.fbx ARGS --load-plugins=assimp --camera-index=0 --animation-index=0 --animation-time=3 --animation-progress)
+  f3d_test(NAME TestDAEAnimationLights DATA animatedLights.dae ARGS --load-plugins=assimp --animation-time=1.8 --animation-progress)
+
+  if("${F3D_ASSIMP_VERSION}" VERSION_GREATER_EQUAL "5.4.3")
+    f3d_test(NAME TestFBXBone DATA animation_with_skeleton.fbx ARGS --load-plugins=assimp --camera-position=1.90735e-06,0,11007.8 --camera-focal-point=1.90735e-06,0,-8.9407e-08)
+    f3d_test(NAME TestFBXBoneAnimation DATA animation_with_skeleton.fbx ARGS --load-plugins=assimp --camera-position=1.90735e-06,0,11007.8 --camera-focal-point=1.90735e-06,0,-8.9407e-08 --animation-time=0.5 --animation-progress)
+    f3d_test(NAME TestInteractionAnimationFBXBone DATA animation_with_skeleton.fbx ARGS --load-plugins=assimp --camera-position=0,0,14000 --camera-focal-point=0,0,0 INTERACTION PREVENT_SKIP_FRAME)#Space;Wait;Space;
   endif()
 
   if(NOT F3D_MACOS_BUNDLE)

--- a/doc/dev/BUILD.md
+++ b/doc/dev/BUILD.md
@@ -10,15 +10,15 @@ please take a look at our [getting started guide](GETTING_STARTED.md).
 * [VTK](https://vtk.org) >= 9.2.6 (9.4.1 recommended).
 * A C++17 compiler.
 * A CMake-compatible build system (Visual Studio, XCode, Ninja, Make, etc.).
-* Optionally, [Assimp](https://www.assimp.org/) >= 5.0.
-* Optionally, Open CASCADE [OCCT](https://dev.opencascade.org/) >= 7.5.2.
-* Optionally, [Alembic](http://www.alembic.io/) >= 1.7.
+* Optionally, [Assimp](https://www.assimp.org/) >= 5.4.0.
+* Optionally, Open CASCADE [OCCT](https://dev.opencascade.org/) >= 7.6.3.
+* Optionally, [Alembic](http://www.alembic.io/) >= 1.8.5.
 * Optionally, [OpenUSD](https://openusd.org/release/index.html) >= 23.05.
-* Optionally, [OpenVDB](https://www.openvdb.org/download/) >= 10.0.0, enable `IOOpenVDB` VTK module.
-* Optionally, [Draco](https://google.github.io/draco/) >= 1.5.
-* Optionally, [Python](https://www.python.org/) >= 3.6 and [pybind11](https://github.com/pybind/pybind11) >= 2.2.
-* Optionally, [Java](https://www.java.com) >= 18.
-* Optionally, [OpenEXR](https://openexr.com/en/latest/) >= 3.0.
+* Optionally, [OpenVDB](https://www.openvdb.org/download/) >= 12.0.0, enable `IOOpenVDB` module during VTK configuration.
+* Optionally, [Draco](https://google.github.io/draco/) >= 1.5.6.
+* Optionally, [Python](https://www.python.org/) >= 3.9 and [pybind11](https://github.com/pybind/pybind11) >= 2.9.2.
+* Optionally, [Java](https://www.java.com) >= 17.
+* Optionally, [OpenEXR](https://openexr.com/en/latest/) >= 3.0.1.
 
 F3D is tested continuously against versions recommended by the [VFX reference platform](https://vfxplatform.com) defined for **CY2025**
 

--- a/plugins/alembic/CMakeLists.txt
+++ b/plugins/alembic/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
   include(f3dPlugin)
 endif()
 
-find_package(Alembic 1.7 REQUIRED)
+find_package(Alembic 1.8.5 REQUIRED)
 
 message(STATUS "Plugin: Alembic ${Alembic_VERSION} found")
 

--- a/plugins/assimp/CMakeLists.txt
+++ b/plugins/assimp/CMakeLists.txt
@@ -11,17 +11,10 @@ else()
   include(f3dPlugin)
 endif()
 
-find_package(assimp 5.0 REQUIRED)
+find_package(assimp 5.4.0 REQUIRED)
 
 set(F3D_ASSIMP_VERSION "${assimp_VERSION}" CACHE INTERNAL "")
 message(STATUS "Plugin: assimp ${assimp_VERSION} found")
-
-if("${assimp_VERSION}" VERSION_GREATER_EQUAL "5.1.0")
-  message(WARNING "Plugin: assimp: Complex animations are not working with assimp 5.1.0 and newer, use assimp 5.0.X for animation support with assimp formats.")
-endif()
-if("${assimp_VERSION}" VERSION_LESS "5.1.0")
-  message(WARNING "Plugin: assimp: Embedded texture are only working with assimp 5.1.X and newer.")
-endif()
 
 f3d_plugin_init()
 

--- a/plugins/draco/CMakeLists.txt
+++ b/plugins/draco/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
   include(f3dPlugin)
 endif()
 
-find_package(draco REQUIRED)
+find_package(draco 1.5.6 REQUIRED)
 
 message(STATUS "Plugin: draco ${draco_VERSION} found")
 

--- a/plugins/occt/CMakeLists.txt
+++ b/plugins/occt/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 find_package(OpenCASCADE REQUIRED)
 
-if("${OpenCASCADE_VERSION}" VERSION_LESS "7.5.0")
+if("${OpenCASCADE_VERSION}" VERSION_LESS "7.6.3")
   message(FATAL_ERROR "Plugin: OpenCASCADE: ${OpenCASCADE_VERSION} is not supported by F3D, please update your OpenCASCADE installation.")
 endif()
 

--- a/plugins/usd/CMakeLists.txt
+++ b/plugins/usd/CMakeLists.txt
@@ -13,7 +13,11 @@ endif()
 
 find_package(pxr REQUIRED)
 
-message(STATUS "Plugin: USD found")
+if("${PXR_VERSION}" VERSION_LESS "2408")
+  message(FATAL_ERROR "Plugin: USD: ${PXR_VERSION} is not supported by F3D, please update your USD installation.")
+endif()
+
+message(STATUS "Plugin: USD ${PXR_VERSION} found")
 
 f3d_plugin_init()
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,7 +14,7 @@ include(GNUInstallDirs)
 include(f3dPython)
 
 find_package(Python 3.9 COMPONENTS Interpreter Development)
-find_package(pybind11 2.2 REQUIRED)
+find_package(pybind11 2.9.2 REQUIRED)
 
 pybind11_add_module(pyf3d MODULE F3DPythonBindings.cxx)
 

--- a/vtkext/private/module/CMakeLists.txt
+++ b/vtkext/private/module/CMakeLists.txt
@@ -97,7 +97,7 @@ if(ANDROID)
 endif()
 
 if(F3D_MODULE_EXR)
-  find_package(OpenEXR 3.0 REQUIRED)
+  find_package(OpenEXR 3.0.1 REQUIRED)
   list(APPEND classes vtkF3DEXRReader)
 endif()
 


### PR DESCRIPTION
Add a mindeps CI testing minium version for:
 - alembic
 - assimp
 - draco
 - occt
 - openexr
 - openvdb
 - pybind11
 - python
 - usd
 - java
 
 Also update related documentation

Minimum version for our direct dependencies:
 - alembic: 1.8.5
 - assimp: v5.4.0
 - draco: 1.5.6
 - occt: V7_6_3
 - openexr: 3.0.1
 - openvdb: 12.0.0
 - pybind11: v2.9.2
 - Python: 3.9
 - usd: v23.05
 - Java: 17
 
 Dependencies that were not added to mindeps:
  - blosc : No find_package in F3D, not listed as dependencies in our doc, no specific versions listed by VFX
  - imath: No find_package in F3D, not listed as dependencies in our doc, no specific versions listed by VFX
  - ospray: No find_package in F3D, not listed as dependencies in our doc, no specific versions listed by VFX, problem with recent releases of F3D, we are "already" testing mindeps and cannot update.
  - tbb : No find_package in F3D, not listed as dependencies in our doc, no specific versions listed by VFX
  - zlib : No find_package in F3D, not listed as dependencies in our doc, no specific versions listed by VFX
  
  Dependencies that should be added to mindeps but more work needed:
 - CMake
 
 
 Adress: #1736 #1940