### PR TITLE
Fix Fedora build prerequisites - use dnf and add vtk-devel (Fixes #2259)

### DIFF
--- a/doc/dev/GETTING_STARTED.md
+++ b/doc/dev/GETTING_STARTED.md
@@ -35,7 +35,7 @@ Note: Ubuntu 24.04 / Debian 12 provides VTK version 9.1 but f3d requires VTK 9.2
 
 ```
 sudo yum update
-sudo yum install make automake gcc gcc-c++ kernel-devel git git-lfs cmake vtk
+sudo dnf install make automake gcc gcc-c++ kernel-devel git git-lfs cmake vtk vtk-devel
 ```
 
 #### Arch Linux


### PR DESCRIPTION
### Fixes #2259

This PR addresses the missing build dependency for Fedora systems in the getting started documentation.

**Changes made:**
- Updated package manager from `yum` to `dnf` (current standard for Fedora)
- Added missing `vtk-devel` package to the installation command

**Before:**
`sudo yum install make automake gcc gcc-c++ kernel-devel git git-lfs cmake vtk`

**After**
`sudo dnf install make automake gcc gcc-c++ kernel-devel git git-lfs cmake vtk vtk-devel`  

> The vtk-devel package is required for successful builds on Fedora systems as reported in the issue.
