### PR TITLE
F3D: Fix a small issue with imperative options

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -831,6 +831,7 @@ f3d_test(NAME TestInteractionConfigFileBindings DATA dragon.vtu CONFIG ${F3D_SOU
 f3d_test(NAME TestInteractionConfigFileMulti DATA multi CONFIG ${F3D_SOURCE_DIR}/testing/configs/complex.json INTERACTION UI) #SY;Right;XG;Right;N;Right;Right
 f3d_test(NAME TestInteractionConfigFileAndCommand DATA multi ARGS -o CONFIG ${F3D_SOURCE_DIR}/testing/configs/complex.json INTERACTION UI) #OX;Right;N;Right;Right;Right
 f3d_test(NAME TestInteractionConfigFileImperative DATA dragon.vtu suzanne.stl ARGS --edges CONFIG ${F3D_SOURCE_DIR}/testing/configs/imperative.json INTERACTION) #E;Right
+f3d_test(NAME TestInteractionConfigFileImperativeNoData CONFIG ${F3D_SOURCE_DIR}/testing/configs/imperative.json INTERACTION NO_DATA_FORCE_RENDER) #X;Up
 f3d_test(NAME TestInteractionCycleVerbose DATA dragon.vtu ARGS --verbose -s NO_BASELINE INTERACTION REGEXP "Not coloring")#SSSSYC
 f3d_test(NAME TestInteractionEmptyDrop INTERACTION REGEXP "Drop event without any provided files.")#DropEvent Empty;
 f3d_test(NAME TestInteractionCameraUpdate DATA dragon.vtu INTERACTION) #MouseWheel;MouseWheel;MouseWheel;S

--- a/testing/baselines/TestInteractionConfigFileImperativeNoData.png
+++ b/testing/baselines/TestInteractionConfigFileImperativeNoData.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af4a555eefb2ebe5fefa0ed9f7d840f8dda905d9916736dcf8e0d49338e4b2e1
+size 7057

--- a/testing/recordings/TestInteractionConfigFileImperativeNoData.log
+++ b/testing/recordings/TestInteractionConfigFileImperativeNoData.log
@@ -1,0 +1,19 @@
+# StreamVersion 1.2
+ConfigureEvent 960 1033 0 0 0 0 0
+ExposeEvent 0 1055 0 0 0 0 0
+RenderEvent 0 1055 0 0 0 0 0
+TimerEvent 0 1055 0 0 0 0 0
+TimerEvent 0 1055 0 0 0 0 0
+EnterEvent 581 217 0 0 0 0 0
+TimerEvent 581 217 0 0 0 0 0
+TimerEvent 581 217 0 0 0 0 0
+KeyPressEvent 581 217 0 101 1 x 0
+CharEvent 581 217 0 101 1 x 0
+TimerEvent 581 217 0 101 1 x 0
+KeyReleaseEvent 581 217 0 101 1 x 0
+TimerEvent 581 217 0 101 1 x 0
+TimerEvent 581 217 0 101 1 x 0
+KeyPressEvent 581 217 0 0 1 Up 0
+CharEvent 581 217 0 0 1 Up 0
+TimerEvent 581 217 0 0 1 Up 0
+KeyReleaseEvent 581 217 0 0 1 Up 0


### PR DESCRIPTION
- Fix an issue with imperative options not taken into account when loading no data
- Improve logging logic of options, logging them only once
- Rework `remove_file_groups` to rely on LoadFileGroup
- Add testing for the bugfix