### PR TITLE
CI: Improve versions mgt logic

### DIFF
--- a/.github/actions/alembic-install-dep/action.yml
+++ b/.github/actions/alembic-install-dep/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Cache Alembic
       id: cache-alembic
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/alembic_install
         key: alembic-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
@@ -67,3 +67,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/alembic_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-alembic.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-alembic.outputs.cache-primary-key }}
+        path: dependencies/alembic_install

--- a/.github/actions/assimp-install-dep/action.yml
+++ b/.github/actions/assimp-install-dep/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Cache ASSIMP
       id: cache-assimp
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/assimp_install
         key: assimp-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
@@ -87,3 +87,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/assimp_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-assimp.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-assimp.outputs.cache-primary-key }}
+        path: dependencies/assimp_install

--- a/.github/actions/blosc-install-dep/action.yml
+++ b/.github/actions/blosc-install-dep/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Cache blosc
       id: cache-blosc
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/blosc_install
         key: blosc-v1.21.6-${{runner.os}}-${{inputs.cpu}}-0
@@ -62,3 +62,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/blosc_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-blosc.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-blosc.outputs.cache-primary-key }}
+        path: dependencies/blosc_install

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -67,6 +67,7 @@ runs:
       with:
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
         raytracing_label: raytracing
+        openvdb_version: ${{inputs.openvdb_version}}
 
     # coverage build is done in source as it seems to be required for codecov
     # CMAKE_MODULE_PATH is required because of

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -10,28 +10,25 @@ inputs:
     default: ''
   alembic_version:
     description: 'Version of alembic to build'
-    required: true
+    required: false
   assimp_version:
     description: 'Version of assimp to build'
-    required: true
+    required: false
   draco_version:
     description: 'Version of draco to build'
-    required: true
+    required: false
   occt_version:
     description: 'Version of occt to build'
-    required: true
+    required: false
   openexr_version:
     description: 'Version of openexr to build'
-    required: true
+    required: false
   openvdb_version:
     description: 'Version of openvdb to build'
-    required: true
-  pybind11_version:
-    description: 'Version of pybind11 to build'
-    required: true
+    required: false
   usd_version:
     description: 'Version of usd to build'
-    required: true
+    required: false
 
 runs:
   using: "composite"
@@ -59,7 +56,6 @@ runs:
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
-        pybind11_version: ${{inputs.pybind11_version}}
         usd_version: ${{inputs.usd_version}}
 
     - name: Install VTK dependency

--- a/.github/actions/draco-install-dep/action.yml
+++ b/.github/actions/draco-install-dep/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Cache Draco
       id: cache-draco
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/draco_install
         key: draco-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-3
@@ -66,3 +66,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/draco_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-draco.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-draco.outputs.cache-primary-key }}
+        path: dependencies/draco_install

--- a/.github/actions/external-build-ci/action.yml
+++ b/.github/actions/external-build-ci/action.yml
@@ -1,10 +1,5 @@
 name: 'External build CI'
 description: 'External build CI'
-inputs:
-  openvdb_version:
-    description: 'Version of openvdb to build'
-    required: false
-
 runs:
   using: "composite"
   steps:
@@ -26,13 +21,11 @@ runs:
       uses: ./source/f3d/.github/actions/vtk-dependencies
       with:
         source_dir: ./source/f3d
-        openvdb_version: ${{inputs.openvdb_version}}
  
     - name: Install VTK dependency
       uses: ./source/f3d/.github/actions/vtk-install-dep
       with:
         vtk_sha_file: ./source/f3d/.github/actions/vtk_commit_sha
-        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/external-build-ci/action.yml
+++ b/.github/actions/external-build-ci/action.yml
@@ -32,6 +32,7 @@ runs:
       uses: ./source/f3d/.github/actions/vtk-install-dep
       with:
         vtk_sha_file: ./source/f3d/.github/actions/vtk_commit_sha
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/external-build-ci/action.yml
+++ b/.github/actions/external-build-ci/action.yml
@@ -3,7 +3,7 @@ description: 'External build CI'
 inputs:
   openvdb_version:
     description: 'Version of openvdb to build'
