### PR TITLE
OBJ: Remove obj.inl logic that is not required since VTK v9.1.0

### DIFF
--- a/plugins/native/obj.inl
+++ b/plugins/native/obj.inl
@@ -4,18 +4,4 @@ void applyCustomImporter(vtkImporter* importer, const std::string& fileName) con
 
   std::string path = vtksys::SystemTools::GetFilenamePath(fileName);
   objImporter->SetTexturePath(path.c_str());
-
-  std::string mtlFile = fileName + ".mtl";
-  if (vtksys::SystemTools::FileExists(mtlFile))
-  {
-    objImporter->SetFileNameMTL(mtlFile.c_str());
-  }
-  else
-  {
-    mtlFile = path + "/" + vtksys::SystemTools::GetFilenameWithoutLastExtension(fileName) + ".mtl";
-    if (vtksys::SystemTools::FileExists(mtlFile))
-    {
-      objImporter->SetFileNameMTL(mtlFile.c_str());
-    }
-  }
 }


### PR DESCRIPTION
Available in VTK 7a6553839d1, which is present in VTK v9.0.1