### PR TITLE
CI: Add logic to trigger f3d-docker-image dispatch workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 - [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
 - [ ] I have added [documentation](https://f3d.app/) for new features
 - [ ] If it is a modifying the libf3d API, I have updated bindings
-- [ ] If it is a modifying the default versions.json, I have updated timestamp
+- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`
 
 ### Continuous integration
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 - [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
 - [ ] I have added [documentation](https://f3d.app/) for new features
 - [ ] If it is a modifying the libf3d API, I have updated bindings
-- [ ] If it is a modifying the default versions, I have updated timestamp
+- [ ] If it is a modifying the default versions.json, I have updated timestamp
 
 ### Continuous integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,10 +702,32 @@ jobs:
         vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
 
 #----------------------------------------------------------------------------
+# Check android/wasm docker images
+#----------------------------------------------------------------------------
+  check_docker_images:
+    needs: default_versions
+
+    runs-on: ubuntu-22.04
+
+    steps:
+
+    - uses: convictional/trigger-workflow-and-wait@v1.6.5
+      with:
+        owner: f3d-app
+        repo: f3d-docker-images
+        github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+        workflow_file_name: build_docker_image.yml 
+        wait_interval: 10
+        client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$GITHUB_REF/.github/workflows/versions.json"}'
+        propagate_failure: true
+        trigger_workflow: true
+        wait_workflow: true
+
+#----------------------------------------------------------------------------
 # android: Check build of F3D for android
 #----------------------------------------------------------------------------
   android:
-    needs: [default_versions, detect_checkboxes]
+    needs: [default_versions, detect_checkboxes, check_docker_images]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Android CI')) || (github.ref == 'refs/heads/master') }}
 
     strategy:
@@ -725,18 +747,6 @@ jobs:
         fetch-depth: 0
         lfs: false
 
-    - uses: convictional/trigger-workflow-and-wait@v1.6.5
-      with:
-        owner: f3d-app
-        repo: f3d-docker-images
-        github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
-        workflow_file_name: build_docker_image.yml 
-        wait_interval: 10
-        client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$GITHUB_REF/.github/workflows/versions.json"}'
-        propagate_failure: true
-        trigger_workflow: true
-        wait_workflow: true
-
     - name: Android CI
       uses: ./source/.github/actions/android-ci
       with:
@@ -746,7 +756,7 @@ jobs:
 # webassembly: Build webassembly artifacts
 #----------------------------------------------------------------------------
   webassembly:
-    needs: [default_versions, detect_checkboxes]
+    needs: [default_versions, detect_checkboxes, check_docker_images]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'WASM CI')) || (github.ref == 'refs/heads/master') }}
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -711,17 +711,84 @@ jobs:
 
     steps:
 
-    - uses: convictional/trigger-workflow-and-wait@v1.6.5
+    - name: Check wasm image
+      id: image_exists_wasm
+      uses: cloudposse/github-action-docker-image-exists@main
+      with:
+        registry: ghcr.io
+        organization: "f3d-app"
+        repository: "f3d-wasm"
+        tag: ${{needs.default_versions.outputs.timestamp}}
+
+    - name: Check android armeabi-v7a image
+      id: image_exists_android_armeabi-v7a
+      uses: cloudposse/github-action-docker-image-exists@main
+      with:
+        registry: ghcr.io
+        organization: "f3d-app"
+        repository: "f3d-android-armeabi-v7a"
+        tag: ${{needs.default_versions.outputs.timestamp}}
+
+    - name: Check android arm64-v8a image
+      id: image_exists_android_arm64-v8a
+      uses: cloudposse/github-action-docker-image-exists@main
+      with:
+        registry: ghcr.io
+        organization: "f3d-app"
+        repository: "f3d-android-arm64-v8a"
+        tag: ${{needs.default_versions.outputs.timestamp}}
+
+    - name: Check android x86 image
+      id: image_exists_android_x86
+      uses: cloudposse/github-action-docker-image-exists@main
+      with:
+        registry: ghcr.io
+        organization: "f3d-app"
+        repository: "f3d-android-x86"
+        tag: ${{needs.default_versions.outputs.timestamp}}
+
+    - name: Check android x86_64 image
+      id: image_exists_android_x86_64
+      uses: cloudposse/github-action-docker-image-exists@main
+      with:
+        registry: ghcr.io
+        organization: "f3d-app"
+        repository: "f3d-android-x86_64"
+        tag: ${{needs.default_versions.outputs.timestamp}}
+
+    # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
+    - name: Trigger docker images build
+      if: ${{ !secrets.F3D_DOCKER_CI_DISPATCH == '' && (
+        !steps.image_exists_wasm.conclusion ||
+        !steps.image_exists_android_armeabi-v7a.conclusion ||
+        !steps.image_exists_android_arm64-v8a.conclusion ||
+        !steps.image_exists_android_x86.conclusion ||
+        !steps.image_exists_android_x86_64.conclusion
+      ) }}
+      uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: f3d-app
         repo: f3d-docker-images
         github_token: ${{ secrets.F3D_DOCKER_CI_DISPATCH }}
-        workflow_file_name: build_docker_image.yml 
+        workflow_file_name: build_docker_image.yml
         wait_interval: 10
         client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/${{github.repository}}/${{github.ref}}/.github/workflows/versions.json"}'
         propagate_failure: true
         trigger_workflow: true
         wait_workflow: true
+
+    - name: Error out when unable to build docker images
+      if: ${{ secrets.F3D_DOCKER_CI_DISPATCH == '' && (
+        !steps.image_exists_wasm.conclusion ||
+        !steps.image_exists_android_armeabi-v7a.conclusion ||
+        !steps.image_exists_android_arm64-v8a.conclusion ||
+        !steps.image_exists_android_x86.conclusion ||
+        !steps.image_exists_android_x86_64.conclusion
+      ) }}
+      uses: actions/github-script@v3
+      with:
+        script: |
+            core.setFailed('Could not generate missing docker images')
 
 #----------------------------------------------------------------------------
 # android: Check build of F3D for android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,7 +715,7 @@ jobs:
       with:
         owner: f3d-app
         repo: f3d-docker-images
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.F3D_DOCKER_CI_DISPATCH }}
         workflow_file_name: build_docker_image.yml 
         wait_interval: 10
         client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$GITHUB_REF/.github/workflows/versions.json"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,7 +730,7 @@ jobs:
 
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
     - name: Trigger docker images build
-      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && !secrets.F3D_DOCKER_CI_DISPATCH_ == '' }}
+      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && secrets.F3D_DOCKER_CI_DISPATCH_ != '' }}
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: f3d-app
@@ -744,7 +744,7 @@ jobs:
         wait_workflow: true
 
     - name: Error out when unable to build docker images
-      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && !secrets.F3D_DOCKER_CI_DISPATCH_ == '' }}
+      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && secrets.F3D_DOCKER_CI_DISPATCH_ == '' }}
       uses: actions/github-script@v3
       with:
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -713,6 +713,7 @@ jobs:
 
     - name: Check wasm image
       id: image_exists_wasm
+      continue-on-error: true
       uses: cloudposse/github-action-docker-image-exists@main
       with:
         registry: ghcr.io
@@ -722,6 +723,7 @@ jobs:
 
     - name: Check android armeabi-v7a image
       id: image_exists_android_armeabi-v7a
+      continue-on-error: true
       uses: cloudposse/github-action-docker-image-exists@main
       with:
         registry: ghcr.io
@@ -731,6 +733,7 @@ jobs:
 
     - name: Check android arm64-v8a image
       id: image_exists_android_arm64-v8a
+      continue-on-error: true
       uses: cloudposse/github-action-docker-image-exists@main
       with:
         registry: ghcr.io
@@ -740,6 +743,7 @@ jobs:
 
     - name: Check android x86 image
       id: image_exists_android_x86
+      continue-on-error: true
       uses: cloudposse/github-action-docker-image-exists@main
       with:
         registry: ghcr.io
@@ -749,6 +753,7 @@ jobs:
 
     - name: Check android x86_64 image
       id: image_exists_android_x86_64
+      continue-on-error: true
       uses: cloudposse/github-action-docker-image-exists@main
       with:
         registry: ghcr.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -711,7 +711,7 @@ jobs:
 
     steps:
 
-    - name: Echo
+    - name: Check docker image exists
       shell: bash {0}
       working-directory: ${{github.workspace}}
       run: |
@@ -730,7 +730,7 @@ jobs:
 
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
     - name: Trigger docker images build
-      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '0'}}
+      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && !secrets.F3D_DOCKER_CI_DISPATCH_ == '' }}
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: f3d-app
@@ -744,7 +744,7 @@ jobs:
         wait_workflow: true
 
     - name: Error out when unable to build docker images
-      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '0'}}
+      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && !secrets.F3D_DOCKER_CI_DISPATCH_ == '' }}
       uses: actions/github-script@v3
       with:
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -761,6 +761,16 @@ jobs:
         repository: "f3d-android-x86_64"
         tag: ${{needs.default_versions.outputs.timestamp}}
 
+    - name: Echo
+      shell: bash
+      working-directory: ${{github.workspace}}
+      run:
+         echo  ${{ steps.image_exists_wasm.conclusion }}
+         echo  ${{ steps.image_exists_armeabi-v7a.conclusion }}
+         echo  ${{ steps.image_exists_arm64-v8a.conclusion }}
+         echo  ${{ steps.image_exists_x86.conclusion }}
+         echo  ${{ steps.image_exists_x86_64.conclusion }}
+
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
     - name: Trigger docker images build
       if: ${{ !steps.image_exists_wasm.conclusion || !steps.image_exists_android_armeabi-v7a.conclusion || !steps.image_exists_android_arm64-v8a.conclusion || !steps.image_exists_android_x86.conclusion || !steps.image_exists_android_x86_64.conclusion }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,7 +712,7 @@ jobs:
     steps:
 
     - name: Echo
-      shell: bash
+      shell: bash {0}
       working-directory: ${{github.workspace}}
       run: |
          docker manifest inspect ghcr.io/f3d-app/f3d-wasm:20250429_0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -732,7 +732,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
         workflow_file_name: build_docker_image.yml 
         wait_interval: 10
-        client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/${{GITHUB_REPOSITORY}}/${{GITHUB_REF}}/.github/workflows/versions.json"}'
+        client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$GITHUB_REF/.github/workflows/versions.json"}'
         propagate_failure: true
         trigger_workflow: true
         wait_workflow: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,7 +715,7 @@ jobs:
       with:
         owner: f3d-app
         repo: f3d-docker-images
-        github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         workflow_file_name: build_docker_image.yml 
         wait_interval: 10
         client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$GITHUB_REF/.github/workflows/versions.json"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -711,21 +711,20 @@ jobs:
 
     steps:
 
-    - name: Check docker image exists
+    - name: Check docker images exists
       shell: bash {0}
       working-directory: ${{github.workspace}}
       run: |
-         docker manifest inspect ghcr.io/f3d-app/f3d-wasm:20250429_0
+         docker manifest inspect ghcr.io/f3d-app/f3d-wasm:${{needs.default_versions.outputs.timestamp}}
          res=$?
-         docker manifest inspect ghcr.io/f3d-app/f3d-android-armeabi-v7a:20250429_0
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-armeabi-v7a:${{needs.default_versions.outputs.timestamp}}
          [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
-         docker manifest inspect ghcr.io/f3d-app/f3d-android-arm64-v8a:20250429_0
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-arm64-v8a:${{needs.default_versions.outputs.timestamp}}
          [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
-         docker manifest inspect ghcr.io/f3d-app/f3d-android-x86:20250429_0
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-x86:${{needs.default_versions.outputs.timestamp}}
          [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
-         docker manifest inspect ghcr.io/f3d-app/f3d-android-x86_64:20250429_0
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-x86_64:${{needs.default_versions.outputs.timestamp}}
          [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
-         echo $res
          echo "F3D_DOCKER_IMAGE_AVAILABLE=$res" >> $GITHUB_ENV
 
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
@@ -739,7 +738,7 @@ jobs:
         repo: f3d-docker-images
         github_token: ${{ secrets.F3D_DOCKER_CI_DISPATCH }}
         workflow_file_name: build_docker_image.yml
-        wait_interval: 10
+        wait_interval: 60
         client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/${{github.repository}}/${{github.ref}}/.github/workflows/versions.json"}'
         propagate_failure: true
         trigger_workflow: true
@@ -751,8 +750,7 @@ jobs:
       if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && env.secret == '' }}
       uses: actions/github-script@v3
       with:
-        script: |
-            core.setFailed('Could not generate missing docker images, reach out to a maintainer')
+        script: core.setFailed('Could not generate missing docker images, reach out to a maintainer')
 
 #----------------------------------------------------------------------------
 # android: Check build of F3D for android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -725,6 +725,18 @@ jobs:
         fetch-depth: 0
         lfs: false
 
+    - uses: convictional/trigger-workflow-and-wait@v1.6.5
+      with:
+        owner: f3d-app
+        repo: f3d-docker-images
+        github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+        workflow_file_name: build_docker_image.yml 
+        wait_interval: 10
+        client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/${{GITHUB_REPOSITORY}}/${{GITHUB_REF}}/.github/workflows/versions.json"}'
+        propagate_failure: true
+        trigger_workflow: true
+        wait_workflow: true
+
     - name: Android CI
       uses: ./source/.github/actions/android-ci
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,7 +730,9 @@ jobs:
 
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
     - name: Trigger docker images build
-      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && secrets.F3D_DOCKER_CI_DISPATCH_ != '' }}
+      env:
+          secret: ${{ secrets.F3D_DOCKER_CI_DISPATCH_ }}
+      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && env.secret != '' }}
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: f3d-app
@@ -744,7 +746,9 @@ jobs:
         wait_workflow: true
 
     - name: Error out when unable to build docker images
-      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && secrets.F3D_DOCKER_CI_DISPATCH_ == '' }}
+      env:
+          secret: ${{ secrets.F3D_DOCKER_CI_DISPATCH_ }}
+      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && env.secret == '' }}
       uses: actions/github-script@v3
       with:
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,7 +718,7 @@ jobs:
         github_token: ${{ secrets.F3D_DOCKER_CI_DISPATCH }}
         workflow_file_name: build_docker_image.yml 
         wait_interval: 10
-        client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$GITHUB_REF/.github/workflows/versions.json"}'
+        client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/${{github.repository}}/${{github.ref}}/.github/workflows/versions.json"}'
         propagate_failure: true
         trigger_workflow: true
         wait_workflow: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -711,6 +711,7 @@ jobs:
 
     steps:
 
+    # {0} is needed to avoid exit on fail
     - name: Check docker images exists
       shell: bash {0}
       working-directory: ${{github.workspace}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,13 +758,7 @@ jobs:
 
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
     - name: Trigger docker images build
-      if: ${{ !secrets.F3D_DOCKER_CI_DISPATCH == '' && (
-        !steps.image_exists_wasm.conclusion ||
-        !steps.image_exists_android_armeabi-v7a.conclusion ||
-        !steps.image_exists_android_arm64-v8a.conclusion ||
-        !steps.image_exists_android_x86.conclusion ||
-        !steps.image_exists_android_x86_64.conclusion
-      ) }}
+      if: ${{ !steps.image_exists_wasm.conclusion || !steps.image_exists_android_armeabi-v7a.conclusion || !steps.image_exists_android_arm64-v8a.conclusion || !steps.image_exists_android_x86.conclusion || !steps.image_exists_android_x86_64.conclusion }}
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: f3d-app
@@ -778,13 +772,7 @@ jobs:
         wait_workflow: true
 
     - name: Error out when unable to build docker images
-      if: ${{ secrets.F3D_DOCKER_CI_DISPATCH == '' && (
-        !steps.image_exists_wasm.conclusion ||
-        !steps.image_exists_android_armeabi-v7a.conclusion ||
-        !steps.image_exists_android_arm64-v8a.conclusion ||
-        !steps.image_exists_android_x86.conclusion ||
-        !steps.image_exists_android_x86_64.conclusion
-      ) }}
+      if: ${{ !steps.image_exists_wasm.conclusion || !steps.image_exists_android_armeabi-v7a.conclusion || !steps.image_exists_android_arm64-v8a.conclusion || !steps.image_exists_android_x86.conclusion || !steps.image_exists_android_x86_64.conclusion }}
       uses: actions/github-script@v3
       with:
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -764,7 +764,7 @@ jobs:
     - name: Echo
       shell: bash
       working-directory: ${{github.workspace}}
-      run:
+      run: |
          echo  ${{ steps.image_exists_wasm.conclusion }}
          echo  ${{ steps.image_exists_armeabi-v7a.conclusion }}
          echo  ${{ steps.image_exists_arm64-v8a.conclusion }}
@@ -773,7 +773,7 @@ jobs:
 
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
     - name: Trigger docker images build
-      if: ${{ !steps.image_exists_wasm.conclusion || !steps.image_exists_android_armeabi-v7a.conclusion || !steps.image_exists_android_arm64-v8a.conclusion || !steps.image_exists_android_x86.conclusion || !steps.image_exists_android_x86_64.conclusion }}
+      if: ${{ steps.image_exists_wasm.conclusion != 'success' }}
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: f3d-app
@@ -787,7 +787,7 @@ jobs:
         wait_workflow: true
 
     - name: Error out when unable to build docker images
-      if: ${{ !steps.image_exists_wasm.conclusion || !steps.image_exists_android_armeabi-v7a.conclusion || !steps.image_exists_android_arm64-v8a.conclusion || !steps.image_exists_android_x86.conclusion || !steps.image_exists_android_x86_64.conclusion }}
+      if: ${{ steps.image_exists_wasm.conclusion != 'success' }}
       uses: actions/github-script@v3
       with:
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -711,69 +711,26 @@ jobs:
 
     steps:
 
-    - name: Check wasm image
-      id: image_exists_wasm
-      continue-on-error: true
-      uses: cloudposse/github-action-docker-image-exists@main
-      with:
-        registry: ghcr.io
-        organization: "f3d-app"
-        repository: "f3d-wasm"
-        tag: ${{needs.default_versions.outputs.timestamp}}
-
-    - name: Check android armeabi-v7a image
-      id: image_exists_android_armeabi-v7a
-      continue-on-error: true
-      uses: cloudposse/github-action-docker-image-exists@main
-      with:
-        registry: ghcr.io
-        organization: "f3d-app"
-        repository: "f3d-android-armeabi-v7a"
-        tag: ${{needs.default_versions.outputs.timestamp}}
-
-    - name: Check android arm64-v8a image
-      id: image_exists_android_arm64-v8a
-      continue-on-error: true
-      uses: cloudposse/github-action-docker-image-exists@main
-      with:
-        registry: ghcr.io
-        organization: "f3d-app"
-        repository: "f3d-android-arm64-v8a"
-        tag: ${{needs.default_versions.outputs.timestamp}}
-
-    - name: Check android x86 image
-      id: image_exists_android_x86
-      continue-on-error: true
-      uses: cloudposse/github-action-docker-image-exists@main
-      with:
-        registry: ghcr.io
-        organization: "f3d-app"
-        repository: "f3d-android-x86"
-        tag: ${{needs.default_versions.outputs.timestamp}}
-
-    - name: Check android x86_64 image
-      id: image_exists_android_x86_64
-      continue-on-error: true
-      uses: cloudposse/github-action-docker-image-exists@main
-      with:
-        registry: ghcr.io
-        organization: "f3d-app"
-        repository: "f3d-android-x86_64"
-        tag: ${{needs.default_versions.outputs.timestamp}}
-
     - name: Echo
       shell: bash
       working-directory: ${{github.workspace}}
       run: |
-         echo  ${{ steps.image_exists_wasm.conclusion }}
-         echo  ${{ steps.image_exists_armeabi-v7a.conclusion }}
-         echo  ${{ steps.image_exists_arm64-v8a.conclusion }}
-         echo  ${{ steps.image_exists_x86.conclusion }}
-         echo  ${{ steps.image_exists_x86_64.conclusion }}
+         docker manifest inspect ghcr.io/f3d-app/f3d-wasm:20250429_0
+         res=$?
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-armeabi-v7a:20250429_0
+         [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-arm64-v8a:20250429_0
+         [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-x86:20250429_0
+         [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-x86_64:20250429_0
+         [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
+         echo $res
+         echo "F3D_DOCKER_IMAGE_AVAILABLE=$res" >> $GITHUB_ENV
 
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
     - name: Trigger docker images build
-      if: ${{ steps.image_exists_wasm.conclusion != 'success' }}
+      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '0'}}
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: f3d-app
@@ -787,7 +744,7 @@ jobs:
         wait_workflow: true
 
     - name: Error out when unable to build docker images
-      if: ${{ steps.image_exists_wasm.conclusion != 'success' }}
+      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '0'}}
       uses: actions/github-script@v3
       with:
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,7 +731,7 @@ jobs:
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
     - name: Trigger docker images build
       env:
-          secret: ${{ secrets.F3D_DOCKER_CI_DISPATCH_ }}
+          secret: ${{ secrets.F3D_DOCKER_CI_DISPATCH }}
       if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && env.secret != '' }}
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
@@ -747,12 +747,12 @@ jobs:
 
     - name: Error out when unable to build docker images
       env:
-          secret: ${{ secrets.F3D_DOCKER_CI_DISPATCH_ }}
+          secret: ${{ secrets.F3D_DOCKER_CI_DISPATCH }}
       if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && env.secret == '' }}
       uses: actions/github-script@v3
       with:
         script: |
-            core.setFailed('Could not generate missing docker images')
+            core.setFailed('Could not generate missing docker images, reach out to a maintainer')
 
 #----------------------------------------------------------------------------
 # android: Check build of F3D for android

--- a/.github/workflows/versions.json
+++ b/.github/workflows/versions.json
@@ -31,5 +31,5 @@
     "java": "17"
   },
   "vtk_commit_sha": "ea8be1be94fa3e6d26196652d34a2e2e012b2b38",
-  "timestamp": "20250428_0"
+  "timestamp": "20250427_0"
 }

--- a/.github/workflows/versions.json
+++ b/.github/workflows/versions.json
@@ -31,5 +31,5 @@
     "java": "17"
   },
   "vtk_commit_sha": "ea8be1be94fa3e6d26196652d34a2e2e012b2b38",
-  "timestamp": "20250427_0"
+  "timestamp": "20250428_0"
 }


### PR DESCRIPTION
### Describe your changes

f3d-docker-images needs to be manually dispatched when changing the timestamp.
This is cumbersome and require manual operation, this automatize this step.

A similar design may allow to enable VTK nightly builds again for android and wasm

Please note this REQUIRES a read/write PAT in a secract named: `F3D_DOCKER_CI_DISPATCH` to be able to run the action.

run with new timestamp (manually cancelled but the dispatch worked):
https://github.com/mwestphal/f3d/actions/runs/14772407617/job/41474602738

run with existing timestamp:
https://github.com/mwestphal/f3d/actions/runs/14772603645/job/41475128549

run without a PAT:
https://github.com/mwestphal/f3d/actions/runs/14772304422/job/41474314912

### Issue ticket number and link if any

related to: https://github.com/f3d-app/f3d/issues/1954

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [x] If it is a modifying the default versions, I have updated timestamp

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM CI
- [x] Android CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
