### PR TITLE
Fix a small issue with color formating

### DIFF
--- a/library/private/options_tools.h
+++ b/library/private/options_tools.h
@@ -518,10 +518,10 @@ std::string format(color_t var)
         }))
   {
     std::ostringstream stream;
-    stream << "#" << std::hex                     //
-           << static_cast<int>(colors[0] * 255.)  //
-           << static_cast<int>(colors[1] * 255.)  //
-           << static_cast<int>(colors[2] * 255.); //
+    stream << "#" << std::hex << std::setfill('0') << std::setw(2)
+           << static_cast<int>(colors[0] * 255.) << std::setw(2)
+           << static_cast<int>(colors[1] * 255.) << std::setw(2)
+           << static_cast<int>(colors[2] * 255.);
     return stream.str();
   }
   else

--- a/library/testing/TestSDKOptionsIO.cxx
+++ b/library/testing/TestSDKOptionsIO.cxx
@@ -146,6 +146,8 @@ int TestSDKOptionsIO(int argc, char* argv[])
   test.parse_expect<f3d::color_t, parsing_exception>("invalid color_t", "cmyk(200%,12%,34%,56%)");
   test.parse_expect<f3d::color_t, parsing_exception>("incorrect size color_t", "0.1,0.2,0.3,0.4");
   test.format<f3d::color_t>("color_t", { 0.1, 0.2, 0.3 }, "0.1,0.2,0.3");
+  test.format<f3d::color_t>("color_t", { 0, 0, 0 }, "#000000");
+  test.format<f3d::color_t>("color_t", { 1, 0, 1 }, "#ff00ff");
   test.format<f3d::color_t>("color_t",
     { static_cast<double>(171. / 255.), static_cast<double>(205. / 255.),
       static_cast<double>(239. / 255.) },


### PR DESCRIPTION
Fix a small issue with color_t padding formating. Ensure it always uses a width of 2. Add testing.