-    required: true
+    required: false
 
 runs:
   using: "composite"

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -7,43 +7,46 @@ inputs:
     default: 'x86_64'
   alembic_version:
     description: 'Version of alembic to build'
-    required: true
+    required: false
   assimp_version:
     description: 'Version of assimp to build'
-    required: true
+    required: false
   draco_version:
     description: 'Version of draco to build'
-    required: true
+    required: false
   occt_version:
     description: 'Version of occt to build'
-    required: true
+    required: false
   openexr_version:
     description: 'Version of openexr to build'
-    required: true
+    required: false
   pybind11_version:
     description: 'Version of pybind11 to build'
-    required: true
+    required: false
   usd_version:
     description: 'Version of usd to build'
-    required: true
+    required: false
 
 runs:
   using: "composite"
   steps:
 
     - name: Install OCCT dependency
+      if: inputs.occt_version != ''
       uses: ./source/.github/actions/occt-install-dep
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.occt_version}}
 
     - name: Install Assimp dependency
+      if: inputs.assimp_version != ''
       uses: ./source/.github/actions/assimp-install-dep
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.assimp_version}}
 
     - name: Install Draco dependency
+      if: inputs.draco_version != ''
       uses: ./source/.github/actions/draco-install-dep
       with:
         cpu: ${{inputs.cpu}}
@@ -55,23 +58,27 @@ runs:
         cpu: ${{inputs.cpu}}
 
     - name: Install OpenEXR dependency
+      if: inputs.openexr_version != ''
       uses: ./source/.github/actions/openexr-install-dep
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.openexr_version}}
 
     - name: Install Alembic dependency
+      if: inputs.alembic_version != ''
       uses: ./source/.github/actions/alembic-install-dep
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.alembic_version}}
 
     - name: Install pybind11 dependency
+      if: inputs.pybind11_version != ''
       uses: ./source/.github/actions/pybind11-install-dep
       with:
         version: ${{inputs.pybind11_version}}
 
     - name: Install USD dependency
+      if: inputs.usd_version != ''
       uses: ./source/.github/actions/usd-install-dep
       with:
         cpu: ${{inputs.cpu}}

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -76,3 +76,4 @@ runs:
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.usd_version}}
+        openexr_version: ${{inputs.openexr_version}}

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -42,34 +42,34 @@ inputs:
     required: true
   alembic_version:
     description: 'Version of alembic to build'
-    required: true
+    required: false
   assimp_version:
     description: 'Version of assimp to build'
-    required: true
+    required: false
   draco_version:
     description: 'Version of draco to build'
-    required: true
+    required: false
   occt_version:
     description: 'Version of occt to build'
-    required: true
+    required: false
   openexr_version:
     description: 'Version of openexr to build'
-    required: true
+    required: false
   openvdb_version:
     description: 'Version of openvdb to build'
-    required: true
+    required: false
   pybind11_version:
     description: 'Version of pybind11 to build'
-    required: true
+    required: false
   python_version:
     description: 'Version of python to install'
-    required: true
+    required: false
   usd_version:
     description: 'Version of usd to build'
-    required: true
+    required: false
   java_version:
     description: 'Version of java to install'
-    required: true
+    required: false
 
 runs:
   using: "composite"
@@ -79,8 +79,6 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.lfs_sha }}" ]] || { echo "lfs_sha input is empty" ; exit 1; }
-        [[ "${{ inputs.python_version }}" ]] || { echo "python_version input is empty" ; exit 1; }
-        [[ "${{ inputs.java_version }}" ]] || { echo "java_version input is empty" ; exit 1; }
 
     - name: Recover LFS Data
       uses: f3d-app/lfs-data-cache-action@v1
@@ -113,13 +111,17 @@ runs:
         openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Set up Python
-      if: inputs.optional_deps_label == 'optional-deps'
+      if: |
+        inputs.optional_deps_label == 'optional-deps' &&
+        inputs.python_version != ''
       uses: actions/setup-python@v5
       with:
         python-version: ${{inputs.python_version}}
 
     - name: Install Python dependencies
