### PR TITLE
fix temporary up vector convergence

### DIFF
--- a/testing/baselines/TestInteractionDragRotateVertical.png
+++ b/testing/baselines/TestInteractionDragRotateVertical.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7acebf8e8ace89c273c86445ccb179a9461c338ed59b383e9d59070de56d290
-size 39544
+oid sha256:ed6541ad0ce8046d0a4e920f44be48271df9eaac287ba59d0314f2fb46800a70
+size 42506

--- a/testing/baselines/TestInteractionDragRotateVertical.png
+++ b/testing/baselines/TestInteractionDragRotateVertical.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ed6541ad0ce8046d0a4e920f44be48271df9eaac287ba59d0314f2fb46800a70
-size 42506
+oid sha256:a44e78a851e188f8668df3c1a1720b7677db0efea3e2efd4d63ee10e8746371b
+size 42395

--- a/testing/baselines/TestInteractionDragRotateVertical.png
+++ b/testing/baselines/TestInteractionDragRotateVertical.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a44e78a851e188f8668df3c1a1720b7677db0efea3e2efd4d63ee10e8746371b
-size 42395
+oid sha256:d7acebf8e8ace89c273c86445ccb179a9461c338ed59b383e9d59070de56d290
+size 39544

--- a/testing/baselines/TestInteractionRollCameraRotation.png
+++ b/testing/baselines/TestInteractionRollCameraRotation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:989a4ed1f623eb625ea521f46939b042494a6429d8cb46f860d0de802bb852e6
-size 13761
+oid sha256:8d137e0861c6ebea48925599f3392712acd9f0d236bcfa86dd71af0747c71f43
+size 10601

