### PR TITLE
CI: Fix VTK nightly build docker images

### DIFF
--- a/.github/workflows/nightly_vtk_master.yml
+++ b/.github/workflows/nightly_vtk_master.yml
@@ -323,7 +323,6 @@ jobs:
 
     # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
     - name: Trigger docker images build
-      if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1'}}
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: f3d-app


### PR DESCRIPTION
### Describe your changes

Recently added VTK nightly had some issues with build_docker_images logic, this fixes it.

### Issue ticket number and link if any

Related to https://github.com/f3d-app/f3d/issues/1954

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [x] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [ ] Fast CI
- [ ] Coverage cached CI
- [ ] Analysis cached CI
- [ ] WASM docker CI
- [ ] Android docker CI
- [ ] macOS Intel cached CI
- [ ] macOS ARM cached CI
- [ ] Windows cached CI
- [ ] Linux cached CI
- [ ] Other cached CI
