### PR TITLE
CI: Force VTK version in wasm nightly

### DIFF
--- a/.github/workflows/nightly_vtk_master.yml
+++ b/.github/workflows/nightly_vtk_master.yml
@@ -363,7 +363,10 @@ jobs:
       fail-fast: false
 
     runs-on: ubuntu-22.04
-    container: ghcr.io/f3d-app/f3d-wasm:${{needs.default_versions.outputs.timestamp}}_${{needs.check_nightly.outputs.vtk_sha}}
+    container: ghcr.io/f3d-app/f3d-wasm:${{needs.default_versions.outputs.timestamp}}_26ed83ed4a877ebf50a3a22d0f532015214263ca
+    # Will be fixed once VTK fixes wasm
+    # https://github.com/f3d-app/f3d/issues/2289
+    # container: ghcr.io/f3d-app/f3d-wasm:${{needs.default_versions.outputs.timestamp}}_${{needs.check_nightly.outputs.vtk_sha}}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Describe your changes

Force VTK version in wasm nightly

### Issue ticket number and link if any

related to https://github.com/f3d-app/f3d/issues/2289

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [ ] Fast CI
- [ ] Coverage cached CI
- [ ] Analysis cached CI
- [ ] WASM docker CI
- [ ] Android docker CI
- [ ] macOS Intel cached CI
- [ ] macOS ARM cached CI
- [ ] Windows cached CI
- [ ] Linux cached CI
- [ ] Other cached CI
