### PR TITLE
Addition of --axesGrid option

### DIFF
--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -26,10 +26,10 @@ runs:
 
     - name: Cache VTK
       id: cache-vtk
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: dependencies/vtk_install
-        key: vtk-${{ inputs.vtk_version }}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-2
+        key: vtk-${{ inputs.vtk_version }}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-1
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -29,7 +29,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: dependencies/vtk_install
-        key: vtk-${{ inputs.vtk_version }}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-1
+        key: vtk-${{ inputs.vtk_version }}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-2
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'
@@ -104,6 +104,7 @@ runs:
         -DVTK_MODULE_ENABLE_VTK_InteractionWidgets=YES
         -DVTK_MODULE_ENABLE_VTK_RenderingAnnotation=YES
         -DVTK_MODULE_ENABLE_VTK_RenderingCore=YES
+        -DVTK_MODULE_ENABLE_VTK_RenderingGridAxes=YES
         -DVTK_MODULE_ENABLE_VTK_RenderingOpenGL2=YES
         -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing=${{ inputs.raytracing_label == 'raytracing' && 'YES' || 'DEFAULT' }}
         -DVTK_MODULE_ENABLE_VTK_RenderingVolumeOpenGL2=YES

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -26,10 +26,10 @@ runs:
 
     - name: Cache VTK
       id: cache-vtk
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v4
       with:
         path: dependencies/vtk_install
-        key: vtk-${{ inputs.vtk_version }}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-1
+        key: vtk-${{ inputs.vtk_version }}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-2
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -42,7 +42,6 @@ runs:
       with:
         path: dependencies/vtk_install
         key: vtk-${{ inputs.vtk_version }}-${{inputs.zlib_version}}-${{inputs.blosc_version}}-${{inputs.tbb_version}}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.cpu}}-2
-        
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'
       working-directory: ${{github.workspace}}/dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ endif ()
 # VTK dependency
 # Optional components should list VTK modules
 # needed by plugins and optional modules
