### PR TITLE
CI: Update VTK to c98d9333f0bce02aad2c5c8c4fcc2364202e55ba

### DIFF
--- a/.github/workflows/versions.json
+++ b/.github/workflows/versions.json
@@ -30,6 +30,6 @@
     "usd": "v24.08",
     "java": "17"
   },
-  "vtk_commit_sha": "ea8be1be94fa3e6d26196652d34a2e2e012b2b38",
-  "timestamp": "20250427_0"
+  "vtk_commit_sha": "c98d9333f0bce02aad2c5c8c4fcc2364202e55ba",
+  "timestamp": "20250502_0"
 }


### PR DESCRIPTION
### Describe your changes

Update VTK used for CI and packaging purpose to c98d9333f0bce02aad2c5c8c4fcc2364202e55ba

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [x] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM CI
- [x] Android CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