-      if: inputs.optional_deps_label == 'optional-deps'
+      if: |
+        inputs.optional_deps_label == 'optional-deps' &&
+        inputs.python_version != ''
       shell: bash
       run: |
         python -m pip install --upgrade pip
@@ -127,6 +129,9 @@ runs:
         python -m pip install pybind11_stubgen
 
     - name: Setup JDK
+      if: |
+        inputs.optional_deps_label == 'optional-deps' &&
+        inputs.java_version != ''
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -110,6 +110,7 @@ runs:
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
         raytracing_label: ${{inputs.raytracing_label}}
         cpu: ${{inputs.cpu}}
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Set up Python
       if: inputs.optional_deps_label == 'optional-deps'

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -15,44 +15,32 @@ inputs:
     default: 'x86_64'
   alembic_version:
     description: 'Version of alembic to build'
-    required: true
+    required: false
   assimp_version:
     description: 'Version of assimp to build'
-    required: true
+    required: false
   draco_version:
     description: 'Version of draco to build'
-    required: true
+    required: false
   occt_version:
     description: 'Version of occt to build'
-    required: true
+    required: false
   openexr_version:
     description: 'Version of openexr to build'
-    required: true
+    required: false
   openvdb_version:
     description: 'Version of openvdb to build'
-    required: true
+    required: false
   pybind11_version:
     description: 'Version of pybind11 to build'
-    required: true
+    required: false
   usd_version:
     description: 'Version of usd to build'
-    required: true
+    required: false
 
 runs:
   using: "composite"
   steps:
-
-    - name: Check required inputs
-      shell: bash
-      run: |
-        [[ "${{ inputs.alembic_version }}" ]] || { echo "alembic_version input is empty" ; exit 1; }
-        [[ "${{ inputs.assimp_version }}" ]] || { echo "assimp_version input is empty" ; exit 1; }
-        [[ "${{ inputs.draco_version }}" ]] || { echo "draco_version input is empty" ; exit 1; }
-        [[ "${{ inputs.occt_version }}" ]] || { echo "occt_version input is empty" ; exit 1; }
-        [[ "${{ inputs.openexr_version }}" ]] || { echo "openexr_version input is empty" ; exit 1; }
-        [[ "${{ inputs.openvdb_version }}" ]] || { echo "openvdb_version input is empty" ; exit 1; }
-        [[ "${{ inputs.pybind11_version }}" ]] || { echo "pybind11_version input is empty" ; exit 1; }
-        [[ "${{ inputs.usd_version }}" ]] || { echo "usd_version input is empty" ; exit 1; }
 
     - name: Dependencies Dir
       shell: bash

--- a/.github/actions/imath-install-dep/action.yml
+++ b/.github/actions/imath-install-dep/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Cache Imath
       id: cache-imath
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/imath_install
         key: imath-v3.1.12-${{runner.os}}-${{inputs.cpu}}-0
@@ -57,3 +57,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/imath_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-imath.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-imath.outputs.cache-primary-key }}
+        path: dependencies/imath_install

--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Cache OCCT
       id: cache-occt
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/occt_install
         key: occt-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-4
@@ -54,7 +54,7 @@ runs:
       if: steps.cache-occt.outputs.cache-hit != 'true'
       working-directory: ${{github.workspace}}/dependencies
       shell: bash
-      run:
+      run: |
         mkdir occt_build
         mkdir occt_install
 
@@ -122,3 +122,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/occt_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-occt.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-occt.outputs.cache-primary-key }}
+        path: dependencies/occt_install

--- a/.github/actions/openexr-install-dep/action.yml
+++ b/.github/actions/openexr-install-dep/action.yml
@@ -25,7 +25,7 @@ runs:
         path: dependencies/openexr_install
         key: openexr-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
 
-    # Dependents: usd
+    # Dependents (not version): usd
     - name: Checkout OpenEXR
       if: steps.cache-openexr.outputs.cache-hit != 'true'
       uses: actions/checkout@v4

