### PR TITLE
Implement print_config_info application command

### DIFF
--- a/application/F3DConfigFileTools.cxx
+++ b/application/F3DConfigFileTools.cxx
@@ -86,7 +86,7 @@ std::vector<fs::path> GetConfigPaths(const std::string& configSearch)
 
 //----------------------------------------------------------------------------
 F3DConfigFileTools::ParsedConfigFiles F3DConfigFileTools::ReadConfigFiles(
-  const std::string& userConfig)
+  const std::string& userConfig, bool dryRun, f3d::log::VerboseLevel logLevel)
 {
   // Default config directory name
   std::string configSearch = "config";
@@ -136,7 +136,7 @@ F3DConfigFileTools::ParsedConfigFiles F3DConfigFileTools::ReadConfigFiles(
     // Recover all config files if needed in directories
     if (fs::is_directory(configPath))
     {
-      f3d::log::debug("Using config directory ", configPath.string());
+      f3d::log::print(logLevel, "Using config directory ", configPath.string());
       const size_t oldSize = actualConfigFilePaths.size();
       auto dirIter = fs::directory_iterator(configPath);
       std::copy(std::filesystem::begin(dirIter), std::filesystem::end(dirIter),
@@ -146,7 +146,7 @@ F3DConfigFileTools::ParsedConfigFiles F3DConfigFileTools::ReadConfigFiles(
     }
     else
     {
-      f3d::log::debug("Using config file ", configPath.string());
+      f3d::log::print(logLevel, "Using config file ", configPath.string());
       actualConfigFilePaths.emplace_back(configPath);
     }
   }
@@ -154,7 +154,13 @@ F3DConfigFileTools::ParsedConfigFiles F3DConfigFileTools::ReadConfigFiles(
   // If we used a configSearch but did not find any, inform the user
   if (!configSearch.empty() && actualConfigFilePaths.empty())
   {
-    f3d::log::info("Configuration file for \"", configSearch, "\" could not be found");
+    f3d::log::print(logLevel, "Configuration file for \"", configSearch, "\" could not be found");
+  }
+
+  // Clear config file paths to avoid reading them if dryRun is set
+  if (dryRun)
+  {
+    actualConfigFilePaths.clear();
   }
 
   // Read config files

--- a/application/F3DConfigFileTools.h
+++ b/application/F3DConfigFileTools.h
@@ -5,6 +5,7 @@
  * @brief   A namespace to parse config files
  */
 #include "F3DOptionsTools.h"
+#include "log.h"
 
 #include <string>
 
@@ -25,7 +26,8 @@ struct ParsedConfigFiles
  * Read config files using userConfig if any, return a ParsedConfigFiles
  * containing ordered optionDict, ordered imperative optionDict and ordered bindingsEntries
  */
-ParsedConfigFiles ReadConfigFiles(const std::string& userConfig);
+ParsedConfigFiles ReadConfigFiles(
+  const std::string& userConfig, bool dryRun, f3d::log::VerboseLevel logLevel);
 }
 
 #endif

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -1041,7 +1041,7 @@ int F3DStarter::Start(int argc, char** argv)
   if (!noConfig)
   {
     F3DConfigFileTools::ParsedConfigFiles parsedConfigFiles =
-      F3DConfigFileTools::ReadConfigFiles(config);
+      F3DConfigFileTools::ReadConfigFiles(config, false, f3d::log::getVerboseLevel());
     this->Internals->ConfigOptionsEntries = parsedConfigFiles.Options;
     this->Internals->ImperativeConfigOptionsEntries = parsedConfigFiles.ImperativeOptions;
     this->Internals->ConfigBindingsEntries = parsedConfigFiles.Bindings;
@@ -1865,6 +1865,9 @@ void F3DStarter::AddCommands()
     // parsing_exception is caught within interactor implementation
     return f3d::options::parse<bool>(args[0]);
   };
+
+  interactor.addCommand("print_config_info", [this](const std::vector<std::string>&)
+    { F3DConfigFileTools::ReadConfigFiles(std::string(), true, f3d::log::VerboseLevel::INFO); });
 
   interactor.addCommand("remove_file_groups",
     [this](const std::vector<std::string>&)


### PR DESCRIPTION
### Describe your changes
I implemented the `print_config_info` command to allow for easily checking which config files are loaded. This is especially useful when f3d is ran not from the command line.

![f3d_print_config_info](https://github.com/user-attachments/assets/b25814bc-3987-40e8-b8dc-94b6be01fcc0)

### Issue ticket number and link if any
#2349

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [ ] Style checks
- [ ] Fast CI
- [ ] Coverage cached CI
- [ ] Analysis cached CI
- [ ] WASM docker CI
- [ ] Android docker CI
- [ ] macOS Intel cached CI
- [ ] macOS ARM cached CI
- [ ] Windows cached CI
- [ ] Linux cached CI
- [ ] Other cached CI
