### PR TITLE
add default values to `CameraState`'s `__init__`

### DIFF
--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -315,7 +315,9 @@ PYBIND11_MODULE(pyf3d, module)
     .def(py::init<>())
     .def(py::init<const f3d::point3_t&, const f3d::point3_t&, const f3d::vector3_t&,
            const f3d::angle_deg_t&>(),
-      py::arg("position"), py::arg("focal_point"), py::arg("view_up"), py::arg("view_angle"))
+      py::arg("position") = f3d::point3_t({ 0., 0., 1. }),
+      py::arg("focal_point") = f3d::point3_t({ 0., 0., 0. }),
+      py::arg("view_up") = f3d::vector3_t({ 0, 1, 0 }), py::arg("view_angle") = 30.)
     .def_readwrite("position", &f3d::camera_state_t::position)
     .def_readwrite("focal_point", &f3d::camera_state_t::focalPoint)
     .def_readwrite("view_up", &f3d::camera_state_t::viewUp)

--- a/python/testing/test_camera.py
+++ b/python/testing/test_camera.py
@@ -63,6 +63,34 @@ def test_default_state():
     assert new_state.view_angle == 30
 
 
+def test_state_init():
+    default_state = f3d.CameraState()
+
+    s1 = f3d.CameraState((1, 2, 3))
+    assert s1.position == (1, 2, 3)
+    assert s1.focal_point == default_state.focal_point
+    assert s1.view_up == default_state.view_up
+    assert s1.view_angle == default_state.view_angle
+
+    s2 = f3d.CameraState(focal_point=(1, 2, 3))
+    assert s2.position == default_state.position
+    assert s2.focal_point == (1, 2, 3)
+    assert s2.view_up == default_state.view_up
+    assert s2.view_angle == default_state.view_angle
+
+    s3 = f3d.CameraState(view_up=(1, 2, 3))
+    assert s3.position == default_state.position
+    assert s3.focal_point == default_state.focal_point
+    assert s3.view_up == (1, 2, 3)
+    assert s3.view_angle == default_state.view_angle
+
+    s4 = f3d.CameraState(view_angle=12.3)
+    assert s4.position == default_state.position
+    assert s4.focal_point == default_state.focal_point
+    assert s4.view_up == default_state.view_up
+    assert s4.view_angle == 12.3
+
+
 @pytest.mark.xfail(reason="CameraState equality not implemented")
 def test_state_compare():
     state1 = f3d.CameraState((1, 2, 3), (1, 22, 3), (0, 0, 1), 32)


### PR DESCRIPTION
### Describe your changes

Python constructor for `CameraState` didn't have default values so it would need to have either no or all arguments passed.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