--- a/.github/actions/openexr-install-dep/action.yml
+++ b/.github/actions/openexr-install-dep/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Cache OpenEXR
       id: cache-openexr
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/openexr_install
         key: openexr-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
@@ -67,3 +67,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/openexr_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-openexr.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-openexr.outputs.cache-primary-key }}
+        path: dependencies/openexr_install

--- a/.github/actions/openvdb-install-dep/action.yml
+++ b/.github/actions/openvdb-install-dep/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Cache OpenVDB
       id: cache-openvdb
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/openvdb_install
         key: openvdb-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
@@ -84,3 +84,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/openvdb_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-openvdb.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-openvdb.outputs.cache-primary-key }}
+        path: dependencies/openvdb_install

--- a/.github/actions/openvdb-install-dep/action.yml
+++ b/.github/actions/openvdb-install-dep/action.yml
@@ -25,7 +25,7 @@ runs:
         path: dependencies/openvdb_install
         key: openvdb-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
 
-    # Dependents: vtk
+    # Dependents (not version): vtk
     - name: Checkout OpenVDB
       if: steps.cache-openvdb.outputs.cache-hit != 'true'
       uses: actions/checkout@v4

--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Cache ospray
       id: cache-ospray
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/ospray_install
         key: ospray-sb-v2.7.1-${{runner.os}}-${{inputs.cpu}}-3
@@ -76,3 +76,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/ospray_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-ospray.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-ospray.outputs.cache-primary-key }}
+        path: dependencies/ospray_install

--- a/.github/actions/pybind11-install-dep/action.yml
+++ b/.github/actions/pybind11-install-dep/action.yml
@@ -11,7 +11,7 @@ runs:
 
     - name: Cache pybind11
       id: cache-pybind11
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/pybind11_install
         key: pybind11-${{inputs.version}}-${{runner.os}}-0
@@ -54,3 +54,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/pybind11_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-pybind11.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-pybind11.outputs.cache-primary-key }}
+        path: dependencies/pybind11_install

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -9,28 +9,28 @@ inputs:
     required: true
   alembic_version:
     description: 'Version of alembic to build'
-    required: true
+    required: false
   assimp_version:
     description: 'Version of assimp to build'
-    required: true
+    required: false
   draco_version:
     description: 'Version of draco to build'
-    required: true
+    required: false
   occt_version:
     description: 'Version of occt to build'
-    required: true
+    required: false
   openexr_version:
     description: 'Version of openexr to build'
-    required: true
+    required: false
   openvdb_version:
     description: 'Version of openvdb to build'
-    required: true
+    required: false
   pybind11_version:
     description: 'Version of pybind11 to build'
-    required: true
+    required: false
   usd_version:
     description: 'Version of usd to build'
-    required: true
+    required: false
 
 runs:
   using: "composite"

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -65,6 +65,7 @@ runs:
       uses: ./source/.github/actions/vtk-install-dep
       with:
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -26,9 +26,6 @@ inputs:
   openexr_version:
     description: 'Version of openexr to build'
     required: false
-  openvdb_version:
-    description: 'Version of openvdb to build'
-    required: false
 
 runs:
   using: "composite"
@@ -55,14 +52,12 @@ runs:
         draco_version: ${{inputs.draco_version}}
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
-        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
         vtk_version: ${{inputs.vtk_version}}
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
-        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -70,6 +70,7 @@ runs:
       with:
         vtk_version: ${{inputs.vtk_version}}
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -13,28 +13,22 @@ inputs:
     required: true
   alembic_version:
     description: 'Version of alembic to build'
-    required: true
+    required: false
   assimp_version:
     description: 'Version of assimp to build'
-    required: true
+    required: false
   draco_version:
     description: 'Version of draco to build'
-    required: true
+    required: false
   occt_version:
     description: 'Version of occt to build'
-    required: true
+    required: false
   openexr_version:
     description: 'Version of openexr to build'
-    required: true
+    required: false
   openvdb_version:
     description: 'Version of openvdb to build'
-    required: true
-  pybind11_version:
-    description: 'Version of pybind11 to build'
-    required: true
-  usd_version:
-    description: 'Version of usd to build'
-    required: true
+    required: false
 
 runs:
   using: "composite"
