### PR TITLE
Unset optional display value

### DIFF
--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -943,9 +943,9 @@ interactor& interactor_impl::initBindings()
   auto docTgl = [](const std::string& doc, const bool& val)
   { return std::pair(doc, (val ? "ON" : "OFF")); };
 
-  // "doc", "ON/OFF/N/A"
+  // "doc", "ON/OFF/Unset"
   auto docTglOpt = [](const std::string& doc, const std::optional<bool>& val)
-  { return std::pair(doc, (val.has_value() ? (val.value() ? "ON" : "OFF") : "N/A")); };
+  { return std::pair(doc, (val.has_value() ? (val.value() ? "ON" : "OFF") : "Unset")); };
 
   // Available standard keys: None
   this->addBinding({mod_t::NONE, "W"}, "cycle_animation", "Scene", docAnim);

--- a/library/testing/TestSDKInteractorDocumentation.cxx
+++ b/library/testing/TestSDKInteractorDocumentation.cxx
@@ -8,7 +8,7 @@ using mod_t = f3d::interaction_bind_t::ModifierKeys;
 constexpr int nGroup = 3;
 constexpr int nBindsCamera = 7;
 constexpr std::string_view initDoc = "Toggle Orthographic Projection";
-constexpr std::string_view initVal = "N/A";
+constexpr std::string_view initVal = "Unset";
 
 int TestSDKInteractorDocumentation(int argc, char* argv[])
 {

--- a/testing/baselines/TestInteractionCheatsheet.png
+++ b/testing/baselines/TestInteractionCheatsheet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67420d729d1a61af0f6c19f9c4e756707eb46c6c26e31861ca30ccb255064e22
-size 49474
+oid sha256:4d618ea5db59f5c26c994405e58de32a1199e1ef64b28d88d0e77615aaf0ad58
+size 49545

--- a/testing/baselines/TestInteractionCheatsheetAnimationName.png
+++ b/testing/baselines/TestInteractionCheatsheetAnimationName.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55c0e40b246dd4c119fa7842cc4e1144644c3cff414a1ae557eeaf1f958790c2
-size 140441
+oid sha256:343a15e8d87300ecb44dc268e539f338f6deb3c8e81a5581373c249a375cb8ca
+size 141040

--- a/testing/baselines/TestInteractionCheatsheetAnimationNameRaytracing.png
+++ b/testing/baselines/TestInteractionCheatsheetAnimationNameRaytracing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e138fd5859dfcc9ce6a2ccf585438e46fd45e7a031235f3ed87933c17d6559f0
-size 144503
+oid sha256:87e56d3bf1120a1d659048ad847985769a9fb732f7eeed7c29dfece230b3d66e
+size 144787

--- a/testing/baselines/TestInteractionCheatsheetBlackBG.png
+++ b/testing/baselines/TestInteractionCheatsheetBlackBG.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:463f443679fe355f5f942495ca4e5940e76194fad3ed5208bf0d5dd0fa191f65
-size 50269
+oid sha256:793b0d9ac02b18cfd5d3e89eb0f4a799e3c37189ddc5b687c9e984d29bc8cc3b
+size 50253

--- a/testing/baselines/TestInteractionCheatsheetBlackBGRaytracing.png
+++ b/testing/baselines/TestInteractionCheatsheetBlackBGRaytracing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ecceaba249c9a5f8bd1fc86675dd521780d77e0f9137d444a3f8e414460db3c
-size 50334
+oid sha256:732d9be01c1caff1f85ffffec64c31606bb728d967cd42ca0698fd988518444b
+size 50185

--- a/testing/baselines/TestInteractionCheatsheetConfigFile.png
+++ b/testing/baselines/TestInteractionCheatsheetConfigFile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e98d82eaba786e8f2319773e1a61e397f9c098d9b83db9166015b745c06c901
-size 250941
+oid sha256:bf1233d87068fd9e99ce57ee288ba5e5983e9b3e0cc9a1658187a8162a64dad8
+size 251199

--- a/testing/baselines/TestInteractionCheatsheetConfigFileRaytracing.png
+++ b/testing/baselines/TestInteractionCheatsheetConfigFileRaytracing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23c99f0437fec79df9b974333d5406210dcb7dfa86dcdac1c1ece8320d7dc141
-size 258096
+oid sha256:2c6f2c96dbeffaf9ef0eb20eefb1270159e74504792b6b45848a3995ff637401
+size 258457

--- a/testing/baselines/TestInteractionCheatsheetNoFile.png
+++ b/testing/baselines/TestInteractionCheatsheetNoFile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c955b6de4772273d74cf18c354f718647dc5abc535ce475658b0ed609d9f5345
-size 43215
+oid sha256:7f0b98792f9e8c7392a5896de14ac913e47a03e5b6fb7a00043a26ed9a5f7a7b
+size 43078

--- a/testing/baselines/TestInteractionCheatsheetNoFileRaytracing.png
+++ b/testing/baselines/TestInteractionCheatsheetNoFileRaytracing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07a13fcee16ec671ad1aa635481075998ddf01c9f5cb0f71882cf182fecb77ba
-size 42879
+oid sha256:7e42391f5393daf716d580ee5d20b7721f40afa128543d644f7c0b5e308c6c3e
+size 42724

--- a/testing/baselines/TestInteractionCheatsheetRaytracing.png
+++ b/testing/baselines/TestInteractionCheatsheetRaytracing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb045beb279ca423e0a07bfca792442abb5eb42c3f36d34ece32b5a11ec47e7c
-size 49477
+oid sha256:0ec9f042f9cb1fdacc66e3dfcccd7d5e33072c03eac2b109f3dec4db0557cc02
+size 49524

--- a/testing/baselines/TestInteractionCheatsheetScalars.png
+++ b/testing/baselines/TestInteractionCheatsheetScalars.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:abae307cea2861da07743ae80ba3602540291a0195dff20d1195509a594ad675
-size 260243
+oid sha256:b2319a82a3b0df2708b411eb9a6f12a4580babb8d165c634eedd7f2cef62acc3
+size 261001

--- a/testing/baselines/TestInteractionCheatsheetScalarsRaytracing.png
+++ b/testing/baselines/TestInteractionCheatsheetScalarsRaytracing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82629e10f66718c237e1698af318c9a4e3cc4a2bb2f40e46f82dff62a46824cb
-size 263211
+oid sha256:2f28e6269a9aba7584a4595b045dc1015eb4e121e38415dd5cbfc00db68be15f
+size 263588

--- a/testing/baselines/TestInteractionCheatsheetWhiteBG.png
+++ b/testing/baselines/TestInteractionCheatsheetWhiteBG.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e80bfba509b32620cdadb013383218903bfa23afa87d6a05e65641ec00fafbbb
-size 46741
+oid sha256:8a7095c03adc16d6586b456a16d03ce4b01c1972599e8fb3520abfd6d1d3febd
+size 46905

--- a/testing/baselines/TestInteractionCheatsheetWhiteBGRaytracing.png
+++ b/testing/baselines/TestInteractionCheatsheetWhiteBGRaytracing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e80bfba509b32620cdadb013383218903bfa23afa87d6a05e65641ec00fafbbb
-size 46741
+oid sha256:ec6f4e181fbc7a03a058bb800ff1de63634445fdd92bd7f341afc5339ad6cac1
+size 46602


### PR DESCRIPTION
std::optional variables are currently displayed as "N/A" on the cheatsheet. This is misleading, so it is being changed to "Unset."
Note: not all of the baselines have been updated, I need to retrieve some from the CI