-find_package(VTK 9.5.0 REQUIRED
+find_package(VTK 9.2.6 REQUIRED
   COMPONENTS
     CommonCore
     CommonDataModel
@@ -101,7 +101,6 @@ find_package(VTK 9.5.0 REQUIRED
     IOXML
     RenderingAnnotation
     RenderingCore
-    RenderingGridAxes
     RenderingOpenGL2
     RenderingVolumeOpenGL2
     TestingCore
@@ -112,6 +111,7 @@ find_package(VTK 9.5.0 REQUIRED
     IOHDF
     IONetCDF
     IOOpenVDB
+    RenderingGridAxes
     RenderingRayTracing)
 message(STATUS "VTK ${VTK_VERSION} found")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ endif ()
 # VTK dependency
 # Optional components should list VTK modules
 # needed by plugins and optional modules
-find_package(VTK 9.2.6 REQUIRED
+find_package(VTK 9.5.0 REQUIRED
   COMPONENTS
     CommonCore
     CommonDataModel
@@ -101,6 +101,7 @@ find_package(VTK 9.2.6 REQUIRED
     IOXML
     RenderingAnnotation
     RenderingCore
+    RenderingGridAxes
     RenderingOpenGL2
     RenderingVolumeOpenGL2
     TestingCore

--- a/application/F3DOptionsTools.cxx
+++ b/application/F3DOptionsTools.cxx
@@ -91,7 +91,7 @@ static inline const std::array<CLIGroup, 8> CLIOptions = {{
       { "grid-unit", "", "Size of grid unit square, automatically computed by default", "<value>", "" },
       { "grid-subdivisions", "", "Number of grid subdivisions", "<value>", "" },
       { "grid-color", "", "Color of main grid lines", "<color>", "" },
-      { "axesGrid", "", "Enable grid axis", "<bool>", "1" },
+      { "axes-grid", "", "Enable grid axis", "<bool>", "1" },
       { "edges", "e", "Show cell edges", "<bool>", "1" },
       { "armature", "", "Enable armature visualization", "<bool>", "1" },
       { "camera-index", "", "Select the camera to use", "<index>", "" },

--- a/application/F3DOptionsTools.cxx
+++ b/application/F3DOptionsTools.cxx
@@ -91,6 +91,7 @@ static inline const std::array<CLIGroup, 8> CLIOptions = {{
       { "grid-unit", "", "Size of grid unit square, automatically computed by default", "<value>", "" },
       { "grid-subdivisions", "", "Number of grid subdivisions", "<value>", "" },
       { "grid-color", "", "Color of main grid lines", "<color>", "" },
+      { "axesGrid", "", "Enable grid axis", "<bool>", "1" },
       { "edges", "e", "Show cell edges", "<bool>", "1" },
       { "armature", "", "Enable armature visualization", "<bool>", "1" },
       { "camera-index", "", "Select the camera to use", "<index>", "" },

--- a/application/F3DOptionsTools.h
+++ b/application/F3DOptionsTools.h
@@ -72,6 +72,7 @@ static inline const std::map<std::string_view, std::string_view> LibOptionsNames
   { "grid-unit", "render.grid.unit" },
   { "grid-subdivisions", "render.grid.subdivisions" },
   { "grid-color", "render.grid.color" },
+  { "axesGrid", "render.cubeAxis.enable" },
   { "edges", "render.show_edges" },
   { "armature", "render.armature.enable" },
   { "camera-index", "scene.camera.index" },

--- a/application/F3DOptionsTools.h
+++ b/application/F3DOptionsTools.h
@@ -72,7 +72,7 @@ static inline const std::map<std::string_view, std::string_view> LibOptionsNames
   { "grid-unit", "render.grid.unit" },
   { "grid-subdivisions", "render.grid.subdivisions" },
   { "grid-color", "render.grid.color" },
-  { "axesGrid", "render.cubeAxis.enable" },
+  { "axes-grid", "render.axes_grid.enable" },
   { "edges", "render.show_edges" },
   { "armature", "render.armature.enable" },
   { "camera-index", "scene.camera.index" },

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -188,6 +188,7 @@ f3d_test(NAME TestGridAbsolute DATA f3d.vtp ARGS -g --up=-Y --camera-direction=-
 f3d_test(NAME TestGridClipping DATA offset-flat-box.glb ARGS -g --grid-absolute --camera-position=70,120,350)
 f3d_test(NAME TestGridColor DATA suzanne.ply ARGS -g --grid-color=1,1,1)
 f3d_test(NAME TestAxis DATA suzanne.ply ARGS -x)
+f3d_test(NAME TestAxesGridEnable DATA suzanne.ply ARGS --axesGrid)
 f3d_test(NAME TestBackfaceVisible DATA backface.vtp ARGS --backface-type=visible)
 f3d_test(NAME TestBackfaceHidden DATA backface.vtp ARGS --backface-type=hidden)
 f3d_test(NAME TestPointCloud DATA pointsCloud.vtp ARGS -o --point-sprites-size=20)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -188,7 +188,7 @@ f3d_test(NAME TestGridAbsolute DATA f3d.vtp ARGS -g --up=-Y --camera-direction=-
 f3d_test(NAME TestGridClipping DATA offset-flat-box.glb ARGS -g --grid-absolute --camera-position=70,120,350)
 f3d_test(NAME TestGridColor DATA suzanne.ply ARGS -g --grid-color=1,1,1)
 f3d_test(NAME TestAxis DATA suzanne.ply ARGS -x)
-f3d_test(NAME TestAxesGridEnable DATA suzanne.ply ARGS --axesGrid)
+f3d_test(NAME TestAxesGridEnable DATA suzanne.ply ARGS --axes-grid)
 f3d_test(NAME TestBackfaceVisible DATA backface.vtp ARGS --backface-type=visible)
 f3d_test(NAME TestBackfaceHidden DATA backface.vtp ARGS --backface-type=hidden)
 f3d_test(NAME TestPointCloud DATA pointsCloud.vtp ARGS -o --point-sprites-size=20)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -188,7 +188,10 @@ f3d_test(NAME TestGridAbsolute DATA f3d.vtp ARGS -g --up=-Y --camera-direction=-
 f3d_test(NAME TestGridClipping DATA offset-flat-box.glb ARGS -g --grid-absolute --camera-position=70,120,350)
 f3d_test(NAME TestGridColor DATA suzanne.ply ARGS -g --grid-color=1,1,1)
 f3d_test(NAME TestAxis DATA suzanne.ply ARGS -x)
-f3d_test(NAME TestAxesGridEnable DATA suzanne.ply ARGS --axes-grid)
+# Needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/11209
+if(VTK_VERSION VERSION_GREATER_EQUAL 9.4.20250513)
+  f3d_test(NAME TestAxesGridEnable DATA suzanne.ply ARGS --axes-grid)
+endif()
 f3d_test(NAME TestBackfaceVisible DATA backface.vtp ARGS --backface-type=visible)
 f3d_test(NAME TestBackfaceHidden DATA backface.vtp ARGS --backface-type=hidden)
 f3d_test(NAME TestPointCloud DATA pointsCloud.vtp ARGS -o --point-sprites-size=20)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -190,7 +190,7 @@ f3d_test(NAME TestGridColor DATA suzanne.ply ARGS -g --grid-color=1,1,1)
 f3d_test(NAME TestAxis DATA suzanne.ply ARGS -x)
 # Needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/11209
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.4.20250513)
-  f3d_test(NAME TestAxesGridEnable DATA suzanne.ply ARGS --axes-grid)
+  f3d_test(NAME TestAxesGridEnable DATA suzanne.ply ARGS --axes-grid THRESHOLD 0.08) # Threshold required for MacOS due to line rendering differences
 endif()
 f3d_test(NAME TestBackfaceVisible DATA backface.vtp ARGS --backface-type=visible)
 f3d_test(NAME TestBackfaceHidden DATA backface.vtp ARGS --backface-type=hidden)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -6,6 +6,7 @@ set(F3D_VTK_MODULES
   VTK::CommonColor
   VTK::IOImage
   VTK::InteractionWidgets
+  VTK::RenderingGridAxes
   f3d::vtkext
   f3d::vtkextPrivate
 )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -6,10 +6,13 @@ set(F3D_VTK_MODULES
   VTK::CommonColor
   VTK::IOImage
   VTK::InteractionWidgets
-  VTK::RenderingGridAxes
   f3d::vtkext
   f3d::vtkextPrivate
 )
+
+if(VTK_VERSION VERSION_GREATER_EQUAL 9.4.20250513)
+  set(F3D_VTK_MODULES ${F3D_VTK_MODULES} VTK::RenderingGridAxes)
+endif()
 
 # Check modules
 if(F3D_MODULE_RAYTRACING)

--- a/library/options.json
+++ b/library/options.json
@@ -69,6 +69,12 @@
         "default_value": "0.0, 0.0, 0.0"
       }
     },
+	"cubeAxis": {
+	  "enable": {
+		"type": "bool",
+		"default_value": "false"
+	  }
+	},
     "raytracing": {
       "enable": {
         "type": "bool",

--- a/library/options.json
+++ b/library/options.json
@@ -69,12 +69,12 @@
         "default_value": "0.0, 0.0, 0.0"
       }
     },
-	"axes_grid": {
-	  "enable": {
-		"type": "bool",
-		"default_value": "false"
-	  }
-	},
+    "axes_grid": {
+      "enable": {
+        "type": "bool",
+        "default_value": "false"
+      }
+    },
     "raytracing": {
       "enable": {
         "type": "bool",

--- a/library/options.json
+++ b/library/options.json
@@ -69,7 +69,7 @@
         "default_value": "0.0, 0.0, 0.0"
       }
     },
-	"cubeAxis": {
+	"axes_grid": {
 	  "enable": {
 		"type": "bool",
 		"default_value": "false"

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -472,6 +472,8 @@ void window_impl::UpdateDynamicOptions()
   renderer->ShowGrid(opt.render.grid.enable);
   renderer->SetGridColor(opt.render.grid.color);
 
+  renderer->ShowCubeAxis(opt.render.cubeAxis.enable);
+
   if (!opt.scene.camera.index.has_value())
   {
     renderer->SetUseOrthographicProjection(opt.scene.camera.orthographic);

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -472,7 +472,7 @@ void window_impl::UpdateDynamicOptions()
   renderer->ShowGrid(opt.render.grid.enable);
   renderer->SetGridColor(opt.render.grid.color);
 
-  renderer->ShowCubeAxis(opt.render.cubeAxis.enable);
+  renderer->ShowAxesGrid(opt.render.axes_grid.enable);
 
   if (!opt.scene.camera.index.has_value())
   {

--- a/testing/baselines/TestAxesGridEnable.png
+++ b/testing/baselines/TestAxesGridEnable.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fad79c0f43670cdbfb75ddc8aebc491766fc4b74a626a031d3ac079991f4da85
-size 27991
+oid sha256:5f1cae48af910f0bc0e93713a588b58e3c671fe29e6a50de6ad45afd4b7f764e
+size 29877

--- a/testing/baselines/TestAxesGridEnable.png
+++ b/testing/baselines/TestAxesGridEnable.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f1cae48af910f0bc0e93713a588b58e3c671fe29e6a50de6ad45afd4b7f764e
-size 29877
+oid sha256:f8b287e77525f75008c4c9464aada60e9101e08635aea6fd9ade7f466a3a2f56
+size 30268

--- a/testing/baselines/TestAxesGridEnable.png
+++ b/testing/baselines/TestAxesGridEnable.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5831c1c9a2609fdf74839001f6c0c29de930d69102ff1f701eeb1f12deb459b
-size 26598
+oid sha256:fad79c0f43670cdbfb75ddc8aebc491766fc4b74a626a031d3ac079991f4da85
+size 27991

--- a/testing/baselines/TestAxesGridEnable.png
+++ b/testing/baselines/TestAxesGridEnable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5831c1c9a2609fdf74839001f6c0c29de930d69102ff1f701eeb1f12deb459b
+size 26598

--- a/vtkext/private/module/vtk.module
+++ b/vtkext/private/module/vtk.module
@@ -20,6 +20,7 @@ PRIVATE_DEPENDS
   VTK::IOXML
   VTK::ImagingHybrid
   VTK::InteractionWidgets
+  VTK::RenderingGridAxes
 OPTIONAL_DEPENDS
   VTK::opengl
   VTK::RenderingRayTracing

--- a/vtkext/private/module/vtk.module
+++ b/vtkext/private/module/vtk.module
@@ -20,10 +20,10 @@ PRIVATE_DEPENDS
   VTK::IOXML
   VTK::ImagingHybrid
   VTK::InteractionWidgets
-  VTK::RenderingGridAxes
 OPTIONAL_DEPENDS
   VTK::opengl
   VTK::RenderingRayTracing
+  VTK::RenderingGridAxes
 TEST_DEPENDS
   VTK::IOGeometry
   VTK::IOPLY

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -712,11 +712,11 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRenderer::ShowCubeAxis(bool show)
+void vtkF3DRenderer::ShowAxesGrid(bool show)
 {
-  if (this->CubeAxisVisible != show)
+  if (this->AxesGridVisible != show)
   {
-    this->CubeAxisVisible = show;
+    this->AxesGridVisible = show;
     this->RenderPassesConfigured = false;
     this->CubeAxesConfigured = false;
     this->CheatSheetConfigured = false;
@@ -726,7 +726,7 @@ void vtkF3DRenderer::ShowCubeAxis(bool show)
 //----------------------------------------------------------------------------
 void vtkF3DRenderer::ConfigureCubeAxisUsingCurrentActors()
 {
-  bool show = this->CubeAxisVisible;
+  bool show = this->AxesGridVisible;
   if (show)
   {
     double* up = this->GetEnvironmentUp();
@@ -768,13 +768,16 @@ void vtkF3DRenderer::ConfigureCubeAxisUsingCurrentActors()
       bbox.GetBounds(a, b, c, x, y, z);
       double bounds[6] = { a, b, c, x, y, z };
       this->CubeAxesActor->SetBounds(bounds);
+
       this->CubeAxesActor->XAxisLabelVisibilityOn();
       this->CubeAxesActor->YAxisLabelVisibilityOn();
       this->CubeAxesActor->ZAxisLabelVisibilityOn();
       this->CubeAxesActor->SetCamera(GetActiveCamera());
-      this->CubeAxesActor->DrawXGridlinesOn();
-      this->CubeAxesActor->DrawYGridlinesOn();
-      this->CubeAxesActor->DrawZGridlinesOn();
+
+      this->CubeAxesActor->SetFlyModeToStaticEdges();
+      this->CubeAxesActor->SetXAxisMinorTickVisibility(false);
+      this->CubeAxesActor->SetYAxisMinorTickVisibility(false);
+      this->CubeAxesActor->SetZAxisMinorTickVisibility(false);
 
       this->CubeAxesActor->GetLabelTextProperty(0)->SetColor(right);
       this->CubeAxesActor->GetTitleTextProperty(0)->SetColor(right);

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -273,6 +273,7 @@ void vtkF3DRenderer::Initialize()
 
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
   this->AddActor(this->GridAxesActor);
+  this->GridAxesActor->SetUseBounds(false);
 #endif
 
   this->GridConfigured = false;
@@ -736,7 +737,6 @@ void vtkF3DRenderer::ConfigureGridAxesUsingCurrentActors()
 {
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
   bool show = this->AxesGridVisible;
-  this->GridAxesActor->SetUseBounds(false);
   if (show)
   {
     double* up = this->GetEnvironmentUp();
@@ -1790,7 +1790,6 @@ void vtkF3DRenderer::UpdateActors()
     this->ConfigureTextActors();
   }
 
-  // GridAxes should not affect bounds, UseBounds must be set false before configuring the render pass.
   if (!this->GridAxesConfigured)
   {
     this->ConfigureGridAxesUsingCurrentActors();

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -719,7 +719,7 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRenderer::ShowAxesGrid(bool show)
+void vtkF3DRenderer::ShowAxesGrid([[maybe_unused]] bool show)
 {
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
   if (this->AxesGridVisible != show)

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -775,7 +775,6 @@ void vtkF3DRenderer::ConfigureGridAxesUsingCurrentActors()
 
       double a, b, c, x, y, z;
       bbox.GetBounds(a, b, c, x, y, z);
-      double bounds[6] = { a, b, c, x, y, z };
       GridAxesActor->SetGridBounds(a, b, c, x, y, z);
 
       GridAxesActor->SetXTitle("X Axis");

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -62,7 +62,7 @@
 #include <vtksys/MD5.h>
 #include <vtksys/SystemTools.hxx>
 
-#if F3D_HAS_GRID_AXES
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250513)
 #include <vtkGridAxesActor3D.h>
 #endif
 
@@ -271,7 +271,7 @@ void vtkF3DRenderer::Initialize()
   this->AddActor(this->SkyboxActor);
   this->AddActor(this->UIActor);
 
-#if F3D_HAS_GRID_AXES
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250513)
   this->AddActor(this->GridAxesActor);
 #endif
 
@@ -720,7 +720,7 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
 //----------------------------------------------------------------------------
 void vtkF3DRenderer::ShowAxesGrid(bool show)
 {
-#if F3D_HAS_GRID_AXES
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250513)
   if (this->AxesGridVisible != show)
   {
     this->AxesGridVisible = show;
@@ -734,7 +734,7 @@ void vtkF3DRenderer::ShowAxesGrid(bool show)
 //----------------------------------------------------------------------------
 void vtkF3DRenderer::ConfigureGridAxesUsingCurrentActors()
 {
-#if F3D_HAS_GRID_AXES
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250513)
   bool show = this->AxesGridVisible;
   if (show)
   {

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -736,6 +736,7 @@ void vtkF3DRenderer::ConfigureGridAxesUsingCurrentActors()
 {
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
   bool show = this->AxesGridVisible;
+  this->GridAxesActor->SetUseBounds(false);
   if (show)
   {
     double* up = this->GetEnvironmentUp();
@@ -1789,6 +1790,12 @@ void vtkF3DRenderer::UpdateActors()
     this->ConfigureTextActors();
   }
 
+  // GridAxes should not affect bounds, UseBounds must be set false before configuring the render pass.
+  if (!this->GridAxesConfigured)
+  {
+    this->ConfigureGridAxesUsingCurrentActors();
+  }
+
   if (!this->RenderPassesConfigured)
   {
     this->ConfigureRenderPasses();
@@ -1798,11 +1805,6 @@ void vtkF3DRenderer::UpdateActors()
   if (!this->GridConfigured)
   {
     this->ConfigureGridUsingCurrentActors();
-  }
-
-  if (!this->GridAxesConfigured)
-  {
-    this->ConfigureGridAxesUsingCurrentActors();
   }
 }
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -724,7 +724,7 @@ void vtkF3DRenderer::ShowAxesGrid(bool show)
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRenderer::ConfigureCubeAxisUsingCurrentActors()
+void vtkF3DRenderer::ConfigureGridAxesUsingCurrentActors()
 {
   bool show = this->AxesGridVisible;
   if (show)
@@ -768,24 +768,10 @@ void vtkF3DRenderer::ConfigureCubeAxisUsingCurrentActors()
       bbox.GetBounds(a, b, c, x, y, z);
       double bounds[6] = { a, b, c, x, y, z };
       GridAxesActor->SetGridBounds(a, b, c, x, y, z);
-      //this->GridAxesActor->SetBounds(bounds);
 
-      //this->GridAxesActor->XAxisLabelVisibilityOn();
-      /*this->CubeAxesActor->YAxisLabelVisibilityOn();
-      this->CubeAxesActor->ZAxisLabelVisibilityOn();
-      this->GridAxesActor->SetCamera(GetActiveCamera());
-
-      this->CubeAxesActor->SetFlyModeToStaticEdges();
-      this->CubeAxesActor->SetXAxisMinorTickVisibility(false);
-      this->CubeAxesActor->SetYAxisMinorTickVisibility(false);
-      this->CubeAxesActor->SetZAxisMinorTickVisibility(false);
-
-      this->CubeAxesActor->GetLabelTextProperty(0)->SetColor(right);
-      this->CubeAxesActor->GetTitleTextProperty(0)->SetColor(right);
-      this->CubeAxesActor->GetLabelTextProperty(1)->SetColor(up);
-      this->CubeAxesActor->GetTitleTextProperty(1)->SetColor(up);
-      this->CubeAxesActor->GetLabelTextProperty(2)->SetColor(front);
-      this->CubeAxesActor->GetTitleTextProperty(2)->SetColor(front);*/
+      GridAxesActor->SetXTitle("X Axis");
+      GridAxesActor->SetYTitle("Y Axis");
+      GridAxesActor->SetZTitle("Z Axis");
 
       this->GridAxesConfigured = true;
     }
@@ -1806,7 +1792,7 @@ void vtkF3DRenderer::UpdateActors()
 
   if (!this->GridAxesConfigured)
   {
-    this->ConfigureCubeAxisUsingCurrentActors();
+    this->ConfigureGridAxesUsingCurrentActors();
   }
 }
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -17,10 +17,10 @@
 #include <vtkCamera.h>
 #include <vtkCellData.h>
 #include <vtkCornerAnnotation.h>
-#include <vtkCubeAxesActor.h>
 #include <vtkCullerCollection.h>
 #include <vtkDiscretizableColorTransferFunction.h>
 #include <vtkFloatArray.h>
+#include <vtkGridAxesActor3D.h>
 #include <vtkImageData.h>
 #include <vtkImageReader2.h>
 #include <vtkImageReader2Factory.h>
@@ -265,7 +265,7 @@ void vtkF3DRenderer::Initialize()
 
   this->AddViewProp(this->ScalarBarActor);
   this->AddActor(this->GridActor);
-  this->AddActor(this->CubeAxesActor);
+  this->AddActor(this->GridAxesActor);
   this->AddActor(this->SkyboxActor);
   this->AddActor(this->UIActor);
 
@@ -718,7 +718,7 @@ void vtkF3DRenderer::ShowAxesGrid(bool show)
   {
     this->AxesGridVisible = show;
     this->RenderPassesConfigured = false;
-    this->CubeAxesConfigured = false;
+    this->GridAxesConfigured = false;
     this->CheatSheetConfigured = false;
   }
 }
@@ -756,23 +756,24 @@ void vtkF3DRenderer::ConfigureCubeAxisUsingCurrentActors()
     }
     else
     {
-      this->CubeAxesActor->SetOrientation(orientation);
-      this->CubeAxesActor->SetVisibility(true);
+      this->GridAxesActor->SetOrientation(orientation);
+      this->GridAxesActor->SetVisibility(true);
 
       double center[4] = { 0, 0, 0, 1 };
       bbox.GetCenter(center);
 
-      this->CubeAxesActor->SetPosition(center);
+      this->GridAxesActor->SetPosition(center);
 
       double a, b, c, x, y, z;
       bbox.GetBounds(a, b, c, x, y, z);
       double bounds[6] = { a, b, c, x, y, z };
-      this->CubeAxesActor->SetBounds(bounds);
+      GridAxesActor->SetGridBounds(a, b, c, x, y, z);
+      //this->GridAxesActor->SetBounds(bounds);
 
-      this->CubeAxesActor->XAxisLabelVisibilityOn();
-      this->CubeAxesActor->YAxisLabelVisibilityOn();
+      //this->GridAxesActor->XAxisLabelVisibilityOn();
+      /*this->CubeAxesActor->YAxisLabelVisibilityOn();
       this->CubeAxesActor->ZAxisLabelVisibilityOn();
-      this->CubeAxesActor->SetCamera(GetActiveCamera());
+      this->GridAxesActor->SetCamera(GetActiveCamera());
 
       this->CubeAxesActor->SetFlyModeToStaticEdges();
       this->CubeAxesActor->SetXAxisMinorTickVisibility(false);
@@ -784,12 +785,12 @@ void vtkF3DRenderer::ConfigureCubeAxisUsingCurrentActors()
       this->CubeAxesActor->GetLabelTextProperty(1)->SetColor(up);
       this->CubeAxesActor->GetTitleTextProperty(1)->SetColor(up);
       this->CubeAxesActor->GetLabelTextProperty(2)->SetColor(front);
-      this->CubeAxesActor->GetTitleTextProperty(2)->SetColor(front);
+      this->CubeAxesActor->GetTitleTextProperty(2)->SetColor(front);*/
 
-      this->CubeAxesConfigured = true;
+      this->GridAxesConfigured = true;
     }
   }
-  this->CubeAxesActor->SetVisibility(show);
+  this->GridAxesActor->SetVisibility(show);
 }
 
 //----------------------------------------------------------------------------
@@ -1803,7 +1804,7 @@ void vtkF3DRenderer::UpdateActors()
     this->ConfigureGridUsingCurrentActors();
   }
 
-  if (!this->CubeAxesConfigured)
+  if (!this->GridAxesConfigured)
   {
     this->ConfigureCubeAxisUsingCurrentActors();
   }

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -62,7 +62,7 @@
 #include <vtksys/MD5.h>
 #include <vtksys/SystemTools.hxx>
 
-#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250513)
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
 #include <vtkGridAxesActor3D.h>
 #endif
 
@@ -271,7 +271,7 @@ void vtkF3DRenderer::Initialize()
   this->AddActor(this->SkyboxActor);
   this->AddActor(this->UIActor);
 
-#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250513)
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
   this->AddActor(this->GridAxesActor);
 #endif
 
@@ -720,7 +720,7 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
 //----------------------------------------------------------------------------
 void vtkF3DRenderer::ShowAxesGrid(bool show)
 {
-#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250513)
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
   if (this->AxesGridVisible != show)
   {
     this->AxesGridVisible = show;
@@ -734,7 +734,7 @@ void vtkF3DRenderer::ShowAxesGrid(bool show)
 //----------------------------------------------------------------------------
 void vtkF3DRenderer::ConfigureGridAxesUsingCurrentActors()
 {
-#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250513)
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
   bool show = this->AxesGridVisible;
   if (show)
   {

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -20,7 +20,6 @@
 #include <vtkCullerCollection.h>
 #include <vtkDiscretizableColorTransferFunction.h>
 #include <vtkFloatArray.h>
-#include <vtkGridAxesActor3D.h>
 #include <vtkImageData.h>
 #include <vtkImageReader2.h>
 #include <vtkImageReader2Factory.h>
@@ -62,6 +61,10 @@
 #include <vtksys/FStream.hxx>
 #include <vtksys/MD5.h>
 #include <vtksys/SystemTools.hxx>
+
+#if F3D_HAS_GRID_AXES
+#include <vtkGridAxesActor3D.h>
+#endif
 
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 2, 20221220)
 #include <vtkSphericalHarmonics.h>
@@ -265,9 +268,12 @@ void vtkF3DRenderer::Initialize()
 
   this->AddViewProp(this->ScalarBarActor);
   this->AddActor(this->GridActor);
-  this->AddActor(this->GridAxesActor);
   this->AddActor(this->SkyboxActor);
   this->AddActor(this->UIActor);
+
+#if F3D_HAS_GRID_AXES
+  this->AddActor(this->GridAxesActor);
+#endif
 
   this->GridConfigured = false;
   this->CheatSheetConfigured = false;
@@ -714,6 +720,7 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
 //----------------------------------------------------------------------------
 void vtkF3DRenderer::ShowAxesGrid(bool show)
 {
+#if F3D_HAS_GRID_AXES
   if (this->AxesGridVisible != show)
   {
     this->AxesGridVisible = show;
@@ -721,11 +728,13 @@ void vtkF3DRenderer::ShowAxesGrid(bool show)
     this->GridAxesConfigured = false;
     this->CheatSheetConfigured = false;
   }
+#endif
 }
 
 //----------------------------------------------------------------------------
 void vtkF3DRenderer::ConfigureGridAxesUsingCurrentActors()
 {
+#if F3D_HAS_GRID_AXES
   bool show = this->AxesGridVisible;
   if (show)
   {
@@ -777,6 +786,8 @@ void vtkF3DRenderer::ConfigureGridAxesUsingCurrentActors()
     }
   }
   this->GridAxesActor->SetVisibility(show);
+
+#endif
 }
 
 //----------------------------------------------------------------------------

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -556,7 +556,7 @@ private:
   bool GridVisible = false;
   bool GridAbsolute = false;
   bool AxisVisible = false;
-  [[maybe_unused]] bool AxesGridVisible = false;
+  bool AxesGridVisible = false;
   std::optional<bool> EdgeVisible;
   bool TimerVisible = false;
   bool FilenameVisible = false;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -556,7 +556,9 @@ private:
   bool GridVisible = false;
   bool GridAbsolute = false;
   bool AxisVisible = false;
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
   bool AxesGridVisible = false;
+#endif
   std::optional<bool> EdgeVisible;
   bool TimerVisible = false;
   bool FilenameVisible = false;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -26,7 +26,7 @@ namespace fs = std::filesystem;
 class vtkDiscretizableColorTransferFunction;
 class vtkColorTransferFunction;
 class vtkCornerAnnotation;
-class vtkCubeAxesActor;
+class vtkGridAxesActor3D;
 class vtkImageReader2;
 class vtkOrientationMarkerWidget;
 class vtkScalarBarActor;
@@ -526,7 +526,7 @@ private:
   vtkSmartPointer<vtkOrientationMarkerWidget> AxisWidget;
 
   vtkNew<vtkActor> GridActor;
-  vtkNew<vtkCubeAxesActor> CubeAxesActor;
+  vtkNew<vtkGridAxesActor3D> GridAxesActor;
   vtkNew<vtkSkybox> SkyboxActor;
   vtkNew<vtkF3DUIActor> UIActor;
 
@@ -535,7 +535,7 @@ private:
   bool CheatSheetConfigured = false;
   bool ActorsPropertiesConfigured = false;
   bool GridConfigured = false;
-  bool CubeAxesConfigured = false;
+  bool GridAxesConfigured = false;
   bool RenderPassesConfigured = false;
   bool LightIntensitiesConfigured = false;
   bool TextActorsConfigured = false;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -472,9 +472,9 @@ private:
   void ConfigureGridUsingCurrentActors();
 
   /**
-   * Configure the cube Axis actor
+   * Configure the Grid Axes actor
    */
-  void ConfigureCubeAxisUsingCurrentActors();
+  void ConfigureGridAxesUsingCurrentActors();
 
   /**
    * Configure the different render passes

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -16,6 +16,7 @@
 
 #include <vtkLight.h>
 #include <vtkOpenGLRenderer.h>
+#include <vtkVersion.h>
 
 #include <filesystem>
 #include <map>

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -526,13 +526,7 @@ private:
   vtkSmartPointer<vtkOrientationMarkerWidget> AxisWidget;
 
     // Does vtk version support GridAxesActor
-#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250514)
-  #define F3D_HAS_GRID_AXES 1
-#else
-  #define F3D_HAS_GRID_AXES 0
-#endif
-
-#if F3D_HAS_GRID_AXES
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250513)
   vtkNew<vtkGridAxesActor3D> GridAxesActor;
 #endif
 

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -525,8 +525,18 @@ private:
 
   vtkSmartPointer<vtkOrientationMarkerWidget> AxisWidget;
 
-  vtkNew<vtkActor> GridActor;
+    // Does vtk version support GridAxesActor
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250514)
+  #define F3D_HAS_GRID_AXES 1
+#else
+  #define F3D_HAS_GRID_AXES 0
+#endif
+
+#if F3D_HAS_GRID_AXES
   vtkNew<vtkGridAxesActor3D> GridAxesActor;
+#endif
+
+  vtkNew<vtkActor> GridActor;
   vtkNew<vtkSkybox> SkyboxActor;
   vtkNew<vtkF3DUIActor> UIActor;
 

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -55,7 +55,7 @@ public:
    */
   void ShowAxis(bool show);
   void ShowGrid(bool show);
-  void ShowCubeAxis(bool show);
+  void ShowAxesGrid(bool show);
   void ShowEdge(const std::optional<bool>& show);
   void ShowTimer(bool show);
   void ShowMetaData(bool show);
@@ -551,7 +551,7 @@ private:
   bool GridVisible = false;
   bool GridAbsolute = false;
   bool AxisVisible = false;
-  bool CubeAxisVisible = false;
+  bool AxesGridVisible = false;
   std::optional<bool> EdgeVisible;
   bool TimerVisible = false;
   bool FilenameVisible = false;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -526,7 +526,7 @@ private:
   vtkSmartPointer<vtkOrientationMarkerWidget> AxisWidget;
 
     // Does vtk version support GridAxesActor
-#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20250513)
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
   vtkNew<vtkGridAxesActor3D> GridAxesActor;
 #endif
 

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -556,7 +556,7 @@ private:
   bool GridVisible = false;
   bool GridAbsolute = false;
   bool AxisVisible = false;
-  bool AxesGridVisible = false;
+  [[maybe_unused]] bool AxesGridVisible = false;
   std::optional<bool> EdgeVisible;
   bool TimerVisible = false;
   bool FilenameVisible = false;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -526,7 +526,7 @@ private:
 
   vtkSmartPointer<vtkOrientationMarkerWidget> AxisWidget;
 
-    // Does vtk version support GridAxesActor
+  // Does vtk version support GridAxesActor
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250513)
   vtkNew<vtkGridAxesActor3D> GridAxesActor;
 #endif

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -26,6 +26,7 @@ namespace fs = std::filesystem;
 class vtkDiscretizableColorTransferFunction;
 class vtkColorTransferFunction;
 class vtkCornerAnnotation;
+class vtkCubeAxesActor;
 class vtkImageReader2;
 class vtkOrientationMarkerWidget;
 class vtkScalarBarActor;
@@ -54,6 +55,7 @@ public:
    */
   void ShowAxis(bool show);
   void ShowGrid(bool show);
+  void ShowCubeAxis(bool show);
   void ShowEdge(const std::optional<bool>& show);
   void ShowTimer(bool show);
   void ShowMetaData(bool show);
@@ -470,6 +472,11 @@ private:
   void ConfigureGridUsingCurrentActors();
 
   /**
+   * Configure the cube Axis actor
+   */
+  void ConfigureCubeAxisUsingCurrentActors();
+
+  /**
    * Configure the different render passes
    */
   void ConfigureRenderPasses();
@@ -519,6 +526,7 @@ private:
   vtkSmartPointer<vtkOrientationMarkerWidget> AxisWidget;
 
   vtkNew<vtkActor> GridActor;
+  vtkNew<vtkCubeAxesActor> CubeAxesActor;
   vtkNew<vtkSkybox> SkyboxActor;
   vtkNew<vtkF3DUIActor> UIActor;
 
@@ -527,6 +535,7 @@ private:
   bool CheatSheetConfigured = false;
   bool ActorsPropertiesConfigured = false;
   bool GridConfigured = false;
+  bool CubeAxesConfigured = false;
   bool RenderPassesConfigured = false;
   bool LightIntensitiesConfigured = false;
   bool TextActorsConfigured = false;
@@ -542,6 +551,7 @@ private:
   bool GridVisible = false;
   bool GridAbsolute = false;
   bool AxisVisible = false;
+  bool CubeAxisVisible = false;
   std::optional<bool> EdgeVisible;
   bool TimerVisible = false;
   bool FilenameVisible = false;


### PR DESCRIPTION
Added command line argument --axesGrid which maps to render.cubeAxis.enable.

Support showing the vtkCubeAxesActor within the viewport, matching to bounding box of the model.

Added application layer test for this option.

Fix #7


- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI