### PR TITLE
[Fix]  Verbose level update dynamic options

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -183,6 +183,25 @@ public:
     return false;
   }
 
+  static std::string GetVerboseLevelString(f3d::log::VerboseLevel level)
+  {
+    switch (level)
+    {
+      case f3d::log::VerboseLevel::QUIET:
+        return "quiet";
+      case f3d::log::VerboseLevel::ERROR:
+        return "error";
+      case f3d::log::VerboseLevel::WARN:
+        return "warning";
+      case f3d::log::VerboseLevel::INFO:
+        return "info";
+      case f3d::log::VerboseLevel::DEBUG:
+        return "debug";
+      default:
+        return "info";
+    }
+  }
+
   static void SetVerboseLevel(const std::string& level, bool forceStdErr)
   {
     // A switch/case over verbose level
@@ -1450,6 +1469,14 @@ void F3DStarter::LoadFileGroup(
         dynamicOptionsDict[name] = dynamicOptions.getAsString(name);
       }
     }
+  }
+
+  // Detect interactively changed verbose level and add it to dynamic options
+  f3d::log::VerboseLevel currentVerboseLevel = f3d::log::getVerboseLevel();
+  std::string currentVerboseLevelString = F3DInternals::GetVerboseLevelString(currentVerboseLevel);
+  if (currentVerboseLevelString != this->Internals->AppOptions.VerboseLevel)
+  {
+    dynamicOptionsDict["verbose"] = currentVerboseLevelString;
   }
 
   // Add the dynamicOptionsDict into the entries, which grows over time if option keep changing and

--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -975,6 +975,7 @@ f3d_test(NAME TestInteractionConfigFileImperativeNoData CONFIG ${F3D_SOURCE_DIR}
 f3d_test(NAME TestInteractionConfigFileOptional DATA zombie.mdl f3d.glb CONFIG ${F3D_SOURCE_DIR}/testing/configs/complex.json INTERACTION UI) #Right
 f3d_test(NAME TestInteractionCycleVerbose DATA dragon.vtu ARGS --verbose -s NO_BASELINE INTERACTION REGEXP "Not coloring")#SSSSYC
 f3d_test(NAME TestInteractionCycleVerboseLevelsUsingBinding DATA dragon.vtu ARGS --verbose=info NO_BASELINE INTERACTION REGEXP "Verbose level changed to: Debug")#Shift+V;Shift+V;Shift+V;Shift+V;Shift+V
+f3d_test(NAME TestInteractionVerboseLevelPreservedOnReload DATA dragon.vtu NO_BASELINE INTERACTION REGEXP "Not coloring")#Shift+V;Shift+V;Shift+V;Shift+V;Up
 f3d_test(NAME TestInteractionEmptyDrop INTERACTION REGEXP "Drop event without any provided files.")#DropEvent Empty;
 f3d_test(NAME TestInteractionCameraUpdate DATA dragon.vtu INTERACTION) #MouseWheel;MouseWheel;MouseWheel;S
 f3d_test(NAME TestInteractionFocalPointPickingDefault DATA dragon.vtu INTERACTION LONG_TIMEOUT)

--- a/testing/recordings/TestInteractionVerboseLevelPreservedOnReload.log
+++ b/testing/recordings/TestInteractionVerboseLevelPreservedOnReload.log
@@ -1,0 +1,25 @@
+# StreamVersion 1.2
+RenderEvent 0 0 0 0 0 0 0
+KeyPressEvent 0 0 1 0 1 Shift_L 0
+KeyPressEvent 0 0 1 22 1 v 0
+CharEvent 0 0 1 22 1 v 0
+KeyReleaseEvent 0 0 1 22 1 v 0
+KeyReleaseEvent 0 0 0 0 1 Shift_L 0
+KeyPressEvent 0 0 1 0 1 Shift_L 0
+KeyPressEvent 0 0 1 22 1 v 0
+CharEvent 0 0 1 22 1 v 0
+KeyReleaseEvent 0 0 1 22 1 v 0
+KeyReleaseEvent 0 0 0 0 1 Shift_L 0
+KeyPressEvent 0 0 1 0 1 Shift_L 0
+KeyPressEvent 0 0 1 22 1 v 0
+CharEvent 0 0 1 22 1 v 0
+KeyReleaseEvent 0 0 1 22 1 v 0
+KeyReleaseEvent 0 0 0 0 1 Shift_L 0
+KeyPressEvent 0 0 1 0 1 Shift_L 0
+KeyPressEvent 0 0 1 22 1 v 0
+CharEvent 0 0 1 22 1 v 0
+KeyReleaseEvent 0 0 1 22 1 v 0
+KeyReleaseEvent 0 0 0 0 1 Shift_L 0
+KeyPressEvent 0 0 0 0 1 Up 0
+CharEvent 0 0 0 0 1 Up 0
+KeyReleaseEvent 0 0 0 0 1 Up 0


### PR DESCRIPTION
### Describe your changes

F3D supports changing verbose level by pressing Shift+V, but it was not kept when loading a file. 
Made changes in `F3DStarter.cxx` to track the change made and add it to dynamic options.

### Issue ticket number and link if any

#2348 

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
