### PR TITLE
Fix animationManager for dynamic range and single frame

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -713,8 +713,8 @@ if(F3D_PLUGIN_BUILD_EXODUS)
   # Test animation with generic importer, coloring and a custom scalar range
   f3d_test(NAME TestAnimationGenericImporterScalarRange DATA small.ex2 ARGS -sb --load-plugins=exodus --animation-time=0.003 --animation-progress --coloring-range=0,1e7)
 
-  # Test Generic Importer Verbose invalid animation.
-  f3d_test(NAME TestVerboseAnimationSingleTimestep DATA single_timestep.e ARGS --load-plugins=exodus --verbose NO_BASELINE REGEXP "time range delta is invalid")
+  # Test Generic Importer Verbose animation with a single frame.
+  f3d_test(NAME TestVerboseAnimationSingleTimestep DATA single_timestep.e ARGS --load-plugins=exodus --verbose NO_BASELINE REGEXP "0, 0")
 
   # Test no render animation time. Regex contains a part of the range of the ACCL field.
   f3d_test(NAME TestNoRenderAnimation DATA small.ex2 ARGS  --load-plugins=exodus --animation-time=0.003 REGEXP "-521950, 6.57485" NO_RENDER)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -440,6 +440,10 @@ f3d_test(NAME TestInteractionAnimationInvert DATA f3d.glb ARGS --animation-speed
 f3d_test(NAME TestVerboseAnimationWrongAnimationTimeHigh DATA BoxAnimated.gltf ARGS --animation-time=10 --verbose REGEXP "Animation time 10 is outside of range \\[0, 3\\.70833\\], using 3\\.70833" NO_BASELINE)
 f3d_test(NAME TestVerboseAnimationWrongAnimationTimeLow DATA BoxAnimated.gltf ARGS --animation-time=-5 --verbose REGEXP "Animation time -5 is outside of range \\[0, 3\\.70833\\], using 0" NO_BASELINE)
 
+# Verbose test for animation time range
+f3d_test(NAME TestVerboseAnimationTimeRange DATA InterpolationTest.glb ARGS --verbose REGEXP "0, 1.66667" NO_BASELINE)
+f3d_test(NAME TestCommandScriptVerboseMultiAnimationTimeRange SCRIPT TestCommandScriptVerboseMultiAnimationTimeRange.txt DATA InterpolationTest.glb ARGS --verbose REGEXP "0, 1.70833" NO_BASELINE)# cycle_animation x3
+
 # Armature test
 f3d_test(NAME TestGLTFRigArmatureNoArmature DATA RiggedFigure.glb ARGS --animation-time=1 --opacity=0.5 -p)
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.4.20241219)
@@ -709,7 +713,7 @@ if(F3D_PLUGIN_BUILD_EXODUS)
   # Test animation with generic importer, coloring and a custom scalar range
   f3d_test(NAME TestAnimationGenericImporterScalarRange DATA small.ex2 ARGS -sb --load-plugins=exodus --animation-time=0.003 --animation-progress --coloring-range=0,1e7)
 
-  # Test Generic Importer Verbose animation. Regex contains the time range.
+  # Test Generic Importer Verbose invalid animation.
   f3d_test(NAME TestVerboseAnimationSingleTimestep DATA single_timestep.e ARGS --load-plugins=exodus --verbose NO_BASELINE REGEXP "time range delta is invalid")
 
   # Test no render animation time. Regex contains a part of the range of the ACCL field.

--- a/library/private/animationManager.h
+++ b/library/private/animationManager.h
@@ -104,10 +104,10 @@ public:
    */
   std::pair<double, double> GetTimeRange();
 
-private:
   animationManager(animationManager const&) = delete;
   void operator=(animationManager const&) = delete;
 
+private:
   /**
    * Update members for animation index from options
    */

