### PR TITLE
improve non-trackball interactor rotation

### DIFF
--- a/testing/baselines/TestInteractionFocalPointPickingDefault.png
+++ b/testing/baselines/TestInteractionFocalPointPickingDefault.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:605d78e398b54a2521a2b2b29d92965fd608c9ad72c108cb828081cfef3ceb61
-size 21362
+oid sha256:125d2b1474e2850c79668b08f40babbb86ffac5fdb9822912aa69bd48ec212df
+size 22574

--- a/testing/baselines/TestInteractionFocalPointPickingPoints.png
+++ b/testing/baselines/TestInteractionFocalPointPickingPoints.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d4ce65caec94f45478f8db08e72fcd9cbaa03669ac11fd5b6d19df586ecf634
-size 1002
+oid sha256:85e476d78e6a29a0fb7d06a9c6fbc56c4f21af43a801dee755885c35a2d6b90b
+size 1018

--- a/testing/baselines/TestInteractionFocalPointPickingShift.png
+++ b/testing/baselines/TestInteractionFocalPointPickingShift.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf1dd9832e992f914d4d9be5b3ba2bbedfc5c7339caa16a04e353a7b3db643c5
-size 29180
+oid sha256:577033b9653db9299dd70396721e52a94ba33f414ec9e700023121aca759068f
+size 30923

--- a/testing/baselines/TestInteractionRollCameraRotation.png
+++ b/testing/baselines/TestInteractionRollCameraRotation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d00f18a435046a5a298981c3bf6684edaa22e02957e0b4c7de0ee3500ea1c582
-size 15385
+oid sha256:989a4ed1f623eb625ea521f46939b042494a6429d8cb46f860d0de802bb852e6
+size 13761

--- a/testing/baselines/TestInteractionSwitchFileNextCameraKeeping.png
+++ b/testing/baselines/TestInteractionSwitchFileNextCameraKeeping.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec57fabc78d2259ce74deabb86eec84f769795a792c076aa491f50005d5810ab
-size 9361
+oid sha256:bee1139110e74f5a92949313bfe285396268f5bcd22d773ebb185ae8e1c36211
+size 9366

--- a/testing/baselines/TestInteractionSwitchFilePrevCameraKeeping.png
+++ b/testing/baselines/TestInteractionSwitchFilePrevCameraKeeping.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec57fabc78d2259ce74deabb86eec84f769795a792c076aa491f50005d5810ab
-size 9361
+oid sha256:bee1139110e74f5a92949313bfe285396268f5bcd22d773ebb185ae8e1c36211
+size 9366

--- a/vtkext/private/module/vtkF3DInteractorStyle.cxx
+++ b/vtkext/private/module/vtkF3DInteractorStyle.cxx
@@ -5,12 +5,14 @@
 
 #include <vtkCamera.h>
 #include <vtkMath.h>
+#include <vtkNew.h>
 #include <vtkObjectFactory.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkRendererCollection.h>
 #include <vtkSkybox.h>
 #include <vtkStringArray.h>
+#include <vtkTransform.h>
 
 vtkStandardNewMacro(vtkF3DInteractorStyle);
 
@@ -156,27 +158,29 @@ void vtkF3DInteractorStyle::Rotate()
   this->InterpolateTemporaryUp(0.1, up);
   up = this->TemporaryUp;
 
-  double dot = vtkMath::Dot(dir, up);
-
-  bool canElevate = ren->GetUseTrackball() || std::abs(dot) < 0.99 || !std::signbit(dot * ryf);
-
-  camera->Azimuth(rxf);
-
-  if (canElevate)
-  {
-    camera->Elevation(ryf);
-  }
-
   if (!ren->GetUseTrackball())
   {
-    // orthogonalize up vector based on focal direction
-    vtkMath::MultiplyScalar(dir, dot);
-    vtkMath::Subtract(up, dir, dir);
-    vtkMath::Normalize(dir);
-    camera->SetViewUp(dir);
+    // Rotate camera around the focal point about the environment's up vector
+    vtkNew<vtkTransform> Transform;
+    Transform->Identity();
+    const double* fp = camera->GetFocalPoint();
+    Transform->Translate(+fp[0], +fp[1], +fp[2]);
+    Transform->RotateWXYZ(rxf, ren->GetUpVector());
+    Transform->Translate(-fp[0], -fp[1], -fp[2]);
+    Transform->TransformPoint(camera->GetPosition(), camera->GetPosition());
+
+    camera->SetViewUp(up);
+    double dot = vtkMath::Dot(dir, up);
+    if (std::abs(dot) < 0.99 || !std::signbit(dot * ryf))
+    {
+      camera->Elevation(ryf);
+    }
+    camera->OrthogonalizeViewUp();
   }
   else
   {
+    camera->Azimuth(rxf);
+    camera->Elevation(ryf);
     camera->OrthogonalizeViewUp();
   }
 

--- a/vtkext/private/module/vtkF3DInteractorStyle.cxx
+++ b/vtkext/private/module/vtkF3DInteractorStyle.cxx
@@ -170,7 +170,7 @@ void vtkF3DInteractorStyle::Rotate()
     Transform->TransformPoint(camera->GetPosition(), camera->GetPosition());
 
     camera->SetViewUp(up);
-    double dot = vtkMath::Dot(dir, up);
+    const double dot = vtkMath::Dot(dir, up);
     if (std::abs(dot) < 0.99 || !std::signbit(dot * ryf))
     {
       camera->Elevation(ryf);


### PR DESCRIPTION
### Describe your changes

Unfactor trackball and non-trackball cases in `vtkF3DInteractorStyle::Rotate()` because we shouldn't use `camera->Azimuth()` for both.
In the non-trackball case we should "manually" rotate the camera around the focal point about the environment's up vector instead.

This one is going to need some manual validation as the tests cannot capture the animated nature of the issue/fix.

Here are before and after captures of [the interaction log from the original issue](https://github.com/user-attachments/files/20014647/f3d-horizontal-dragging.log):

https://github.com/user-attachments/assets/97a80871-e361-4b05-8e75-1f5633bef065

https://github.com/user-attachments/assets/cb361934-e529-4715-ad27-8cd0a5b82d18

I'm assuming the baseline changes are due to this PR fixing the elevation drift in addition to the shakiness.


### Issue ticket number and link if any

Would fix #2216

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
