### PR TITLE
CI: Wait build docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -711,48 +711,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-
-    # {0} is needed to avoid exit on fail
-    - name: Check docker images exists
-      shell: bash {0}
-      working-directory: ${{github.workspace}}
-      run: |
-         docker manifest inspect ghcr.io/f3d-app/f3d-wasm:${{needs.default_versions.outputs.timestamp}}
-         res=$?
-         docker manifest inspect ghcr.io/f3d-app/f3d-android-armeabi-v7a:${{needs.default_versions.outputs.timestamp}}
-         [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
-         docker manifest inspect ghcr.io/f3d-app/f3d-android-arm64-v8a:${{needs.default_versions.outputs.timestamp}}
-         [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
-         docker manifest inspect ghcr.io/f3d-app/f3d-android-x86:${{needs.default_versions.outputs.timestamp}}
-         [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
-         docker manifest inspect ghcr.io/f3d-app/f3d-android-x86_64:${{needs.default_versions.outputs.timestamp}}
-         [ $? -eq 0 ] && [ $res -eq 0 ] || res=$?
-         echo "F3D_DOCKER_IMAGE_AVAILABLE=$res" >> $GITHUB_ENV
-
-    # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
-    - name: Trigger docker images build
-      env:
-          secret: ${{ secrets.F3D_DOCKER_CI_DISPATCH }}
-      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && env.secret != '' }}
-      uses: convictional/trigger-workflow-and-wait@v1.6.5
+    - name: Wait on build-docker-images workflow
+      uses: ArcticLampyrid/action-wait-for-workflow@v1.2.0
       with:
-        owner: f3d-app
-        repo: f3d-docker-images
-        github_token: ${{ secrets.F3D_DOCKER_CI_DISPATCH }}
-        workflow_file_name: build_docker_image.yml
-        wait_interval: 60
-        client_payload: '{"versions_file_url": "https://raw.githubusercontent.com/${{github.repository}}/${{github.ref}}/.github/workflows/versions.json"}'
-        propagate_failure: true
-        trigger_workflow: true
-        wait_workflow: true
-
-    - name: Error out when unable to build docker images
-      env:
-          secret: ${{ secrets.F3D_DOCKER_CI_DISPATCH }}
-      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1' && env.secret == '' }}
-      uses: actions/github-script@v3
-      with:
-        script: core.setFailed('Could not generate missing docker images, reach out to a maintainer')
+        workflow: build-docker-images.yml
+        allowed-conclusions: success
 
 #----------------------------------------------------------------------------
 # android: Check build of F3D for android


### PR DESCRIPTION
### Describe your changes

Remove incorrect job from CI.yml and instead wait for build_docker_image.yml to finish

### Issue ticket number and link if any

Related to : https://github.com/f3d-app/f3d/issues/1954

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [x] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM CI
- [x] Android CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
