### PR TITLE
USD: Remove time related useless code

### DIFF
--- a/plugins/usd/module/vtkF3DUSDImporter.cxx
+++ b/plugins/usd/module/vtkF3DUSDImporter.cxx
@@ -1259,18 +1259,9 @@ vtkIdType vtkF3DUSDImporter::GetNumberOfAnimations()
 
 //----------------------------------------------------------------------------
 bool vtkF3DUSDImporter::GetTemporalInformation(vtkIdType vtkNotUsed(animationIndex),
-  double frameRate, int& nbTimeSteps, double timeRange[2], vtkDoubleArray* timeSteps)
+  double vtkNotUsed(frameRate), int& vtkNotUsed(nbTimeSteps), double timeRange[2], vtkDoubleArray* vtkNotUsed(timeSteps))
 {
   this->Internals->GetTimeRange(timeRange);
-
-  nbTimeSteps = static_cast<int>((timeRange[1] - timeRange[0]) * frameRate);
-
-  for (int i = 0; i < nbTimeSteps; i++)
-  {
-    double timestep = timeRange[0] + static_cast<double>(i) / frameRate;
-    timeSteps->InsertNextTypedTuple(&timestep);
-  }
-
   return true;
 }
 


### PR DESCRIPTION
### Describe your changes

The USD importer compute timesteps based on framerate, which F3D do not use at all, remove it.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
