### PR TITLE
Add external navigation link to F3D libf3d doxygen in config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -332,6 +332,8 @@ nav_external_links:
     url: https://github.com/f3d-app/f3d
   - title: Web viewer
     url: https://f3d.app/web
+  - title: F3D libf3d doxygen
+    url: https://f3d.app/doc/libf3d/doxygen/
 
 # Google Analytics Tracking
 ga_tracking: G-ZCWEYB9KVG

--- a/_config.yml
+++ b/_config.yml
@@ -332,7 +332,7 @@ nav_external_links:
     url: https://github.com/f3d-app/f3d
   - title: Web viewer
     url: https://f3d.app/web
-  - title: F3D libf3d doxygen
+  - title: libf3d API documentation
     url: https://f3d.app/doc/libf3d/doxygen/
 
 # Google Analytics Tracking


### PR DESCRIPTION
### Describe your changes
Added an external navigation link to the F3D libf3d doxygen documentation in _config.yml under nav_external_links.
### Issue ticket number and link if any
Closes #2316
### Checklist for finalizing the PR

- [X] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [ ] Fast CI
- [ ] Coverage cached CI
- [ ] Analysis cached CI
- [ ] WASM docker CI
- [ ] Android docker CI
- [ ] macOS Intel cached CI
- [ ] macOS ARM cached CI
- [ ] Windows cached CI
- [ ] Linux cached CI
- [ ] Other cached CI