@@ -62,8 +56,6 @@ runs:
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
-        pybind11_version: ${{inputs.pybind11_version}}
-        usd_version: ${{inputs.usd_version}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -22,9 +22,6 @@ inputs:
   openvdb_version:
     description: 'Version of openvdb to build'
     required: true
-  pybind11_version:
-    description: 'Version of pybind11 to build'
-    required: true
   usd_version:
     description: 'Version of usd to build'
     required: true
@@ -55,7 +52,6 @@ runs:
         occt_version: ${{inputs.occt_version}}
         openexr_version: ${{inputs.openexr_version}}
         openvdb_version: ${{inputs.openvdb_version}}
-        pybind11_version: ${{inputs.pybind11_version}}
         usd_version: ${{inputs.usd_version}}
 
     - name: Install VTK dependency

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -62,6 +62,7 @@ runs:
       uses: ./source/.github/actions/vtk-install-dep
       with:
         vtk_sha_file: ./source/.github/actions/vtk_commit_sha
+        openvdb_version: ${{inputs.openvdb_version}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/tbb-install-dep/action.yml
+++ b/.github/actions/tbb-install-dep/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Cache TBB
       id: cache-tbb
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/tbb_install
         key: tbb-v2021.12.0-${{runner.os}}-${{inputs.cpu}}-2
@@ -60,3 +60,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/tbb_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-tbb.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-tbb.outputs.cache-primary-key }}
+        path: dependencies/tbb_install

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Cache USD
       id: cache-usd
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/usd_install
         key: usd-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-3
@@ -74,3 +74,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/usd_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-usd.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-usd.outputs.cache-primary-key }}
+        path: dependencies/usd_install

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -8,17 +8,26 @@ inputs:
   version:
     description: 'Version of usd to build'
     required: true
+  openexr_version:
+    description: 'Version of openexr to build against'
+    required: true
 
 runs:
   using: "composite"
   steps:
+
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.openexr_version }}" ]] || { echo "openexr_version input is empty" ; exit 1; }
 
     - name: Cache USD
       id: cache-usd
       uses: actions/cache/restore@v4
       with:
         path: dependencies/usd_install
-        key: usd-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-3
+        key: usd-${{inputs.version}}-${{inputs.openexr_version}}-${{runner.os}}-${{inputs.cpu}}-3
 
     - name: Checkout USD
       if: steps.cache-usd.outputs.cache-hit != 'true'

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -27,7 +27,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: dependencies/usd_install
-        key: usd-${{inputs.version}}-${{inputs.openexr_version}}-${{runner.os}}-${{inputs.cpu}}-3
+        key: usd-${{inputs.version}}-${{inputs.openexr_version}}-${{runner.os}}-${{inputs.cpu}}-0
 
     - name: Checkout USD
       if: steps.cache-usd.outputs.cache-hit != 'true'

--- a/.github/actions/vtk-android-install-dep/action.yml
+++ b/.github/actions/vtk-android-install-dep/action.yml
@@ -27,24 +27,20 @@ runs:
         [[ "${{ inputs.arch }}" ]] || { echo "arch input is empty" ; exit 1; }
 
     - name: Recover VTK Short SHA from file
-      if: |
-        steps.cache-vtk.outputs.cache-hit != 'true' &&
-        inputs.vtk_version == 'commit'
+      if: inputs.vtk_version == 'commit'
       working-directory: ${{github.workspace}}
       shell: bash
       run: echo "VTK_SHA_OR_TAG=$(<${{ inputs.vtk_sha_file }})" >> $GITHUB_ENV
 
     - name: Copy VTK version to env var
-      if: |
-        steps.cache-vtk.outputs.cache-hit != 'true' &&
-        inputs.vtk_version != 'commit'
+      if: inputs.vtk_version != 'commit'
       working-directory: ${{github.workspace}}
       shell: bash
       run: echo "VTK_SHA_OR_TAG=${{inputs.vtk_version}}" >> $GITHUB_ENV
 
     - name: Cache VTK
       id: cache-vtk
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/vtk_build
         key: vtk-android-${{env.VTK_SHA_OR_TAG}}-${{inputs.api_level}}-${{inputs.arch}}-1
