### PR TITLE
CI: Fix a small issue when running docker image check on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -710,8 +710,10 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    # Pull request can require a rebuild of docker image, wait for it to be done
     steps:
     - name: Wait on build-docker-images workflow
+      if: ${{ github.event_name == 'pull_request' }}
       uses: ArcticLampyrid/action-wait-for-workflow@v1.2.0
       with:
         workflow: build-docker-images.yml


### PR DESCRIPTION
### Describe your changes

With the merge of https://github.com/f3d-app/f3d/pull/2210, there is now a wait for the docker images being built.
However, this wait only makes sense on pull requests, not on push.

### Issue ticket number and link if any

Related to: https://github.com/f3d-app/f3d/issues/1954

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [x] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM CI
- [x] Android CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
