### PR TITLE
Fix: Add validation for invalid "reset-" option keys in config files

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -505,13 +505,7 @@ public:
                 }
                 else
                 {
-                  static bool alreaedyWarned = false;
-                  if (!alreaedyWarned)
-                  {
-                    f3d::log::warn("Invalid option: 'reset-' must be followed by a valid option "
-                                   "name, ignoring entry");
-                    alreaedyWarned = true;
-                  }
+                  f3d::log::warn("Invalid option: 'reset-' must be followed by a valid option name, ignoring entry");
                   continue;
                 }
               }

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -505,7 +505,7 @@ public:
                 }
                 else
                 {
-                  f3d::log::warn("Invalid option: 'reset-' must be followed by a valid option "
+                  f3d::log::warn("Invalid option: 'reset' must be followed by a valid option "
                                  "name, ignoring entry");
                   continue;
                 }

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -496,10 +496,24 @@ public:
               // XXX: Use starts_with once C++20 is supported
               if (libf3dOptionName.rfind("reset-", 0) == 0)
               {
-                reset = true;
-                libf3dOptionName = libf3dOptionName.substr(6);
-                keyForLog = libf3dOptionName;
-                libf3dOptionValue = "reset";
+                if (libf3dOptionName.size() > 6) 
+                {
+                  reset = true;
+                  libf3dOptionName = libf3dOptionName.substr(6);
+                  keyForLog = libf3dOptionName;
+                  libf3dOptionValue = "reset";
+                }
+                else
+                {
+                  static bool alreaedyWarned = false;
+                  if (!alreaedyWarned)
+                  {
+                    f3d::log::warn(
+                        "Invalid option: 'reset-' must be followed by a valid option name, ignoring entry");
+                    alreaedyWarned = true;
+                  }
+                  continue;
+                }
               }
 
               // Handle reader options

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -505,7 +505,8 @@ public:
                 }
                 else
                 {
-                  f3d::log::warn("Invalid option: 'reset-' must be followed by a valid option name, ignoring entry");
+                  f3d::log::warn("Invalid option: 'reset-' must be followed by a valid option "
+                                 "name, ignoring entry");
                   continue;
                 }
               }

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -508,8 +508,8 @@ public:
                   static bool alreaedyWarned = false;
                   if (!alreaedyWarned)
                   {
-                    f3d::log::warn(
-                        "Invalid option: 'reset-' must be followed by a valid option name, ignoring entry");
+                    f3d::log::warn("Invalid option: 'reset-' must be followed by a valid option "
+                                   "name, ignoring entry");
                     alreaedyWarned = true;
                   }
                   continue;

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -496,7 +496,7 @@ public:
               // XXX: Use starts_with once C++20 is supported
               if (libf3dOptionName.rfind("reset-", 0) == 0)
               {
-                if (libf3dOptionName.size() > 6) 
+                if (libf3dOptionName.size() > 6)
                 {
                   reset = true;
                   libf3dOptionName = libf3dOptionName.substr(6);

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -1098,7 +1098,7 @@ f3d_test(NAME TestNonExistentConfigFileStem DATA cow.vtp CONFIG "dummy" REGEXP "
 f3d_test(NAME TestInvalidConfigFile DATA cow.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/invalid.json REGEXP "Unable to parse the configuration file" NO_BASELINE)
 
 # Test invalid reset key in config file
-f3d_test(NAME TestInvalidResetOptions DATA cow.vtp ARGS `--reset-` REGEXP "Invalid option: 'reset-' must be followed by a valid option name, ignoring entry" NO_BASELINE)
+f3d_test(NAME TestInvalidResetOptions DATA cow.vtp ARGS `--reset=` REGEXP "Invalid option: 'reset' must be followed by a valid option name, ignoring entry" NO_BASELINE)
 
 # Test invalid multifile mode
 f3d_test(NAME TestInvalidMultiFileMode DATA mb/recursive ARGS --multi-file-mode=add REGEXP "Unrecognized multi-file-mode: add. Assuming \"single\" mode." NO_BASELINE)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -1100,7 +1100,6 @@ f3d_test(NAME TestInvalidConfigFile DATA cow.vtp CONFIG ${F3D_SOURCE_DIR}/testin
 # Test invalid reset key in config file
 f3d_test(NAME TestInvalidResetKey DATA cow.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/invalid_reset.json REGEXP "Invalid option: 'reset-' must be followed by a valid option name, ignoring entry" NO_BASELINE)
 
-
 # Test invalid multifile mode
 f3d_test(NAME TestInvalidMultiFileMode DATA mb/recursive ARGS --multi-file-mode=add REGEXP "Unrecognized multi-file-mode: add. Assuming \"single\" mode." NO_BASELINE)
 

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -1097,6 +1097,10 @@ f3d_test(NAME TestNonExistentConfigFileStem DATA cow.vtp CONFIG "dummy" REGEXP "
 # Test invalid config file
 f3d_test(NAME TestInvalidConfigFile DATA cow.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/invalid.json REGEXP "Unable to parse the configuration file" NO_BASELINE)
 
+# Test invalid reset key in config file
+f3d_test(NAME TestInvalidResetKey DATA cow.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/invalid_reset.json REGEXP "Invalid option: 'reset-' must be followed by a valid option name, ignoring entry" NO_BASELINE)
+
+
 # Test invalid multifile mode
 f3d_test(NAME TestInvalidMultiFileMode DATA mb/recursive ARGS --multi-file-mode=add REGEXP "Unrecognized multi-file-mode: add. Assuming \"single\" mode." NO_BASELINE)
 

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -1098,7 +1098,7 @@ f3d_test(NAME TestNonExistentConfigFileStem DATA cow.vtp CONFIG "dummy" REGEXP "
 f3d_test(NAME TestInvalidConfigFile DATA cow.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/invalid.json REGEXP "Unable to parse the configuration file" NO_BASELINE)
 
 # Test invalid reset key in config file
-f3d_test(NAME TestInvalidResetOptions DATA cow.vtp ARGS `--reset=` REGEXP "Invalid option: 'reset' must be followed by a valid option name, ignoring entry" NO_BASELINE)
+f3d_test(NAME TestInvalidResetOptions DATA cow.vtp ARGS --reset= REGEXP "Invalid option: 'reset' must be followed by a valid option name, ignoring entry" NO_BASELINE)
 
 # Test invalid multifile mode
 f3d_test(NAME TestInvalidMultiFileMode DATA mb/recursive ARGS --multi-file-mode=add REGEXP "Unrecognized multi-file-mode: add. Assuming \"single\" mode." NO_BASELINE)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -1098,7 +1098,7 @@ f3d_test(NAME TestNonExistentConfigFileStem DATA cow.vtp CONFIG "dummy" REGEXP "
 f3d_test(NAME TestInvalidConfigFile DATA cow.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/invalid.json REGEXP "Unable to parse the configuration file" NO_BASELINE)
 
 # Test invalid reset key in config file
-f3d_test(NAME TestInvalidResetKey DATA cow.vtp CONFIG ${F3D_SOURCE_DIR}/testing/configs/invalid_reset.json REGEXP "Invalid option: 'reset-' must be followed by a valid option name, ignoring entry" NO_BASELINE)
+f3d_test(NAME TestInvalidResetOptions DATA cow.vtp ARGS `--reset-` REGEXP "Invalid option: 'reset-' must be followed by a valid option name, ignoring entry" NO_BASELINE)
 
 # Test invalid multifile mode
 f3d_test(NAME TestInvalidMultiFileMode DATA mb/recursive ARGS --multi-file-mode=add REGEXP "Unrecognized multi-file-mode: add. Assuming \"single\" mode." NO_BASELINE)

--- a/testing/configs/invalid_reset.json
+++ b/testing/configs/invalid_reset.json
@@ -1,0 +1,7 @@
+[
+  {
+    "options": {
+      "reset-": true
+    }
+  }
+]

--- a/testing/configs/invalid_reset.json
+++ b/testing/configs/invalid_reset.json
@@ -1,7 +1,0 @@
-[
-  {
-    "options": {
-      "reset-": true
-    }
-  }
-]


### PR DESCRIPTION
### Summary

This PR improves the handling of invalid config entries like `"reset-"` with no option name.
Such entries previously resulted in confusing logs like:

`'' option ... does not exists , did you mean 'up'?`

Now, a clear and informative warning is logged, and the entry is safely skipped:

`Invalid option: 'reset-' must be followed by a valid option name, ignoring entry`

### Changes

- Added a simple validation to detect invalid `reset-` keys
- Logs a clear warning message only once, even if config is applied multiple times

### Why

Better UX for users writing config files and prevents misleading log messages.

### Checklist

- [x] PR from fork
- [x] Feature branch created
- [x] CI passed
- [x] Coverage added
