### PR TITLE
doc: Update build instructions as vtk version support can be misleading

### DIFF
--- a/doc/dev/GETTING_STARTED.md
+++ b/doc/dev/GETTING_STARTED.md
@@ -29,7 +29,7 @@ sudo apt upgrade
 sudo apt install build-essential git git-lfs cmake libvtk9-dev
 ```
 
-Note: Ubuntu 24.04 provides VTK version 9.1 but f3d requires VTK 9.2.6 at minimum, so building and installing vtk from source is suggested. Windows build instructions make those steps clearer.
+Note: Ubuntu 24.04 / Debian 12 provides VTK version 9.1 but f3d requires VTK 9.2.6 at minimum, so building and installing vtk from source is suggested. Look at Windows build instruction for inspiration if needed.
 
 #### Fedora/Centos/RedHat
 

--- a/doc/dev/GETTING_STARTED.md
+++ b/doc/dev/GETTING_STARTED.md
@@ -29,6 +29,8 @@ sudo apt upgrade
 sudo apt install build-essential git git-lfs cmake libvtk9-dev
 ```
 
+Note: Ubuntu 24.04 provides VTK version 9.1 but f3d requires VTK 9.2.6 at minimum, so building and installing vtk from source is suggested. Windows build instructions make those steps clearer.
+
 #### Fedora/Centos/RedHat
 
 ```


### PR DESCRIPTION
### Describe your changes

Ubuntu 24.04 provides VTK version 9.1 by default but f3d requires VTK 9.2.6 at minimum, so following the build instructions will give potential cmake errors for unsupported versions.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [x] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [ ] Fast CI
- [ ] Coverage cached CI
- [ ] Analysis cached CI
- [ ] WASM docker CI
- [ ] Android docker CI
- [ ] macOS Intel cached CI
- [ ] macOS ARM cached CI
- [ ] Windows cached CI
- [ ] Linux cached CI
- [ ] Other cached CI
