### PR TITLE
QuakeMDL: Set Normals array properly

### DIFF
--- a/plugins/native/module/vtkF3DQuakeMDLImporter.cxx
+++ b/plugins/native/module/vtkF3DQuakeMDLImporter.cxx
@@ -488,7 +488,7 @@ vtkIdType vtkF3DQuakeMDLImporter::GetNumberOfAnimations()
 //----------------------------------------------------------------------------
 std::string vtkF3DQuakeMDLImporter::GetAnimationName(vtkIdType animationIndex)
 {
-  assert(animationIndex < this->Internals->AnimationNames.size());
+  assert(animationIndex < static_cast<vtkIdType>(this->Internals->AnimationNames.size()));
   assert(animationIndex >= 0);
   return this->Internals->AnimationNames[animationIndex];
 }
@@ -496,7 +496,7 @@ std::string vtkF3DQuakeMDLImporter::GetAnimationName(vtkIdType animationIndex)
 //----------------------------------------------------------------------------
 void vtkF3DQuakeMDLImporter::EnableAnimation(vtkIdType animationIndex)
 {
-  assert(animationIndex < this->Internals->AnimationNames.size());
+  assert(animationIndex < static_cast<vtkIdType>(this->Internals->AnimationNames.size()));
   assert(animationIndex >= 0);
   this->Internals->ActiveAnimation = animationIndex;
 }