--- a/vtkext/private/module/vtkF3DInteractorStyle.cxx
+++ b/vtkext/private/module/vtkF3DInteractorStyle.cxx
@@ -367,7 +367,7 @@ void vtkF3DInteractorStyle::SetTemporaryUp(const double* tempUp)
 void vtkF3DInteractorStyle::InterpolateTemporaryUp(
   const double factorDelta, const double* target, double* output)
 {
-  this->TemporaryUpFactor = std::max(TemporaryUpFactor - factorDelta, 0.0);
+  this->TemporaryUpFactor = std::max(this->TemporaryUpFactor - factorDelta, 0.0);
   if (this->TemporaryUpFactor >= 0)
   {
     const double factor = (1 - std::cos(vtkMath::Pi() * this->TemporaryUpFactor)) / 2;

--- a/vtkext/private/module/vtkF3DInteractorStyle.cxx
+++ b/vtkext/private/module/vtkF3DInteractorStyle.cxx
@@ -152,14 +152,12 @@ void vtkF3DInteractorStyle::Rotate()
   double ryf = dy * delta_elevation * this->MotionFactor;
 
   vtkCamera* camera = ren->GetActiveCamera();
-  double dir[3];
-  camera->GetDirectionOfProjection(dir);
-  double* up = ren->GetUpVector();
-  this->InterpolateTemporaryUp(0.1, up);
-  up = this->TemporaryUp;
 
   if (!ren->GetUseTrackball())
   {
+    double up[3];
+    this->InterpolateTemporaryUp(0.1, ren->GetUpVector(), up);
+
     // Rotate camera around the focal point about the environment's up vector
     vtkNew<vtkTransform> Transform;
     Transform->Identity();
@@ -362,14 +360,21 @@ void vtkF3DInteractorStyle::SetTemporaryUp(const double* tempUp)
   {
     this->TemporaryUp[i] = tempUp[i];
   }
+  this->TemporaryUpFactor = 1;
 }
 
 //------------------------------------------------------------------------------
-void vtkF3DInteractorStyle::InterpolateTemporaryUp(double factor, const double* input)
+void vtkF3DInteractorStyle::InterpolateTemporaryUp(
+  const double factorDelta, const double* target, double* output)
 {
-  for (int i = 0; i < 3; i++)
+  this->TemporaryUpFactor = std::max(TemporaryUpFactor - factorDelta, 0.0);
+  if (this->TemporaryUpFactor >= 0)
   {
-    this->TemporaryUp[i] = (1.0 - factor) * this->TemporaryUp[i] + factor * input[i];
+    const double factor = (1 - std::cos(vtkMath::Pi() * this->TemporaryUpFactor)) / 2;
+    for (int i = 0; i < 3; i++)
+    {
+      output[i] = factor * this->TemporaryUp[i] + (1.0 - factor) * target[i];
+    }
+    vtkMath::Normalize(output);
   }
-  vtkMath::Normalize(this->TemporaryUp);
 }

--- a/vtkext/private/module/vtkF3DInteractorStyle.cxx
+++ b/vtkext/private/module/vtkF3DInteractorStyle.cxx
@@ -360,7 +360,7 @@ void vtkF3DInteractorStyle::SetTemporaryUp(const double* tempUp)
   {
     this->TemporaryUp[i] = tempUp[i];
   }
-  this->TemporaryUpFactor = 1;
+  this->TemporaryUpFactor = 1.0;
 }
 
 //------------------------------------------------------------------------------
@@ -370,7 +370,7 @@ void vtkF3DInteractorStyle::InterpolateTemporaryUp(
   this->TemporaryUpFactor = std::max(this->TemporaryUpFactor - factorDelta, 0.0);
   if (this->TemporaryUpFactor >= 0)
   {
-    const double factor = (1 - std::cos(vtkMath::Pi() * this->TemporaryUpFactor)) / 2;
+    const double factor = (1.0 - std::cos(vtkMath::Pi() * this->TemporaryUpFactor)) * 0.5;
     for (int i = 0; i < 3; i++)
     {
       output[i] = factor * this->TemporaryUp[i] + (1.0 - factor) * target[i];

--- a/vtkext/private/module/vtkF3DInteractorStyle.h
+++ b/vtkext/private/module/vtkF3DInteractorStyle.h
@@ -136,7 +136,7 @@ protected:
   /**
    * Interpolation state for `TemporaryUp`
    */
-  double TemporaryUpFactor = 1;
+  double TemporaryUpFactor = 1.0;
 };
 
 #endif

--- a/vtkext/private/module/vtkF3DInteractorStyle.h
+++ b/vtkext/private/module/vtkF3DInteractorStyle.h
@@ -107,13 +107,21 @@ public:
   void FindPokedRenderer(int vtkNotUsed(x), int vtkNotUsed(y));
 
   /**
-   * Temporary up vector to support rolled camera interaction
+   * Reset temporary up vector to renderer's up direction to support rolled camera interaction.
    */
   void ResetTemporaryUp();
+  /**
+   * Set temporary up vector to support rolled camera interaction.
+   */
   void SetTemporaryUp(const double* tempUp);
-  void InterpolateTemporaryUp(const double factor, const double* input);
 
 protected:
+  /**
+   * Decrement `TemporaryUpFactor` by `factorDelta`
+   * and use it to interpolate `output` between `TemporaryUp` and `target`.
+   */
+  void InterpolateTemporaryUp(const double factorDelta, const double* target, double* output);
+
   /**
    * Overridden to support being disabled
    */
@@ -125,6 +133,10 @@ protected:
    * Temporary up vector to support rolled camera interaction
    */
   double TemporaryUp[3] = { 0, 0, 0 };
+  /**
+   * Interpolation state for `TemporaryUp`
+   */
+  double TemporaryUpFactor = 1;
 };
 
 #endif

--- a/vtkext/private/module/vtkF3DInteractorStyle.h
+++ b/vtkext/private/module/vtkF3DInteractorStyle.h
@@ -110,18 +110,13 @@ public:
    * Reset temporary up vector to renderer's up direction to support rolled camera interaction.
    */
   void ResetTemporaryUp();
+
   /**
    * Set temporary up vector to support rolled camera interaction.
    */
   void SetTemporaryUp(const double* tempUp);
 
 protected:
-  /**
-   * Decrement `TemporaryUpFactor` by `factorDelta`
-   * and use it to interpolate `output` between `TemporaryUp` and `target`.
-   */
-  void InterpolateTemporaryUp(const double factorDelta, const double* target, double* output);
-
   /**
    * Overridden to support being disabled
    */
@@ -130,9 +125,16 @@ protected:
   bool CameraMovementDisabled = false;
 
   /**
+   * Decrement `TemporaryUpFactor` by `factorDelta`
+   * and use it to interpolate `output` between `TemporaryUp` and `target`.
+   */
+  void InterpolateTemporaryUp(const double factorDelta, const double* target, double* output);
+
+  /**
    * Temporary up vector to support rolled camera interaction
    */
   double TemporaryUp[3] = { 0, 0, 0 };
+
   /**
    * Interpolation state for `TemporaryUp`
    */


### PR DESCRIPTION
### Describe your changes

Currently the interpolation of the temporary up vector towards the renderer's up vector does not converge properly. This can cause gimbal lock issues when using the non-trackball interactor after having rolled the camera with the `4` or `6` keys.

This PR changes the implementation by introducing a new member variable to store the state/progress of the interpolation and having `InterpolateTemporaryUp()` mutate that instead of the actual temporary vector.



### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
