### PR TITLE
Expanded transform2d parsing

### DIFF
--- a/doc/user/PARSING.md
+++ b/doc/user/PARSING.md
@@ -12,6 +12,7 @@ The following types are supported:
 - path: A path to a local file.
 - color: A RGB color.
 - direction: A 3D vector representing a direction.
+- transform2d: A 9D vector representing a 3x3 matrix.
 
 As well as a list for bool, int, double, ratio, string, noted as
 
@@ -108,3 +109,12 @@ The following formats are supported when parsing a string into a colormap:
 - `val, color, ...`
 
 When formatting a colormap into a string, it is formatted as `val, color, ...`.
+
+## Transform2D
+
+The following formats are supported when parsing a string into a transform2D:
+
+- A 9D double vector
+- At least one of the following: `scale: val, val`, `translation: val, val`, `angle: val` in any order, comma-separated. `scale` may be given one value, which will apply to both the x and y axes of the matrix.
+
+When formatting a transform2d into a string, it is formatted as a 9D double vector

--- a/library/public/types.h
+++ b/library/public/types.h
@@ -247,6 +247,42 @@ public:
     (*this)[7] = M3_2;
     (*this)[8] = M3_3;
   }
+
+  // clang-format off
+  /**
+   *  The general form of a 3x3 transformation matrix M with scale S(x,y),
+   *  translation T(x,y), and angle a, is solved out to the following:
+   * 
+   *      [cos(a)*S(x), -sin(t)*S(y),   T(x)]
+   *  M = [sin(a)*S(x), cos(a)*S(y),    T(y)]
+   *      [0,           0,              1   ]
+   * 
+   *  Using this formula, we fill each cell using the values in the constructor
+   */
+  // clang-format on
+
+  inline transform2d_t(double scaleX, double scaleY, double translationX, double translationY,
+    double angle)
+  {
+    (*this)[0] = cos(angle) * scaleX;
+    (*this)[1] = -sin(angle) * scaleY;
+    (*this)[2] = translationX;
+    (*this)[3] = sin(angle) * scaleX;
+    (*this)[4] = cos(angle) * scaleY;
+    (*this)[5] = translationY;
+    (*this)[6] = 0;
+    (*this)[7] = 0;
+    (*this)[8] = 1;
+
+    // remove negative 0.0 wherever it occurs
+    for (int i = 0; i < 9; i++)
+    {
+      if ((*this)[i] == 0.0 && std::signbit((*this)[i]))
+      {
+        (*this)[i] = 0.0;
+      }
+    }
+  }
 };
 
 /**

--- a/library/testing/TestSDKOptions.cxx
+++ b/library/testing/TestSDKOptions.cxx
@@ -192,6 +192,34 @@ int TestSDKOptions(int argc, char* argv[])
     std::get<std::vector<double>>(opt.get("model.scivis.colormap")) ==
       std::vector<double>{ 0, 0, 0, 0, 1, 1, 1, 0 });
 
+  // Test transform2d_t
+  opt.setAsString("model.textures_transform", "1,0,0,0,-1,0,0,0,1");
+  test("setAsString vector transform2d", opt.getAsString("model.textures_transform"),
+    "1,0,0,0,-1,0,0,0,1");
+
+  opt.setAsString("model.textures_transform", "scale:0.1");
+  test("setAsString scale transform2d", opt.getAsString("model.textures_transform"),
+    "0.1,0,0,0,0.1,0,0,0,1");
+
+  opt.setAsString("model.textures_transform", "translation:0.51,2.1");
+  test("setAsString translation transform2d", opt.getAsString("model.textures_transform"),
+    "1,0,0.51,0,1,2.1,0,0,1");
+
+  opt.model.textures_transform = { 0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5 };
+  test("getAsString transform2d",
+    opt.getAsString("model.textures_transform") == "0.5,0,0,0,0.5,0,0,0,0.5");
+
+  opt.setAsString("model.textures_transform", "angle:0.21");
+  test("setAsString/get angle transform2d",
+    std::get<std::vector<double>>(opt.get("model.textures_transform")) ==
+      std::vector<double>{ cos(0.21), -sin(0.21), 0, sin(0.21), cos(0.21), 0, 0, 0, 1 });
+
+  opt.setAsString("model.textures_transform", "scale:0.1,translation:0.51,2.1,angle:0.21");
+  test("setAsString/get scale/translation/angle transform2d",
+    std::get<std::vector<double>>(opt.get("model.textures_transform")) ==
+      std::vector<double>{
+        0.1 * cos(0.21), 0.1 * -sin(0.21), 0.51, 0.1 * sin(0.21), 0.1 * cos(0.21), 2.1, 0, 0, 1 });
+
   // Test closest option
   auto closest = opt.getClosestOption("modle.sciivs.cell");
   test("closest option", closest.first == "model.scivis.cells" && closest.second == 5);

--- a/library/testing/TestSDKOptionsIO.cxx
+++ b/library/testing/TestSDKOptionsIO.cxx
@@ -211,6 +211,39 @@ int TestSDKOptionsIO(int argc, char* argv[])
     "transform2d_t", "0,0,0,0,0,0,0,0,0", { 0, 0, 0, 0, 0, 0, 0, 0, 0 });
   test.parse<f3d::transform2d_t>(
     "transform2d_t", "0.5,0,0,0,0.5,0,0,0,0.5", { 0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5 });
+  test.parse<f3d::transform2d_t>("transform2d_t", "scale:0.1", { 0.1, 0, 0, 0, 0.1, 0, 0, 0, 1 });
+  test.parse<f3d::transform2d_t>(
+    "transform2d_t", "scale:0.1,0.2", { 0.1, 0, 0, 0, 0.2, 0, 0, 0, 1 });
+  test.parse<f3d::transform2d_t>(
+    "transform2d_t", "translation:0.51,2.1", { 1, 0, 0.51, 0, 1, 2.1, 0, 0, 1 });
+  test.parse<f3d::transform2d_t>(
+    "transform2d_t", "angle:0.21", { cos(0.21), -sin(0.21), 0, sin(0.21), cos(0.21), 0, 0, 0, 1 });
+  test.parse<f3d::transform2d_t>("transform2d_t", "scale:0.1,translation:0.51,2.1,angle:0.21",
+    { 0.1 * cos(0.21), 0.1 * -sin(0.21), 0.51, 0.1 * sin(0.21), 0.1 * cos(0.21), 2.1, 0, 0, 1 });
+  test.parse_expect<f3d::transform2d_t, parsing_exception>("vector too small", "1");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>(
+    "vector too large", "1,2,3,4,5,6,7,8,9,0");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>(
+    "text in transform notation", "1,2,three,4,5,6,7,8,9");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>("invalid argument", "rotation:45.0");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>("no value provided for scale", "scale:");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>(
+    "no value provided for scale", "scale:,angle:0.5");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>("too many scale values", "scale:1,2,3");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>(
+    "no value provided for translation", "translation:");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>(
+    "one value provided for translation", "translation:0.5");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>(
+    "too many values provided for translation", "translation:1,2,3");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>("no value provided for angle", "angle:");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>("too many angle values", "angle:1,2,3");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>(
+    "multiple scale transforms", "scale:1,2,scale:3,4");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>(
+    "multiple translation transforms", "translation:1,2,translation:3,4");
+  test.parse_expect<f3d::transform2d_t, parsing_exception>(
+    "multiple angle transforms", "angle:0.1,angle:0.2");
   test.format<f3d::transform2d_t>(
     "transform2d_t", { 1, 0, 0, 0, -1, 0, 0, 0, 1 }, "1,0,0,0,-1,0,0,0,1");
   test.format<f3d::transform2d_t>(


### PR DESCRIPTION
### Describe your changes

- Transform2d has a scale/translation/angle constructor in addition to the 9D vector constructor
- Transform2d parsing includes scale/translation/angle notation
- Transform2d parsing explained in PARSING.md
- Tests for Transform2D added to TestSDKOptions and TestSDKOptionsIO

### Issue ticket number and link if any

https://github.com/f3d-app/f3d/issues/2301

### Checklist for finalizing the PR

- [x ] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [x ] I have added [documentation](https://f3d.app/) for new features
- [x ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x ] Style checks
- [x ] Fast CI
- [x ] Coverage cached CI
- [x ] Analysis cached CI
- [x ] WASM docker CI
- [x ] Android docker CI
- [x ] macOS Intel cached CI
- [x ] macOS ARM cached CI
- [x ] Windows cached CI
- [x ] Linux cached CI
- [x ] Other cached CI