@@ -510,7 +510,7 @@ void vtkF3DQuakeMDLImporter::DisableAnimation(vtkIdType vtkNotUsed(animationInde
 //----------------------------------------------------------------------------
 bool vtkF3DQuakeMDLImporter::IsAnimationEnabled(vtkIdType animationIndex)
 {
-  assert(animationIndex < this->Internals->AnimationNames.size());
+  assert(animationIndex < static_cast<vtkIdType>(this->Internals->AnimationNames.size()));
   assert(animationIndex >= 0);
   return this->Internals->ActiveAnimation == animationIndex;
 }
@@ -520,11 +520,11 @@ bool vtkF3DQuakeMDLImporter::GetTemporalInformation(vtkIdType animationIndex,
   double vtkNotUsed(frameRate), int& vtkNotUsed(nbTimeSteps), double timeRange[2],
   vtkDoubleArray* vtkNotUsed(timeSteps))
 {
-  assert(animationIndex < this->Internals->AnimationNames.size());
+  assert(animationIndex < static_cast<vtkIdType>(this->Internals->AnimationNames.size()));
   assert(animationIndex >= 0);
 
   const std::vector<double>& times = this->Internals->AnimationTimes[animationIndex];
-  // F3D do not care about timesteps, only set time range
+  // F3D does not care about timesteps, only set time range
   timeRange[0] = times.front();
   timeRange[1] = times.back();
   return true;

--- a/plugins/native/module/vtkF3DQuakeMDLImporter.cxx
+++ b/plugins/native/module/vtkF3DQuakeMDLImporter.cxx
@@ -157,7 +157,7 @@ struct vtkF3DQuakeMDLImporter::vtkInternals
 
     vtkNew<vtkFloatArray> normals;
     normals->SetNumberOfComponents(3);
-    normals->Allocate(header->numTriangles * 3 * 3);
+    normals->SetNumberOfTuples(header->numTriangles * 3);
 
     for (int i = 0; i < header->numTriangles; i++)
     {

--- a/testing/baselines/TestDefaultConfigFileQuakeMDL.png
+++ b/testing/baselines/TestDefaultConfigFileQuakeMDL.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:123ea1e04c2ad01dff978d99ff22d97ff07d39ee32f6b9d90f77cde203b9757e
-size 57577
+oid sha256:1d67ec12693899b78110e1b863d57b10c280c17312699f963e52160cfe52fb48
+size 58114

--- a/testing/baselines/TestQuakeMDL.png
+++ b/testing/baselines/TestQuakeMDL.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59ea2112926601a1f8922d5ed1b5484f9c1fc599d42cb3fd7af7e1513fba56cf
-size 23321
+oid sha256:09f353b791ba60108fdf5284886350f4a3bd23a209941968ad82def2bfc2fe06
+size 30649

--- a/testing/baselines/TestQuakeMDLActorCollection.png
+++ b/testing/baselines/TestQuakeMDLActorCollection.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:053f916c7af1f7a324e0642a362c8b7bb414068153c989c3e68d0acabef631d2
-size 18090
+oid sha256:23c5ed70a0e1fa5de9f94c81942b63def546322eb105b200c1495730d4cd60b5
+size 22389

--- a/testing/baselines/TestQuakeMDLAnimationBetween.png
+++ b/testing/baselines/TestQuakeMDLAnimationBetween.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7f961e8bf61ef59a192b426a805d3c93007026ad344b81cd9bb34164dafcd1a
-size 23022
+oid sha256:7fbf14d2cc2d1f7dc1489259e2f2b985dccdc0ff5e16c6f68087e672e1fb76bf
+size 30838

--- a/testing/baselines/TestQuakeMDLAnimationGroupFrame.png
+++ b/testing/baselines/TestQuakeMDLAnimationGroupFrame.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d28f0292424fb4a1ceba89c9f2196ab3b3da160b796d96ecdd9dd21607bb95ee
-size 13413
+oid sha256:70406eb594669c8702f72cf5d581b4e5e60cd9f58a56a261616790e491787f15
+size 17534

--- a/testing/baselines/TestQuakeMDLAnimationMulti.png
+++ b/testing/baselines/TestQuakeMDLAnimationMulti.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:122a6afc80e74586d5bee6cf7dffc097136d6455fb820dd9018e50b2c9bc2d34
-size 22379
+oid sha256:380751667337efd0af59f685b3a9ac6286b07f071c0bee1743d58c36c8cf59e6
+size 21992

--- a/testing/baselines/TestQuakeMDLAnimationSimpleFrame.png
+++ b/testing/baselines/TestQuakeMDLAnimationSimpleFrame.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:51172ae7dab6731c6e0e7b89a7d2e4cb05c714c0b59c7fee36cc69c2011e2933
-size 22143
+oid sha256:7ea40a77ca387f8b37ec164a463fc796ec3fa73da2b02fae2259df6ffb1c9e0f
+size 29100

--- a/testing/baselines/TestQuakeMDLDisableAnimation.png
+++ b/testing/baselines/TestQuakeMDLDisableAnimation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d235088c6726cab2d20cec2ec5a7b261a4796dc35c9874eec8298262839fd3e
-size 25098
+oid sha256:d61eeb2048aac60f19cf7e750d843779060f4a61a40dca955de05a05ba2f8433
+size 25928

--- a/testing/baselines/TestThumbnailConfigFileQuakeMDL.png
+++ b/testing/baselines/TestThumbnailConfigFileQuakeMDL.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec1682af94695e38510645cfdda2aefc1034b5f4ebf42a7bb41a8b2332773f1f
-size 19177
+oid sha256:11657b21ef95d08f65f4edf5ed99004f128b4309eda4117ded0d62896237eb5e
+size 18346

--- a/webassembly/app.html
+++ b/webassembly/app.html
@@ -58,7 +58,7 @@
                 class="file-input"
                 type="file"
                 id="file-selector"
-                accept=".gml,.gltf,.glb,.obj,.ply,.pts,.stl,.vtk,.vtp,.vtu,.3ds,.wrl,.vrml,.fbx,.off,.x,.dae,.stp,.step,.igs,.iges,.brep,.xbf,.drc"
+                accept=".gml,.gltf,.glb,.obj,.ply,.pts,.stl,.vtk,.vtp,.vtu,.3ds,.wrl,.vrml,.fbx,.off,.x,.dae,.stp,.step,.igs,.iges,.brep,.xbf,.drc,.mdl"
               />
               <span class="file-cta">
                 <span class="file-label">Open a file...</span>


### PR DESCRIPTION
In QuakeMDLImporter, the normals array was allocated, but this did not change its actual size. We now set the array size directly, which allocates memory just like it did before. Having a normals array without data confused the web renderer which did not display anything (#2153)

Tests have been updated with corrected normals.

Closes #2153 