### PR TITLE
assimp: Record imported actors from internals

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -650,7 +650,7 @@ if(F3D_PLUGIN_BUILD_ASSIMP)
   endif()
 
   if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20240707)
-    f3d_test(NAME TestAssimpMetaData DATA 16bit.fbx ARGS --verbose --load-plugins=assimp REGEXP "Number of actors: 1" NO_BASELINE)
+    f3d_test(NAME TestAssimpMetaData DATA duck.fbx ARGS --verbose --load-plugins=assimp REGEXP "Number of points: 12636" NO_BASELINE)
   endif()
 
 endif()

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -649,6 +649,10 @@ if(F3D_PLUGIN_BUILD_ASSIMP)
     f3d_test(NAME TestThumbnailConfigFileAssimpDAE DATA duck.dae CONFIG thumbnail_build LONG_TIMEOUT TONE_MAPPING)
   endif()
 
+  if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20240707)
+    f3d_test(NAME TestAssimpMetaData DATA 16bit.fbx ARGS --verbose --load-plugins=assimp REGEXP "Number of actors: 1" NO_BASELINE)
+  endif()
+
 endif()
 
 if(F3D_PLUGIN_BUILD_DRACO)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -649,7 +649,11 @@ if(F3D_PLUGIN_BUILD_ASSIMP)
     f3d_test(NAME TestThumbnailConfigFileAssimpDAE DATA duck.dae CONFIG thumbnail_build LONG_TIMEOUT TONE_MAPPING)
   endif()
 
-f3d_test(NAME TestAssimpVerbose DATA duck.fbx ARGS --verbose --load-plugins=assimp REGEXP "Number of points: 12636" NO_BASELINE)
+  f3d_test(NAME TestAssimpVerbose DATA duck.fbx ARGS --verbose --load-plugins=assimp REGEXP "Number of points: 12636" NO_BASELINE)
+
+  if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20240707)
+    f3d_test(NAME TestAssimpMetaDataImporter DATA duck.fbx ARGS -m UI)
+  endif()
 
 endif()
 

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -652,7 +652,7 @@ if(F3D_PLUGIN_BUILD_ASSIMP)
   f3d_test(NAME TestAssimpVerbose DATA duck.fbx ARGS --verbose --load-plugins=assimp REGEXP "Number of points: 12636" NO_BASELINE)
 
   if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20240707)
-    f3d_test(NAME TestAssimpMetaDataImporter DATA duck.fbx ARGS -m UI)
+    f3d_test(NAME TestAssimpMetaDataImporter DATA duck.fbx ARGS --load-plugins=assimp -m UI)
   endif()
 
 endif()

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -649,9 +649,7 @@ if(F3D_PLUGIN_BUILD_ASSIMP)
     f3d_test(NAME TestThumbnailConfigFileAssimpDAE DATA duck.dae CONFIG thumbnail_build LONG_TIMEOUT TONE_MAPPING)
   endif()
 
-  if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20240707)
-    f3d_test(NAME TestAssimpMetaData DATA duck.fbx ARGS --verbose --load-plugins=assimp REGEXP "Number of points: 12636" NO_BASELINE)
-  endif()
+f3d_test(NAME TestAssimpVerbose DATA duck.fbx ARGS --verbose --load-plugins=assimp REGEXP "Number of points: 12636" NO_BASELINE)
 
 endif()
 

--- a/plugins/assimp/module/vtkF3DAssimpImporter.cxx
+++ b/plugins/assimp/module/vtkF3DAssimpImporter.cxx
@@ -899,6 +899,7 @@ int vtkF3DAssimpImporter::ImportBegin()
 void vtkF3DAssimpImporter::ImportActors(vtkRenderer* renderer)
 {
   this->Internals->ImportRoot(renderer);
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 20240707)
   // Record all actors imported from internals to importer itself
   for (auto& pair : this->Internals->NodeActors)
   {
@@ -909,6 +910,7 @@ void vtkF3DAssimpImporter::ImportActors(vtkRenderer* renderer)
       this->ActorCollection->AddItem(actor);
     }
   }
+#endif
 }
 
 //----------------------------------------------------------------------------

--- a/plugins/assimp/module/vtkF3DAssimpImporter.cxx
+++ b/plugins/assimp/module/vtkF3DAssimpImporter.cxx
@@ -673,6 +673,9 @@ public:
 
     vtkNew<vtkActorCollection> actors;
 
+    vtkIdType nPoints = 0;
+    vtkIdType nCells = 0;
+
     for (unsigned int i = 0; i < node->mNumMeshes; i++)
     {
       vtkNew<vtkActor> actor;
@@ -684,6 +687,10 @@ public:
       actor->SetUserMatrix(mat);
       actor->SetProperty(this->Properties[this->Scene->mMeshes[node->mMeshes[i]]->mMaterialIndex]);
 
+      vtkPolyData* surface = vtkPolyDataMapper::SafeDownCast(actor->GetMapper())->GetInput();
+      nPoints += surface->GetNumberOfPoints();
+      nCells += surface->GetNumberOfCells();
+
       renderer->AddActor(actor);
       actors->AddItem(actor);
     }
@@ -694,6 +701,16 @@ public:
     }
     this->Description += node->mName.C_Str();
     this->Description += "\n";
+
+    if ((nPoints > 0) || (nCells > 0))
+    {
+      this->Description += "Number of points: ";
+      this->Description += std::to_string(nPoints);
+      this->Description += "\n";
+      this->Description += "Number of cells: ";
+      this->Description += std::to_string(nCells);
+      this->Description += "\n";
+    }
 
     this->NodeActors.insert({ node->mName.data, actors });
     this->NodeLocalMatrix.insert({ node->mName.data, localMat });

--- a/plugins/assimp/module/vtkF3DAssimpImporter.cxx
+++ b/plugins/assimp/module/vtkF3DAssimpImporter.cxx
@@ -899,6 +899,16 @@ int vtkF3DAssimpImporter::ImportBegin()
 void vtkF3DAssimpImporter::ImportActors(vtkRenderer* renderer)
 {
   this->Internals->ImportRoot(renderer);
+  // Record all actors imported from internals to importer itself
+  for (auto& pair : this->Internals->NodeActors)
+  {
+    vtkCollectionSimpleIterator ait;
+    pair.second->InitTraversal(ait);
+    while (auto* actor = pair.second->GetNextActor(ait))
+    {
+      this->ActorCollection->AddItem(actor);
+    }
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/testing/baselines/TestAssimpMetaDataImporter.png
+++ b/testing/baselines/TestAssimpMetaDataImporter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2869afa8d6561c43833986fafc0faf469fcf145155942b5c1d9b6c83756e4966
+size 31989


### PR DESCRIPTION
Importer itself did't have actor stored which prevented metadata retrieval for display

Issues with missing metadata was reported in https://github.com/f3d-app/f3d/issues/1945