### PR TITLE
Rework docker image build

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -40,7 +40,7 @@ jobs:
     container: ghcr.io/f3d-app/f3d-ci
     name: Set default versions
     needs: detect_checkboxes
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'CI')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'CI')) }}
     outputs:
       timestamp: ${{ steps.set_default_versions.outputs.timestamp }}
 
@@ -70,9 +70,8 @@ jobs:
 
     steps:
 
-    # {0} is needed to avoid exit on fail
     - name: Check docker images exists
-      shell: bash {0}
+      shell: bash
       working-directory: ${{github.workspace}}
       run: |
          res=0
@@ -85,6 +84,7 @@ jobs:
 
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
     - name: Trigger docker images build
+      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1'}}
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: f3d-app

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,98 @@
+on:
+  pull_request_target:
+    types: [assigned, opened, synchronize, reopened]
+    branches:
+      - master
+      - release
+name: Build docker images
+jobs:
+
+#----------------------------------------------------------------------------
+# Detect checkboxes are checked
+#----------------------------------------------------------------------------
+  detect_checkboxes:
+    name: Detect Checkboxes
+    runs-on: ubuntu-latest
+    outputs:
+      checked: ${{ steps.detect.outputs.checked }}
+      unchecked: ${{ steps.detect.outputs.unchecked }}
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkbox Trigger
+        id: detect
+        uses: AhmedBaset/checklist@3
+        with:
+          token: ${{ github.token }}
+
+      - name: list changes
+        run: |
+          echo "checked=${{ steps.detect.outputs.checked }}"
+          echo "unchecked=${{ steps.detect.outputs.unchecked }}"
+
+#----------------------------------------------------------------------------
+# Default versions: Set default version for all dependencies
+#----------------------------------------------------------------------------
+  default_versions:
+    runs-on: ubuntu-22.04
+    container: ghcr.io/f3d-app/f3d-ci
+    name: Set default versions
+    needs: detect_checkboxes
+    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'CI')) || (github.ref == 'refs/heads/master') }}
+    outputs:
+      timestamp: ${{ steps.set_default_versions.outputs.timestamp }}
+
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+        path: 'source'
+        fetch-depth: 1
+        lfs: false
+
+    - name: Set default versions
+      id: set_default_versions
+      uses: f3d-app/default-versions-action@main
+      with:
+        file: ./source/.github/workflows/versions.json
+
+#----------------------------------------------------------------------------
+# Build android/wasm docker images if needed
+#----------------------------------------------------------------------------
+  build_docker_images:
+    needs: default_versions
+
+    runs-on: ubuntu-22.04
+
+    steps:
+
+    # {0} is needed to avoid exit on fail
+    - name: Check docker images exists
+      shell: bash {0}
+      working-directory: ${{github.workspace}}
+      run: |
+         res=0
+         docker manifest inspect ghcr.io/f3d-app/f3d-wasm:${{needs.default_versions.outputs.timestamp}} || res=$?
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-armeabi-v7a:${{needs.default_versions.outputs.timestamp}} || res=$?
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-arm64-v8a:${{needs.default_versions.outputs.timestamp}} || res=$?
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-x86:${{needs.default_versions.outputs.timestamp}} || res=$?
+         docker manifest inspect ghcr.io/f3d-app/f3d-android-x86_64:${{needs.default_versions.outputs.timestamp}} || res=$?
+         echo "F3D_DOCKER_IMAGE_AVAILABLE=$res" >> $GITHUB_ENV
+
+    # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
+    - name: Trigger docker images build
+      uses: convictional/trigger-workflow-and-wait@v1.6.5
+      with:
+        owner: f3d-app
+        repo: f3d-docker-images
+        github_token: ${{ secrets.F3D_DOCKER_CI_DISPATCH }}
+        workflow_file_name: build_docker_image.yml
+        wait_interval: 60
+        client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/${{github.event.pull_request.head.repo.full_name}}/${{github.event.pull_request.head.ref}}/.github/workflows/versions.json"}'
+        propagate_failure: true
+        trigger_workflow: true
+        wait_workflow: true

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -49,6 +49,8 @@ jobs:
       with:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
+        fetch-depth: 1
+        lfs: false
 
     - name: C++ Formatting
       uses: DoozyX/clang-format-lint-action@v0.16


### PR DESCRIPTION
### Describe your changes

Fixup for https://github.com/f3d-app/f3d/pull/2202 that rely on the build-docker-images workflow run in a pull_request_target workflow instead.

This will let anyone generate new images based on their modification in versions.json

Follow-up PR once this is merged: https://github.com/f3d-app/f3d/pull/2210

Example usage with forks where images are being built (cancelled manually):
 - https://github.com/f3d-app/f3d/actions/runs/14780963675/job/41499655273
 - https://github.com/f3d-app/f3d/actions/runs/14780963188/job/41499660448
 - https://github.com/f3d-app/f3d-docker-images/actions/runs/14780984331
 
 Example usage with forks where images are not being built:
  - https://github.com/f3d-app/f3d/actions/runs/14781289301/job/41500830457
  - https://github.com/f3d-app/f3d/actions/runs/14781289542/job/41500891522
  
  Also fix a small issue with lfs data in style checks.

### Issue ticket number and link if any

Related to : https://github.com/f3d-app/f3d/issues/1954

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [x] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM CI
- [x] Android CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
