### PR TITLE
Fix typo: 'warps' -> 'wraps' in architecture doc

### DIFF
--- a/doc/dev/ARCHITECTURE.md
+++ b/doc/dev/ARCHITECTURE.md
@@ -29,7 +29,7 @@ Here is diagram explaining how some of these parts interact together:
            │
            │                                   ┌──────────┐
            │                                   │          │
-       depends on                     ┌─warps──│  python  │
+       depends on                     ┌─wraps──│  python  │
            │                          │        │          │
            │                          │        └──────────┘
            │         ┌───────────┐    │        ┌──────────┐


### PR DESCRIPTION
This PR fixes a small typo in the architecture documentation: "warps" -> "wraps".

