### PR TITLE
WIP: Improve Cheatsheet look

### DIFF
--- a/vtkext/private/module/vtkF3DImguiActor.cxx
+++ b/vtkext/private/module/vtkF3DImguiActor.cxx
@@ -467,7 +467,7 @@ void vtkF3DImguiActor::RenderCheatSheet()
     }
   }
 
-  winWidth += 2.f * ImGui::GetStyle().WindowPadding.x + ImGui::GetStyle().ScrollbarSize + maxBindingTextWidth;
+  winWidth += 2.f * ImGui::GetStyle().WindowPadding.x + ImGui::GetStyle().ScrollbarSize + maxBindingTextWidth * 0.5f;
   textHeight += 2.f * ImGui::GetStyle().WindowPadding.y;
 
   const float winTop = std::max(margin, (viewport->WorkSize.y - textHeight) * 0.5f);

--- a/vtkext/private/module/vtkF3DImguiActor.cxx
+++ b/vtkext/private/module/vtkF3DImguiActor.cxx
@@ -491,17 +491,17 @@ void vtkF3DImguiActor::RenderCheatSheet()
     for (const auto& [bind, desc, val] : list)
     {
       ImDrawList* drawList = ImGui::GetWindowDrawList();
-      ImVec4 rec_color, text_color;
+      ImVec4 bindingRectColor, descTextColor;
 
       if (val == "ON")
       {
-        rec_color = F3DImguiStyle::GetHighlightColor();
-        text_color = F3DImguiStyle::GetHighlightColor();
+        bindingRectColor = F3DImguiStyle::GetHighlightColor();
+        descTextColor = F3DImguiStyle::GetHighlightColor();
       }
       else
       {
-        rec_color = F3DImguiStyle::GetMidColor();
-        text_color = F3DImguiStyle::GetTextColor();
+        bindingRectColor = F3DImguiStyle::GetMidColor();
+        descTextColor = F3DImguiStyle::GetTextColor();
       }
 
       drawList->ChannelsSplit(2);
@@ -510,21 +510,23 @@ void vtkF3DImguiActor::RenderCheatSheet()
       ImGui::Text("%s", bind.c_str());
 
       drawList->ChannelsSetCurrent(0);
-      ImVec2 top_corner(ImGui::GetItemRectMin().x - margin, ImGui::GetItemRectMin().y - margin);
-      ImVec2 bottom_corner(ImGui::GetItemRectMin().x + maxBindingTextWidth + margin,
+      ImVec2 topBindingCorner(
+        ImGui::GetItemRectMin().x - margin, ImGui::GetItemRectMin().y - margin);
+      ImVec2 bottomBindingCorner(ImGui::GetItemRectMin().x + maxBindingTextWidth + margin,
         ImGui::GetItemRectMax().y + margin);
-      drawList->AddRectFilled(top_corner, bottom_corner, ImColor(rec_color), 5.f);
+      drawList->AddRectFilled(
+        topBindingCorner, bottomBindingCorner, ImColor(bindingRectColor), 5.f);
       drawList->ChannelsMerge();
 
       ImGui::SameLine();
-      ImGui::SetCursorPosX(bottom_corner.x + ImGui::GetStyle().WindowPadding.x);
+      ImGui::SetCursorPosX(bottomBindingCorner.x + ImGui::GetStyle().WindowPadding.x);
       if (val.empty() || val == "ON" || val == "OFF")
       {
-        ImGui::TextColored(text_color, "%s", desc.c_str());
+        ImGui::TextColored(descTextColor, "%s", desc.c_str());
       }
       else
       {
-        ImGui::TextColored(text_color, "%s [%s]", desc.c_str(), val.c_str());
+        ImGui::TextColored(descTextColor, "%s [%s]", desc.c_str(), val.c_str());
       }
 
       ImGui::NewLine();

--- a/vtkext/private/module/vtkF3DImguiActor.cxx
+++ b/vtkext/private/module/vtkF3DImguiActor.cxx
@@ -461,13 +461,15 @@ void vtkF3DImguiActor::RenderCheatSheet()
       textHeight += ImGui::GetTextLineHeightWithSpacing();
 
       ImVec2 bindingLineSize = ImGui::CalcTextSize(bind.c_str());
-      if (bindingLineSize.x >= maxBindingTextWidth) {
+      if (bindingLineSize.x >= maxBindingTextWidth)
+      {
         maxBindingTextWidth = bindingLineSize.x;
       }
     }
   }
 
-  winWidth += 2.f * ImGui::GetStyle().WindowPadding.x + ImGui::GetStyle().ScrollbarSize + maxBindingTextWidth * 0.5f;
+  winWidth += 2.f * ImGui::GetStyle().WindowPadding.x + ImGui::GetStyle().ScrollbarSize +
+    maxBindingTextWidth * 0.5f;
   textHeight += 2.f * ImGui::GetStyle().WindowPadding.y;
 
   const float winTop = std::max(margin, (viewport->WorkSize.y - textHeight) * 0.5f);
@@ -488,13 +490,16 @@ void vtkF3DImguiActor::RenderCheatSheet()
     ImGui::SeparatorText(group.c_str());
     for (const auto& [bind, desc, val] : list)
     {
-      ImDrawList *drawList = ImGui::GetWindowDrawList();
+      ImDrawList* drawList = ImGui::GetWindowDrawList();
       ImVec4 rec_color, text_color;
 
-      if(val == "ON") {
+      if (val == "ON")
+      {
         rec_color = F3DImguiStyle::GetHighlightColor();
-        text_color = F3DImguiStyle::GetHighlightColor();  
-      } else {
+        text_color = F3DImguiStyle::GetHighlightColor();
+      }
+      else
+      {
         rec_color = F3DImguiStyle::GetMidColor();
         text_color = F3DImguiStyle::GetTextColor();
       }
@@ -503,10 +508,11 @@ void vtkF3DImguiActor::RenderCheatSheet()
 
       drawList->ChannelsSetCurrent(1);
       ImGui::Text("%s", bind.c_str());
-      
+
       drawList->ChannelsSetCurrent(0);
       ImVec2 top_corner(ImGui::GetItemRectMin().x - margin, ImGui::GetItemRectMin().y - margin);
-      ImVec2 bottom_corner(ImGui::GetItemRectMin().x + maxBindingTextWidth + margin, ImGui::GetItemRectMax().y + margin);
+      ImVec2 bottom_corner(ImGui::GetItemRectMin().x + maxBindingTextWidth + margin,
+        ImGui::GetItemRectMax().y + margin);
       drawList->AddRectFilled(top_corner, bottom_corner, ImColor(rec_color), 5.f);
       drawList->ChannelsMerge();
 
@@ -515,7 +521,9 @@ void vtkF3DImguiActor::RenderCheatSheet()
       if (val.empty() || val == "ON" || val == "OFF")
       {
         ImGui::TextColored(text_color, "%s", desc.c_str());
-      } else {  
+      }
+      else
+      {
         ImGui::TextColored(text_color, "%s [%s]", desc.c_str(), val.c_str());
       }
 


### PR DESCRIPTION
### Describe your changes

This change target to improve CheatSheet appearence : 

<img width="1730" height="1015" alt="image" src="https://github.com/user-attachments/assets/e462c7c4-8976-4261-956d-d76e3da74d29" />

However we still need to discuss about some design choices : 
* Should Bindings be centered in Rect ? 
* How to represent non boolean value state ?
* may be something else ? 

PR should still stay as Draft, while we do not make a choice about points above. 

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [ ] Style checks
- [ ] Fast CI
- [ ] Coverage cached CI
- [ ] Analysis cached CI
- [ ] WASM docker CI
- [ ] Android docker CI
- [ ] macOS Intel cached CI
- [ ] macOS ARM cached CI
- [ ] Windows cached CI
- [ ] Linux cached CI
- [ ] Other cached CI
