### PR TITLE
vtkF3DQuakeMDLImporter.cxx: add missing include

### DIFF
--- a/plugins/native/module/vtkF3DQuakeMDLImporter.h
+++ b/plugins/native/module/vtkF3DQuakeMDLImporter.h
@@ -12,6 +12,8 @@
 
 #include <vtkF3DImporter.h>
 
+#include <memory>
+
 class vtkF3DQuakeMDLImporter : public vtkF3DImporter
 {
 public:


### PR DESCRIPTION
Build failure:

```
[ 64%] Building CXX object plugins/native/module/CMakeFiles/vtkextNative.dir/vtkF3DQuakeMDLImporter.cxx.o
In file included from /home/pbsds/tmp/repos/f3d/plugins/native/module/vtkF3DQuakeMDLImporter.cxx:1:
/home/pbsds/tmp/repos/f3d/plugins/native/module/vtkF3DQuakeMDLImporter.h:70:8: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
   70 |   std::unique_ptr<vtkInternals> Internals;
      |        ^~~~~~~~~~
/home/pbsds/tmp/repos/f3d/plugins/native/module/vtkF3DQuakeMDLImporter.h:14:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; this is probably fixable by adding ‘#include <memory>’
   13 | #include <vtkF3DImporter.h>
  +++ |+#include <memory>
   14 |
```

Environment:

* cmake-3.31.5
* binutils-2.43.1
* glibc-2.40-66
* coreutils-9.6
* gcc-14-20241116
* vtk-9.2.6
* libX11-1.8.1
* xorgproto-2024.1
* libxcb-1.17.0
* libglvnd-1.7.0
* opencascade-occt-7.8.1
* assimp-5.4.3
* fontconfig-2.16.0
* freetype-2.13.3
* zlib-1.3.1
* bzip2-1.0.8
* brotli-1.1.0
* libpng-apng-1.6.46