### PR TITLE
imgui: make widget not be brought to front on focus

### DIFF
--- a/vtkext/private/module/vtkF3DImguiActor.cxx
+++ b/vtkext/private/module/vtkF3DImguiActor.cxx
@@ -322,6 +322,7 @@ void vtkF3DImguiActor::RenderDropZone()
       ImGuiWindowFlags_NoBringToFrontOnFocus;
 
     ImGui::Begin("DropZoneText", nullptr, flags);
+    /* Use background draw list to prevent "ignoring" NoBringToFrontOnFocus */
     ImDrawList* draw_list = ImGui::GetBackgroundDrawList();
 
     const ImVec2 p0(dropzonePad, dropzonePad);

--- a/vtkext/private/module/vtkF3DImguiActor.cxx
+++ b/vtkext/private/module/vtkF3DImguiActor.cxx
@@ -446,7 +446,8 @@ void vtkF3DImguiActor::RenderCheatSheet()
 
   ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
     ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings |
-    ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove;
+    ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove |
+    ImGuiWindowFlags_NoBringToFrontOnFocus;
 
   ImGui::Begin("CheatSheet", nullptr, flags);
 

--- a/vtkext/private/module/vtkF3DImguiActor.cxx
+++ b/vtkext/private/module/vtkF3DImguiActor.cxx
@@ -322,7 +322,7 @@ void vtkF3DImguiActor::RenderDropZone()
       ImGuiWindowFlags_NoBringToFrontOnFocus;
 
     ImGui::Begin("DropZoneText", nullptr, flags);
-    ImDrawList* draw_list = ImGui::GetWindowDrawList();
+    ImDrawList* draw_list = ImGui::GetBackgroundDrawList();
 
     const ImVec2 p0(dropzonePad, dropzonePad);
     const ImVec2 p1(dropzonePad + dropZoneW, dropzonePad + dropZoneH);

--- a/vtkext/private/module/vtkF3DImguiActor.cxx
+++ b/vtkext/private/module/vtkF3DImguiActor.cxx
@@ -318,7 +318,8 @@ void vtkF3DImguiActor::RenderDropZone()
     ImGui::SetNextWindowBgAlpha(0.f);
 
     ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings |
-      ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove;
+      ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove |
+      ImGuiWindowFlags_NoBringToFrontOnFocus;
 
     ImGui::Begin("DropZoneText", nullptr, flags);
     ImDrawList* draw_list = ImGui::GetWindowDrawList();


### PR DESCRIPTION
For now only done for cheatsheet, can be update with better clarification on expected behavior - which kind of widgets are affected.

related to https://github.com/f3d-app/f3d/issues/2103