### PR TITLE
Imgui console is rendered below scalar bar and axis #1926

### DIFF
--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -248,6 +248,7 @@ void vtkF3DRenderer::Initialize()
   this->ImporterTimeStamp = 0;
   this->ImporterUpdateTimeStamp = 0;
 
+  this->AddActor2D(this->ScalarBarActor);
   this->AddActor(this->GridActor);
   this->AddActor(this->DropZoneActor);
   this->AddActor(this->SkyboxActor);
@@ -268,7 +269,6 @@ void vtkF3DRenderer::Initialize()
 
   this->GridInfo = "";
 
-  this->AddActor2D(this->ScalarBarActor);
   this->ScalarBarActor->VisibilityOff();
 
   this->ExpandingRangeSet = false;


### PR DESCRIPTION
whats done:
  - Fix the issue with scalar bar rendering above imgui console
whats to be done:
  - Fix axis rendering above imgui console