### PR TITLE
fix zsh completion

### DIFF
--- a/resources/completion.zsh
+++ b/resources/completion.zsh
@@ -7,7 +7,7 @@ local f3dhelp
 
 f3dhelp=$(f3d --help 2>&1 | sed '1,/Examples/!d' | sed 's/\[.*\] *//')
 
-shortopts=$(echo $f3dhelp | grep "^\s*[-].," | sed "s/^ *\(-.\), *--[^ ]* *\(.*\)$/\1[\2]/")
+shortopts=$(echo $f3dhelp | grep "^\s*[-]., --" | sed "s/^ *\(-.\), *--[^ ]* *\(.*\)$/\1[\2]/")
 longopts=$(echo $f3dhelp | grep "[, ] [-]-" | sed 's/=.*>//g' | sed 's/-.,//g' | sed "s/^ *\([^ ]*\) *\(.*\)$/\1[\2]/g")
 
 arguments=("${(f)shortopts}")


### PR DESCRIPTION
Completion on zsh was broken, with the error message `_arguments:comparguments:327: invalid argument:                                 -y, means direct scalars (default: -1)`.

The error was caused by improper parsing of the following help message:
```
  -y, --coloring-component [=<comp_index>(=-2)]
                                Component from the array to color with. -1
                                means magnitude, -2 or the short option,
                                -y, means direct scalars (default: -1)
```

This PR fixes this issue by requiring `--` to follow `, ` for short options.