@@ -81,3 +77,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/vtk_build
       shell: bash
       run: cmake --build . --parallel 2
+
+    - name: Save cache
+      if: steps.cache-vtk.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-vtk.outputs.cache-primary-key }}
+        path: dependencies/vtk_build

--- a/.github/actions/vtk-dependencies/action.yml
+++ b/.github/actions/vtk-dependencies/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: './source'
   openvdb_version:
     description: 'Version of openvdb to build'
-    required: true
+    required: false
 
 runs:
   using: "composite"
@@ -40,6 +40,7 @@ runs:
         cpu: ${{inputs.cpu}}
 
     - name: Install OpenVDB
+      if: inputs.openvdb_version != ''
       uses: ./.actions/openvdb-install-dep
       with:
         cpu: ${{inputs.cpu}}

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -19,16 +19,11 @@ inputs:
     default: 'x86_64'
   openvdb_version:
     description: 'Version of openvdb to build against'
-    required: true
+    required: false
 
 runs:
   using: "composite"
   steps:
-
-    - name: Check required inputs
-      shell: bash
-      run: |
-        [[ "${{ inputs.openvdb_version }}" ]] || { echo "openvdb_version input is empty" ; exit 1; }
 
     - name: Recover VTK Short SHA from file
       if: |
@@ -96,7 +91,7 @@ runs:
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX:PATH=../vtk_install
         -DCMAKE_PREFIX_PATH:PATH=$(pwd)/../install/
-        -DOpenVDB_CMAKE_PATH=$(pwd)/../install/lib/cmake/OpenVDB/
+        -DOpenVDB_CMAKE_PATH=${{ inputs.openvdb_version != '' && '$(pwd)/../install/lib/cmake/OpenVDB/' || '' }}
         -DVTKOSPRAY_ENABLE_DENOISER=ON
         -DVTK_BUILD_TESTING=OFF
         -DVTK_DEBUG_LEAKS=ON
@@ -114,7 +109,7 @@ runs:
         -DVTK_MODULE_ENABLE_VTK_IOGeometry=YES
         -DVTK_MODULE_ENABLE_VTK_IOImage=YES
         -DVTK_MODULE_ENABLE_VTK_IOImport=YES
-        -DVTK_MODULE_ENABLE_VTK_IOOpenVDB=YES
+        -DVTK_MODULE_ENABLE_VTK_IOOpenVDB=${{ inputs.openvdb_version != '' && 'YES' || 'DEFAULT' }}
         -DVTK_MODULE_ENABLE_VTK_IOPLY=YES
         -DVTK_MODULE_ENABLE_VTK_IOParallel=YES
         -DVTK_MODULE_ENABLE_VTK_IOXML=YES

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -17,10 +17,18 @@ inputs:
     description: 'CPU architecture to build for'
     required: false
     default: 'x86_64'
+  openvdb_version:
+    description: 'Version of openvdb to build against'
+    required: true
 
 runs:
   using: "composite"
   steps:
+
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.openvdb_version }}" ]] || { echo "openvdb_version input is empty" ; exit 1; }
 
     - name: Recover VTK Short SHA from file
       if: |
@@ -43,7 +51,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: dependencies/vtk_install
-        key: vtk-${{env.VTK_SHA_OR_TAG}}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-8
+        key: vtk-${{env.VTK_SHA_OR_TAG}}-openvdb-${{inputs.openvdb_version}}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-8
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -40,7 +40,7 @@ runs:
 
     - name: Cache VTK
       id: cache-vtk
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/vtk_install
         key: vtk-${{env.VTK_SHA_OR_TAG}}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-8
@@ -136,3 +136,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/vtk_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-vtk.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-vtk.outputs.cache-primary-key }}
+        path: dependencies/vtk_install

