### PR TITLE
F3DWeb: Add missing NetCDF and Exodus extensions

### DIFF
--- a/webassembly/app.html
+++ b/webassembly/app.html
@@ -58,7 +58,7 @@
                 class="file-input"
                 type="file"
                 id="file-selector"
-                accept=".gml,.gltf,.glb,.obj,.ply,.pts,.stl,.vtk,.vtp,.vtu,.vtkhdf,.3ds,.wrl,.vrml,.fbx,.off,.x,.dae,.ex2,.exo,.e,.stp,.step,.igs,.iges,.brep,.xbf,.drc,.mdl"
+                accept=".gml,.gltf,.glb,.obj,.ply,.pts,.stl,.vtk,.vtp,.vtu,.vtkhdf,.3ds,.wrl,.vrml,.fbx,.off,.x,.dae,.ex2,.exo,.e,.g,.stp,.step,.igs,.iges,.brep,.xbf,.drc,.mdl,.nc,.cdf,.ncdf"
               />
               <span class="file-cta">
                 <span class="file-label">Open a file...</span>


### PR DESCRIPTION
### Describe your changes

F3DWeb:

- Add NetCDF extensions
- Add .g exodus extension

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [ ] Fast CI
- [ ] Coverage cached CI
- [ ] Analysis cached CI
- [x] WASM docker CI
- [ ] Android docker CI
- [ ] macOS Intel cached CI
- [ ] macOS ARM cached CI
- [ ] Windows cached CI
- [ ] Linux cached CI
- [ ] Other cached CI
