### PR TITLE
CI: Cache VTK dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,10 +178,75 @@ jobs:
         usd_version: ${{matrix.usd_version}}
 
 #----------------------------------------------------------------------------
+# Cache VTK Dependency: Checkout and compile VTK if not cached
+#----------------------------------------------------------------------------
+  cache_vtk_dependency:
+    name: Cache VTK dependency
+    needs: [default_versions, detect_checkboxes, cache_dependencies]
+    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'cached CI')) || (github.ref == 'refs/heads/master') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-latest, macos-13, macos-14]
+        vtk_version: ["${{needs.default_versions.outputs.vtk_commit_sha}}", v9.4.2, v9.3.1, v9.2.6]
+        build_type: [standard]
+        exclude:
+          - os: macos-13
+            vtk_version: v9.3.1
+          - os: macos-13
+            vtk_version: v9.2.6
+          - os: macos-14
+            vtk_version: v9.3.1
+          - os: macos-14
+            vtk_version: v9.2.6
+        include:
+          - cpu: x86_64
+          - raytracing_label: raytracing
+          - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+          - os: macos-14
+            cpu: arm64
+          - build_type: mindeps
+            os: ubuntu-22.04
+            vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
+            cpu: x86_64
+            raytracing_label: raytracing
+            openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
+          - build_type: no_optional_deps
+            os: ubuntu-22.04
+            vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
+            cpu: x86_64
+            raytracing_label: no-raytracing
+          - build_type: no_raytracing
+            os: ubuntu-22.04
+            vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
+            cpu: x86_64
+            raytracing_label: no-raytracing
+            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
+
+    runs-on: ${{matrix.os}}
+    container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        path: 'source'
+        fetch-depth: 1
+        lfs: false
+
+    - name: VTK dependency
+      uses: ./source/.github/actions/vtk-install-dep
+      with:
+        vtk_version: ${{matrix.vtk_version}}
+        raytracing_label: ${{matrix.raytracing_label}}
+        cpu: ${{matrix.cpu}}
+        openvdb_version: ${{matrix.openvdb_version}}
+
+#----------------------------------------------------------------------------
 # Windows CI: Build and test, cross-vtk build matrix
 #----------------------------------------------------------------------------
   windows:
-    needs: [cache_lfs, cache_dependencies, default_versions, detect_checkboxes]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Windows cached CI')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
@@ -257,7 +322,7 @@ jobs:
 # Linux CI: Build and test, cross-vtk build matrix
 #----------------------------------------------------------------------------
   linux:
-    needs: [cache_lfs, cache_dependencies, default_versions, detect_checkboxes]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Linux cached CI')) || (github.ref == 'refs/heads/master') }}
 
     strategy:
@@ -414,7 +479,7 @@ jobs:
 # MacOS CI: Build and test, cross-vtk build matrix
 #----------------------------------------------------------------------------
   macos:
-    needs: [cache_lfs, cache_dependencies, default_versions, detect_checkboxes]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'macOS Intel cached CI')) || (github.ref == 'refs/heads/master') }}
 
     strategy:
@@ -453,7 +518,7 @@ jobs:
 # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
 #----------------------------------------------------------------------------
   macos_arm:
-    needs: [cache_lfs, cache_dependencies, default_versions, detect_checkboxes]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'macOS ARM cached CI')) || (github.ref == 'refs/heads/master') }}
 
     strategy:
@@ -503,7 +568,7 @@ jobs:
 # Python packaging: Build and test the Python wheel
 #----------------------------------------------------------------------------
   python-packaging:
-    needs: [cache_lfs, cache_dependencies, default_versions, detect_checkboxes]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Other cached CI')) || (github.ref == 'refs/heads/master') }}
 
     strategy:
@@ -557,7 +622,7 @@ jobs:
 # Coverage: Build and test on linux with last VTK with coverage option
 #----------------------------------------------------------------------------
   coverage:
-    needs: [cache_lfs, cache_dependencies, default_versions, detect_checkboxes]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Coverage cached CI')) || (github.ref == 'refs/heads/master') }}
 
     runs-on: ubuntu-22.04
@@ -598,7 +663,7 @@ jobs:
 # "memory" returns false positives in VTK:
 # https://stackoverflow.com/questions/60097307/memory-sanitizer-reports-use-of-uninitialized-value-in-global-object-constructio
   sanitizer:
-    needs: [cache_lfs, cache_dependencies, default_versions, detect_checkboxes]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Other cached CI')) || (github.ref == 'refs/heads/master') }}
 
     strategy:
@@ -640,7 +705,7 @@ jobs:
 # static-analysis: Run static analysis on linux
 #----------------------------------------------------------------------------
   static-analysis:
-    needs: [cache_lfs, cache_dependencies, default_versions, detect_checkboxes]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Analysis cached CI')) || (github.ref == 'refs/heads/master') }}
 
     strategy:
@@ -679,7 +744,7 @@ jobs:
 # external-build: Check build of F3D as sub-project
 #----------------------------------------------------------------------------
   external-build:
-    needs: [cache_dependencies, default_versions, detect_checkboxes]
+    needs: [cache_vtk_dependency, default_versions, detect_checkboxes]
     if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Other cached CI')) || (github.ref == 'refs/heads/master') }}
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,26 @@ jobs:
         fetch-depth: 1
         lfs: false
 
+    - name: Dependencies Dir
+      shell: bash
+      working-directory: ${{github.workspace}}
+      run: |
+        mkdir dependencies
+        cd dependencies
+        mkdir install
+
+    - name: Install VTK dependencies
+      uses: ./source/.github/actions/vtk-dependencies
+      with:
+        cpu: ${{matrix.cpu}}
+        openvdb_version: ${{matrix.openvdb_version}}
+
+    - name: Install Raytracing Dependencies
+      if: inputs.raytracing_label == 'raytracing'
+      uses: ./source/.github/actions/ospray-sb-install-dep
+      with:
+        cpu: ${{matrix.cpu}}
+
     - name: VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
         openvdb_version: ${{matrix.openvdb_version}}
 
     - name: Install Raytracing Dependencies
-      if: inputs.raytracing_label == 'raytracing'
+      if: matrix.raytracing_label == 'raytracing'
       uses: ./source/.github/actions/ospray-sb-install-dep
       with:
         cpu: ${{matrix.cpu}}


### PR DESCRIPTION
### Describe your changes

When change VTK version or VTK build option, VTK cache needs to be rebuild, which takes a long time and is duplicated accross jobs. Lets create a dedicated caching job that will ensure VTK caches are ready to use before the actual CI jobs.

### Issue ticket number and link if any

Related to: #194 

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