--- a/.github/actions/zlib-install-dep/action.yml
+++ b/.github/actions/zlib-install-dep/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Cache zlib
       id: cache-zlib
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/zlib_install
         key: zlib-v1.3.1-${{runner.os}}-${{inputs.cpu}}-4
@@ -56,3 +56,10 @@ runs:
       working-directory: ${{github.workspace}}/dependencies/zlib_install
       shell: bash
       run: cp -r ./* ../install/
+
+    - name: Save cache
+      if: steps.cache-zlib.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-zlib.outputs.cache-primary-key }}
+        path: dependencies/zlib_install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
     if: github.event.pull_request.draft == false
     needs: [cache_lfs, cache_dependencies, default_versions]
 
+    # no-optional-deps still needs OpenVDB for VTK
     strategy:
       fail-fast: false
       matrix:
@@ -285,16 +286,7 @@ jobs:
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: auto
             static_label: no-static
-            alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-            assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-            draco_version: ${{needs.default_versions.outputs.draco_version}}
-            occt_version: ${{needs.default_versions.outputs.occt_version}}
-            openexr_version: ${{needs.default_versions.outputs.openexr_version}}
             openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-            pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-            python_version: ${{needs.default_versions.outputs.python_version}}
-            usd_version: ${{needs.default_versions.outputs.usd_version}}
-            java_version: ${{needs.default_versions.outputs.java_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -403,7 +395,6 @@ jobs:
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
         python_version: ${{needs.default_versions.outputs.python_version}}
         usd_version: ${{needs.default_versions.outputs.usd_version}}
-        java_version: ${{needs.default_versions.outputs.java_version}}
 
 #----------------------------------------------------------------------------
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -454,7 +445,6 @@ jobs:
         pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
         python_version: ${{needs.default_versions.outputs.python_version}}
         usd_version: ${{needs.default_versions.outputs.usd_version}}
-        java_version: ${{needs.default_versions.outputs.java_version}}
 
 #----------------------------------------------------------------------------
 # Python packaging: Build and test the Python wheel
@@ -544,7 +534,6 @@ jobs:
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-        pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
         usd_version: ${{needs.default_versions.outputs.usd_version}}
 
 #----------------------------------------------------------------------------
@@ -591,8 +580,6 @@ jobs:
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-        pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-        usd_version: ${{needs.default_versions.outputs.usd_version}}
 
 #----------------------------------------------------------------------------
 # static-analysis: Run static analysis on linux
@@ -630,7 +617,6 @@ jobs:
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
         openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-        pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
         usd_version: ${{needs.default_versions.outputs.usd_version}}
 
 #----------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,6 @@ jobs:
     if: github.event.pull_request.draft == false
     needs: [cache_lfs, cache_dependencies, default_versions]
 
-    # no-optional-deps still needs OpenVDB for VTK
     strategy:
       fail-fast: false
       matrix:
@@ -286,7 +285,6 @@ jobs:
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: auto
             static_label: no-static
-            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
           - build_type: static_libs
             vtk_version: commit
             raytracing_label: no-raytracing
@@ -579,7 +577,6 @@ jobs:
         draco_version: ${{needs.default_versions.outputs.draco_version}}
         occt_version: ${{needs.default_versions.outputs.occt_version}}
         openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-        openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # static-analysis: Run static analysis on linux
@@ -623,7 +620,7 @@ jobs:
 # external-build: Check build of F3D as sub-project
 #----------------------------------------------------------------------------
   external-build:
-    needs: [cache_dependencies, default_versions]
+    needs: cache_dependencies
     if: github.event.pull_request.draft == false
 
     strategy:
@@ -643,8 +640,6 @@ jobs:
 
     - name: External build CI
       uses: ./source/f3d/.github/actions/external-build-ci
-      with:
-        openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
 
 #----------------------------------------------------------------------------
 # android: Check build of F3D for android


### PR DESCRIPTION
 - Use save/restore logic for dependencies cache to avoid rebuild dependencies when not needed
 - Improve dependents logic to invalidate cache when another dependencies changes
 - Add support for not restoring cache of not needed dependencies when version is empty
 - Add support for not build OpenVDB and building VTK without OpenVDB