### PR TITLE
Support rendering AMR Datasets

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -725,6 +725,7 @@ endif()
 if(F3D_PLUGIN_BUILD_HDF)
   if (VTK_VERSION VERSION_GREATER_EQUAL 9.3.0)
     f3d_test(NAME TestVTKHDF DATA blob.vtkhdf ARGS --load-plugins=hdf -s)
+    f3d_test(NAME TestAMRDataSet DATA amr.vtkhdf ARGS --load-plugins=hdf -s)
   endif()
 
   f3d_test(NAME TestExodus DATA disk_out_ref.ex2 ARGS --load-plugins=hdf -s --camera-position=-11,-2,-49)

--- a/testing/baselines/TestAMRDataSet.png
+++ b/testing/baselines/TestAMRDataSet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d498c4df2ea4d176e0f6855cc3508a3e28eb3af4787690fbce7abf99b3748d3
+size 31241

--- a/testing/data/amr.vtkhdf
+++ b/testing/data/amr.vtkhdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85cc9cb688a76ec74b4f9b1561458036ab16ea60dc88d382674512672ee31d6c
+size 65648

--- a/vtkext/private/module/vtkF3DPostProcessFilter.cxx
+++ b/vtkext/private/module/vtkF3DPostProcessFilter.cxx
@@ -3,9 +3,9 @@
 #include "F3DLog.h"
 
 #include <vtkAppendPolyData.h>
+#include <vtkCompositeDataIterator.h>
+#include <vtkCompositeDataSet.h>
 #include <vtkDataObject.h>
-#include <vtkDataObjectTree.h>
-#include <vtkDataObjectTreeIterator.h>
 #include <vtkDataSetSurfaceFilter.h>
 #include <vtkImageData.h>
 #include <vtkImageToPoints.h>
@@ -38,16 +38,14 @@ int vtkF3DPostProcessFilter::RequestData(vtkInformation* vtkNotUsed(request),
   vtkPolyData* outputPoints = vtkPolyData::GetData(outputVector, 1);
   vtkImageData* outputImage = vtkImageData::GetData(outputVector, 2);
 
-  vtkDataObjectTree* composite = vtkDataObjectTree::SafeDownCast(dataObject);
+  vtkCompositeDataSet* composite = vtkCompositeDataSet::SafeDownCast(dataObject);
   vtkSmartPointer<vtkDataSet> dataset = vtkDataSet::SafeDownCast(dataObject);
 
   // Extract data from a composite dataset
   if (composite)
   {
-    auto iter = vtkSmartPointer<vtkDataObjectTreeIterator>::Take(composite->NewTreeIterator());
-    iter->VisitOnlyLeavesOn();
+    auto iter = vtkSmartPointer<vtkCompositeDataIterator>::Take(composite->NewIterator());
     iter->SkipEmptyNodesOn();
-    iter->TraverseSubTreeOn();
 
     // If it contains a single leaf, extract it as is
     int nLeaf = 0;
@@ -57,7 +55,7 @@ int vtkF3DPostProcessFilter::RequestData(vtkInformation* vtkNotUsed(request),
       nLeaf++;
     }
 
-    // If multiple leafs, extract all surfaces and append them together
+    // If multiple leaves, extract all surfaces and append them together
     if (nLeaf > 1)
     {
       vtkNew<vtkAppendPolyData> append;
@@ -160,7 +158,7 @@ int vtkF3DPostProcessFilter::RequestData(vtkInformation* vtkNotUsed(request),
 int vtkF3DPostProcessFilter::FillInputPortInformation(int vtkNotUsed(port), vtkInformation* info)
 {
   info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
-  info->Append(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataObjectTree");
+  info->Append(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkCompositeDataSet");
   return 1;
 }
 


### PR DESCRIPTION
### Describe your changes

Use `vtkCompositeDataIterator` instead of `vtkDataObjectTreeIterator` to allow processing composite data types that are not object trees, such as AMR classes. The processing we do using the object tree iterator is not using the tree structure, so changing to a composite iterator should yield the same result for existing composite types (multi-block, PDC, etc.)

### Issue ticket number and link if any

close  #2199 

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [x] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