--- a/library/private/animationManager.h
+++ b/library/private/animationManager.h
@@ -29,7 +29,7 @@ class window_impl;
 class animationManager
 {
 public:
-  animationManager(const options& options, window_impl& window);
+  animationManager(options& options, window_impl& window);
   ~animationManager() = default;
 
   /**
@@ -60,13 +60,9 @@ public:
 
   /**
    * Cycle onto and play the next available animation
+   * This modifies the scene.animation.index option
    */
   void CycleAnimation();
-
-  /**
-   * Enable only the current animation
-   */
-  void EnableOnlyCurrentAnimation();
 
   /**
    * Get the current animation index
@@ -103,16 +99,21 @@ public:
    */
   bool LoadAtTime(double timeValue);
 
-  animationManager(animationManager const&) = delete;
-  void operator=(animationManager const&) = delete;
-
   /**
    * Return a pair containing the current time range values
    */
   std::pair<double, double> GetTimeRange();
 
 private:
-  const options& Options;
+  animationManager(animationManager const&) = delete;
+  void operator=(animationManager const&) = delete;
+
+  /**
+   * Update members for animation index from options
+   */
+  void UpdateForAnimationIndex();
+
+  options& Options;
   window_impl& Window;
   vtkImporter* Importer = nullptr;
   interactor_impl* Interactor = nullptr;
@@ -123,7 +124,7 @@ private:
   double CurrentTime = 0;
   double DeltaTime = 0;
   bool CurrentTimeSet = false;
-  int AnimationIndex = 0;
+  int AnimationIndex = -2;
   int AvailAnimations = -1;
 
   vtkSmartPointer<vtkProgressBarWidget> ProgressWidget;

--- a/library/private/animationManager.h
+++ b/library/private/animationManager.h
@@ -120,7 +120,6 @@ private:
 
   double TimeRange[2] = { 0.0, 0.0 };
   bool Playing = false;
-  bool HasAnimation = false;
   double CurrentTime = 0;
   double DeltaTime = 0;
   bool CurrentTimeSet = false;

--- a/library/private/scene_impl.h
+++ b/library/private/scene_impl.h
@@ -29,7 +29,7 @@ public:
   /**
    * Documented public API
    */
-  scene_impl(const options& options, window_impl& window);
+  scene_impl(options& options, window_impl& window);
   ~scene_impl();
   scene& add(const std::filesystem::path& filePath) override;
   scene& add(const std::vector<std::filesystem::path>& filePath) override;

--- a/library/src/animationManager.cxx
+++ b/library/src/animationManager.cxx
@@ -280,7 +280,8 @@ void animationManager::UpdateForAnimationIndex()
 {
   assert(this->Importer);
 
-  if (this->Options.scene.animation.index <= -2 || this->AnimationIndex == this->Options.scene.animation.index || this->AvailAnimations <= 0)
+  if (this->Options.scene.animation.index <= -2 ||
+    this->AnimationIndex == this->Options.scene.animation.index || this->AvailAnimations <= 0)
   {
     // Already updated or no animation available
     return;

--- a/library/src/animationManager.cxx
+++ b/library/src/animationManager.cxx
@@ -108,41 +108,6 @@ void animationManager::Initialize()
   }
   this->EnableOnlyCurrentAnimation();
 
-  // Recover time ranges for all enabled animations
-  this->TimeRange[0] = std::numeric_limits<double>::infinity();
-  this->TimeRange[1] = -std::numeric_limits<double>::infinity();
-  for (vtkIdType animIndex = 0; animIndex < this->AvailAnimations; animIndex++)
-  {
-    if (this->Importer->IsAnimationEnabled(animIndex))
-    {
-      double timeRange[2];
-      int nbTimeSteps;
-      vtkNew<vtkDoubleArray> timeSteps;
-
-      // Discard timesteps, F3D only cares about elapsed time using time range and deltaTime
-      // Specifying a frame rate (60) in the next call is not needed after VTK 9.2.20230603 :
-      // VTK_VERSION_CHECK(9, 2, 20230603)
-      this->Importer->GetTemporalInformation(animIndex, 60, nbTimeSteps, timeRange, timeSteps);
-
-      // Accumulate time ranges
-      this->TimeRange[0] = std::min(timeRange[0], this->TimeRange[0]);
-      this->TimeRange[1] = std::max(timeRange[1], this->TimeRange[1]);
-      this->HasAnimation = true;
-    }
-  }
-  if (this->TimeRange[0] >= this->TimeRange[1])
-  {
-    log::warn("Animation(s) time range delta is invalid: [", this->TimeRange[0], ", ",
-      this->TimeRange[1], "]. Disabling animation.");
-    this->HasAnimation = false;
-    return;
-  }
-  else
-  {
-    log::debug("Animation(s) time range is: [", this->TimeRange[0], ", ", this->TimeRange[1], "].");
-  }
-  log::debug("");
-
   bool autoplay = this->Options.scene.animation.autoplay;
   if (autoplay)
   {
@@ -331,6 +296,41 @@ void animationManager::EnableOnlyCurrentAnimation()
       this->Importer->EnableAnimation(i);
     }
   }
+
+  // Recover time ranges for all enabled animations
+  this->TimeRange[0] = std::numeric_limits<double>::infinity();
+  this->TimeRange[1] = -std::numeric_limits<double>::infinity();
+  for (vtkIdType animIndex = 0; animIndex < this->AvailAnimations; animIndex++)
+  {
+    if (this->Importer->IsAnimationEnabled(animIndex))
+    {
+      double timeRange[2];
+      int nbTimeSteps;
+      vtkNew<vtkDoubleArray> timeSteps;
+
+      // Discard timesteps, F3D only cares about elapsed time using time range and deltaTime
+      // Specifying a frame rate (60) in the next call is not needed after VTK 9.2.20230603 :
+      // VTK_VERSION_CHECK(9, 2, 20230603)
+      this->Importer->GetTemporalInformation(animIndex, 60, nbTimeSteps, timeRange, timeSteps);
+
+      // Accumulate time ranges
+      this->TimeRange[0] = std::min(timeRange[0], this->TimeRange[0]);
+      this->TimeRange[1] = std::max(timeRange[1], this->TimeRange[1]);
+      this->HasAnimation = true;
+    }
+  }
+  if (this->TimeRange[0] >= this->TimeRange[1])
+  {
+    log::warn("Animation(s) time range delta is invalid: [", this->TimeRange[0], ", ",
+      this->TimeRange[1], "]. Disabling animation.");
+    this->HasAnimation = false;
+    return;
+  }
+  else
+  {
+    log::debug("Animation(s) time range is: [", this->TimeRange[0], ", ", this->TimeRange[1], "].");
+  }
+  log::debug("");
 }
 
 //----------------------------------------------------------------------------

