### PR TITLE
hdf: Add missing exodus extensions

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -770,6 +770,9 @@ if(F3D_PLUGIN_BUILD_HDF)
   endif()
 
   f3d_test(NAME TestExodus DATA disk_out_ref.ex2 ARGS --load-plugins=hdf -s --camera-position=-11,-2,-49)
+  f3d_test(NAME TestExodusExo DATA box.exo ARGS --load-plugins=hdf NO_RENDER NO_BASELINE REGEXP "Number of points: 24")
+  f3d_test(NAME TestExodusG DATA box.g ARGS --load-plugins=hdf NO_RENDER NO_BASELINE REGEXP "Number of points: 24")
+  f3d_test(NAME TestExodusE DATA single_timestep.e ARGS --load-plugins=hdf NO_RENDER NO_BASELINE REGEXP "Number of points: 1331")
 
   f3d_test(NAME TestExodusConfig DATA disk_out_ref.ex2 CONFIG ${F3D_SOURCE_DIR}/testing/configs/exodus.json ARGS -s --camera-position=-11,-2,-49)
 

--- a/plugins/hdf/CMakeLists.txt
+++ b/plugins/hdf/CMakeLists.txt
@@ -24,7 +24,7 @@ f3d_plugin_declare_reader(
 
 f3d_plugin_declare_reader(
   NAME ExodusII
-  EXTENSIONS exo ex2 e
+  EXTENSIONS exo ex2 e g
   MIMETYPES application/vnd.exodus
   VTK_READER vtkExodusIIReader
   FORMAT_DESCRIPTION "Exodus II"

--- a/plugins/hdf/configs/config.d/10_hdf.json
+++ b/plugins/hdf/configs/config.d/10_hdf.json
@@ -1,6 +1,7 @@
 [
   {
-    "match": ".*(ex2|vtkhdf)",
+    "match-type": "glob",
+    "match": "*.{exo,ex2,e,g,vtkhdf}",
     "options": {
       "scalar-coloring": true,
       "load-plugins": "hdf",

--- a/plugins/hdf/configs/thumbnail.d/10_hdf.json
+++ b/plugins/hdf/configs/thumbnail.d/10_hdf.json
@@ -1,6 +1,7 @@
 [
   {
-    "match": ".*(ex2|vtkhdf)",
+    "match-type": "glob",
+    "match": "*.{exo,ex2,e,g,vtkhdf}",
     "options": {
       "scalar-coloring": true,
       "load-plugins": "hdf"

--- a/plugins/hdf/f3d-hdf-formats.xml
+++ b/plugins/hdf/f3d-hdf-formats.xml
@@ -5,6 +5,7 @@
     <glob pattern="*.ex2"/>
     <glob pattern="*.exo"/>
     <glob pattern="*.e"/>
+    <glob pattern="*.g"/>
   </mime-type>
   <mime-type type="application/vnd.vtkhdf">
     <comment>VTKHDF file</comment>

--- a/testing/data/box.exo
+++ b/testing/data/box.exo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5fe2d9bd391e21c74216223cb532e5bf498268deffdb602e34e9d7f7b12c22d
+size 7848

--- a/testing/data/box.g
+++ b/testing/data/box.g
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5fe2d9bd391e21c74216223cb532e5bf498268deffdb602e34e9d7f7b12c22d
+size 7848


### PR DESCRIPTION
### Describe your changes

 - Add missing extensions for exodusii reader (.g|.exo)
 - Add related tests
 
 Please note there are more extensions that we could support, but that seems overkill to me and I'm not familiar with them:
 https://www.paraview.org/paraview-docs/nightly/cxx/md__builds_gitlab-kitware-sciviz-ci_Documentation_release_6_80_ioss-writer-default.html

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
