### PR TITLE
Fix JSON key quotes in CONFIGURATION_FILE.md

### DIFF
--- a/doc/user/CONFIGURATION_FILE.md
+++ b/doc/user/CONFIGURATION_FILE.md
@@ -20,40 +20,40 @@ A typical config file with options may look like this:
 ```javascript
 [
   {
-    options: {
+    "options": {
       "background-color": "0.7,0.7,0.7",
-      color: "0.5,0.1,0.1",
+      "color": "0.5,0.1,0.1",
       "anti-aliasing": true,
-      timer: true,
-      progress: true,
-      axis: true,
-      bar: true,
-      roughness: 0.2,
-      grid: true,
-      "scalar-coloring": true,
-    },
+      "timer": true,
+      "progress": true,
+      "axis": true,
+      "bar": true,
+      "roughness": 0.2,
+      "grid": true,
+      "scalar-coloring": true
+    }
   },
   {
-    match: ".*vt.",
-    options: {
-      edges: true,
-    },
+    "match": ".*vt.",
+    "options": {
+      "edges": true
+    }
   },
   {
-    match: ".*gl(tf|b)",
-    options: {
-      raytracing: true,
-      denoise: true,
-      samples: 3,
-    },
+    "match": ".*gl(tf|b)",
+    "options": {
+      "raytracing": true,
+      "denoise": true,
+      "samples": 3
+    }
   },
   {
-    match: ".*mhd",
-    options: {
-      volume: true,
-    },
-  },
-];
+    "match": ".*mhd",
+    "options": {
+      "volume": true
+    }
+  }
+]
 ```
 
 Here, the first block defines a basic configuration with many desired options for all files.
@@ -104,25 +104,25 @@ A typical config file with bindings may look like this:
 ```javascript
 [
   {
-    bindings: {
+    "bindings": {
       "Ctrl+Shift+O": "toggle ui.filename",
       "Any+3": "roll_camera -90",
-      O: "set_camera isometric",
-    },
+      "O": "set_camera isometric"
+    }
   },
   {
-    match: ".*vtu",
-    bindings: {
+    "match": ".*vtu",
+    "bindings": {
       "Any+3": "roll_camera 90",
       "Shift+O": "toggle model.point_sprites.enable",
       "Ctrl+O": [
         "toggle render.grid.enable",
-        "toggle scene.camera.orthographic",
+        "toggle scene.camera.orthographic"
       ],
-      "None+I": "toggle ui.axis",
-    },
-  },
-];
+      "None+I": "toggle ui.axis"
+    }
+  }
+]
 ```
 
 Here, the first block define new bindings for all and any files.

--- a/doc/user/CONFIGURATION_FILE.md
+++ b/doc/user/CONFIGURATION_FILE.md
@@ -17,7 +17,7 @@ when switching between files.
 
 A typical config file with options may look like this:
 
-```javascript
+```json
 [
   {
     "options": {
@@ -75,7 +75,7 @@ off on the command line if needed, eg: `--point-sprites=false`.
 Command line options and options that are changed interactively overrides options that are set in configuration files.
 This is not always a desired behavior, so in order to force an option to always be taken into account even if set in command line or changed interactively, it is possible to use imperative options, by adding a `!` in front of the option name, eg:
 
-```
+```json
 [
   {
     "options": {
@@ -101,7 +101,7 @@ A `bindings` block can be added to specify associations between binds (eg : `Ctr
 
 A typical config file with bindings may look like this:
 
-```javascript
+```json
 [
   {
     "bindings": {


### PR DESCRIPTION
### Description

This PR updates the JSON examples in `doc/user/CONFIGURATION_FILE.md` to use double quotes around all keys, as required by the official JSON specification (RFC 8259).

Prettier does not modify JSON in Markdown files properly.
All examples were validated using [jsonlint.com](https://jsonlint.com/) to ensure correctness.

### Checklist

- [x] Verified that similar issues do not occur in other documentation files.
- [x] This change affects documentation only.

resolves #2087
