### PR TITLE
remove warning for insignificant animation time differences

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -750,8 +750,10 @@ if(F3D_PLUGIN_BUILD_HDF)
   f3d_test(NAME TestNoRenderAnimation DATA small.ex2 ARGS  --load-plugins=hdf --animation-time=0.003 REGEXP "-994.473, 33.9259" NO_RENDER)
 
   # Test animation time clamping
-  f3d_test(NAME TestAnimationTimeLimitsHigh DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=10)
-  f3d_test(NAME TestAnimationTimeLimitsLow DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=-5)
+  f3d_test(NAME TestAnimationTimeLimitsHigh DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=10 REGEXP "Animation time 10 is outside of range")
+  f3d_test(NAME TestAnimationTimeLimitsLow DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=-5 REGEXP "Animation time -5 is outside of range")
+  f3d_test(NAME TestAnimationTimeLimitsHighNoWarning DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=0.0043001 REGEXP_FAIL "outside of range" NO_RENDER)
+  f3d_test(NAME TestAnimationTimeLimitsLowNoWarning DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=-0.000001 REGEXP_FAIL "outside of range" NO_RENDER)
 
   # Test if negative range is respected when loading a file without specifying the animation time
   f3d_test(NAME TestTimeRangeLessThanZeroNoAnimationTime DATA negative_range_animated.e ARGS -s --load-plugins=hdf)

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -750,8 +750,8 @@ if(F3D_PLUGIN_BUILD_HDF)
   f3d_test(NAME TestNoRenderAnimation DATA small.ex2 ARGS  --load-plugins=hdf --animation-time=0.003 REGEXP "-994.473, 33.9259" NO_RENDER)
 
   # Test animation time clamping
-  f3d_test(NAME TestAnimationTimeLimitsHigh DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=10 REGEXP "Animation time 10 is outside of range")
-  f3d_test(NAME TestAnimationTimeLimitsLow DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=-5 REGEXP "Animation time -5 is outside of range")
+  f3d_test(NAME TestAnimationTimeLimitsHigh DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=10)
+  f3d_test(NAME TestAnimationTimeLimitsLow DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=-5)
   f3d_test(NAME TestAnimationTimeLimitsHighNoWarning DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=0.0043001 REGEXP_FAIL "outside of range" NO_RENDER)
   f3d_test(NAME TestAnimationTimeLimitsLowNoWarning DATA small.ex2 ARGS ARGS --load-plugins=hdf --animation-time=-0.000001 REGEXP_FAIL "outside of range" NO_RENDER)
 

--- a/library/src/animationManager.cxx
+++ b/library/src/animationManager.cxx
@@ -192,19 +192,26 @@ bool animationManager::LoadAtTime(double timeValue)
   }
 
   /* clamp target time to available range */
+  // 1 microsecond tolerance so we don't log messages if times are insignificantly close
+  constexpr double epsilon = 1e-6;
   if (timeValue < this->TimeRange[0])
   {
-    log::warn("Animation time ", timeValue, " is outside of range [", this->TimeRange[0], ", ",
-      this->TimeRange[1], "], using ", this->TimeRange[0], ".");
+    if (this->TimeRange[0] - timeValue > epsilon)
+    {
+      log::warn("Animation time ", timeValue, " is outside of range [", this->TimeRange[0], ", ",
+        this->TimeRange[1], "], using ", this->TimeRange[0], ".");
+    }
     timeValue = this->TimeRange[0];
   }
   else if (timeValue > this->TimeRange[1])
   {
-    log::warn("Animation time ", timeValue, " is outside of range [", this->TimeRange[0], ", ",
-      this->TimeRange[1], "], using ", this->TimeRange[1], ".");
+    if (timeValue - this->TimeRange[1] > epsilon)
+    {
+      log::warn("Animation time ", timeValue, " is outside of range [", this->TimeRange[0], ", ",
+        this->TimeRange[1], "], using ", this->TimeRange[1], ".");
+    }
     timeValue = this->TimeRange[1];
   }
-
   this->CurrentTime = timeValue;
   this->CurrentTimeSet = true;
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 20240707)


### PR DESCRIPTION
### Describe your changes

Check if the time difference is significant before logging a warning.

The `Animation time 0.1 is outside of range [0.1, 17.1], using 0.1.` case we observed was due to the file format storing the model times as `float` while the app stores the user-provided time as `double` leading to a `0.100000000000000005551 < 0.100000001490116119385` comparison which doesn't warrant a warning especially if the values are rounded and indistinguishable to the user.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
