### PR TITLE
add `py.typed` file to Python module

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -115,6 +115,6 @@ install(TARGETS pyf3d
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/__init__.py-install" RENAME "__init__.py"
   DESTINATION ${f3d_python_install_path} COMPONENT python)
 if (F3D_BINDINGS_PYTHON_GENERATE_STUBS)
-  install(FILES  "${f3d_module_dir}/__init__.pyi" "${f3d_module_dir}/pyf3d.pyi"
+  install(FILES "${f3d_module_dir}/__init__.pyi" "${f3d_module_dir}/pyf3d.pyi" "${CMAKE_CURRENT_SOURCE_DIR}/py.typed"
     DESTINATION ${f3d_python_install_path} COMPONENT python)
 endif()


### PR DESCRIPTION
### Describe your changes

We provide typing stubs for the Python module so we also need to add an empty `py.typed` file so that type checking tools know to use them.

For example, assuming the following `a.py`:
```py
import f3d
engine = f3d.Engine.create()
engine.window.size = 900, 720.0
```
and running `mypy a.py` we get:
```
a.py:1: error: Skipping analyzing "f3d": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```
after adding the `py.typed` file and re-runing the same command we get the much more useful and expected:
```
a.py:3: error: Incompatible types in assignment (expression has type "tuple[int, float]", variable has type "tuple[int, int]")  [assignment]
```



### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