--- a/library/src/animationManager.cxx
+++ b/library/src/animationManager.cxx
@@ -287,7 +287,8 @@ void animationManager::UpdateForAnimationIndex()
   }
 
   // Valid animation index : ]-2, AvailAnimations[
-  if (this->Options.scene.animation.index <= -2 || this->Options.scene.animation.index >= this->AvailAnimations)
+  if (this->Options.scene.animation.index <= -2 ||
+    this->Options.scene.animation.index >= this->AvailAnimations)
   {
     log::warn(
       "Specified animation index is greater than the highest possible animation index, enabling "

--- a/library/src/animationManager.cxx
+++ b/library/src/animationManager.cxx
@@ -337,7 +337,8 @@ void animationManager::UpdateForAnimationIndex()
       this->TimeRange[1], "]. Swapping range.");
     std::swap(this->TimeRange[0], this->TimeRange[1]);
   }
-  log::debug("Current animation time range is: [", this->TimeRange[0], ", ", this->TimeRange[1], "].");
+  log::debug(
+    "Current animation time range is: [", this->TimeRange[0], ", ", this->TimeRange[1], "].");
   log::debug("");
 }
 

--- a/library/src/animationManager.cxx
+++ b/library/src/animationManager.cxx
@@ -280,7 +280,7 @@ void animationManager::UpdateForAnimationIndex()
 {
   assert(this->Importer);
 
-  if (this->AnimationIndex == this->Options.scene.animation.index || this->AvailAnimations <= 0)
+  if (this->Options.scene.animation.index <= -2 || this->AnimationIndex == this->Options.scene.animation.index || this->AvailAnimations <= 0)
   {
     // Already updated or no animation available
     return;

--- a/library/src/animationManager.cxx
+++ b/library/src/animationManager.cxx
@@ -280,20 +280,23 @@ void animationManager::UpdateForAnimationIndex()
 {
   assert(this->Importer);
 
-  if (this->Options.scene.animation.index <= -2 ||
-    this->AnimationIndex == this->Options.scene.animation.index || this->AvailAnimations <= 0)
+  if (this->AnimationIndex == this->Options.scene.animation.index || this->AvailAnimations <= 0)
   {
     // Already updated or no animation available
     return;
   }
 
-  this->AnimationIndex = this->Options.scene.animation.index;
-  if (this->AnimationIndex > 0 && this->AnimationIndex >= this->AvailAnimations)
+  // Valid animation index : ]-2, AvailAnimations[
+  if (this->Options.scene.animation.index <= -2 || this->Options.scene.animation.index >= this->AvailAnimations)
   {
     log::warn(
       "Specified animation index is greater than the highest possible animation index, enabling "
       "the first animation.");
     this->AnimationIndex = 0;
+  }
+  else
+  {
+    this->AnimationIndex = this->Options.scene.animation.index;
   }
 
   for (int i = 0; i < this->AvailAnimations; i++)

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -721,8 +721,6 @@ interactor& interactor_impl::initCommands()
     [&](const std::vector<std::string>&)
     {
       this->Internals->AnimationManager->CycleAnimation();
-      this->Internals->Options.scene.animation.index =
-        this->Internals->AnimationManager->GetAnimationIndex();
     });
 
   this->addCommand("cycle_anti_aliasing",

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -718,10 +718,7 @@ interactor& interactor_impl::initCommands()
     });
 
   this->addCommand("cycle_animation",
-    [&](const std::vector<std::string>&)
-    {
-      this->Internals->AnimationManager->CycleAnimation();
-    });
+    [&](const std::vector<std::string>&) { this->Internals->AnimationManager->CycleAnimation(); });
 
   this->addCommand("cycle_anti_aliasing",
     [&](const std::vector<std::string>&)

--- a/library/src/scene_impl.cxx
+++ b/library/src/scene_impl.cxx
@@ -29,7 +29,7 @@ namespace f3d::detail
 class scene_impl::internals
 {
 public:
-  internals(const options& options, window_impl& window)
+  internals(options& options, window_impl& window)
     : Options(options)
     , Window(window)
     , AnimationManager(options, window)
@@ -190,7 +190,7 @@ public:
 };
 
 //----------------------------------------------------------------------------
-scene_impl::scene_impl(const options& options, window_impl& window)
+scene_impl::scene_impl(options& options, window_impl& window)
   : Internals(std::make_unique<scene_impl::internals>(options, window))
 {
 }

--- a/testing/baselines/TestDefaultConfigFileExodus.png
+++ b/testing/baselines/TestDefaultConfigFileExodus.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:100a1e7a281f8930d4b00c66d6168b367ad6ea208a32d805b503ec5a53270a8c
-size 45265
+oid sha256:48e45c2f4b6a83e9b3af41066c41c22b1d0666ca1ae04c66f7bb5de98a01b357
+size 44919

--- a/testing/baselines/TestMetaData.png
+++ b/testing/baselines/TestMetaData.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf65ebde79ea9020ae1dd53f36199e28d4c952bd7a97e596f1e01762b044675a
-size 9224
+oid sha256:c34410dace45d268a2d6f6208a1bdd5c9b113607dfc9db59b8ea4fad646e47fc
+size 8916

--- a/testing/scripts/TestCommandScriptVerboseMultiAnimationTimeRange.txt
+++ b/testing/scripts/TestCommandScriptVerboseMultiAnimationTimeRange.txt
@@ -1,0 +1,3 @@
+cycle_animation
+cycle_animation
+cycle_animation


### PR DESCRIPTION
- Fix animationManager to handle dynamic time ranges in multiple animations
- Properly support single frame animation
- Add tests
- Update single frame animation test baseline where console badge disappears
- Follow up issue: https://github.com/f3d-app/f3d/issues/2130