### PR TITLE
interactor: Add bindingType to the libf3d API

### DIFF
--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -44,11 +44,11 @@ public:
 
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,
-    std::string group = std::string(),
-    documentation_callback_t documentationCallback = nullptr, BindingType type = BindingType::UNDEFINED) override;
+    std::string group = std::string(), documentation_callback_t documentationCallback = nullptr,
+    BindingType type = BindingType::UNDEFINED) override;
   interactor& addBinding(const interaction_bind_t& bind, std::string command,
-    std::string group = std::string(),
-    documentation_callback_t documentationCallback = nullptr, BindingType type = BindingType::UNDEFINED) override;
+    std::string group = std::string(), documentation_callback_t documentationCallback = nullptr,
+    BindingType type = BindingType::UNDEFINED) override;
   interactor& removeBinding(const interaction_bind_t& bind) override;
   std::vector<std::string> getBindGroups() const override;
   std::vector<interaction_bind_t> getBindsForGroup(std::string group) const override;

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -45,17 +45,17 @@ public:
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,
     std::string group = std::string(),
-    documentation_callback_t documentationCallback = nullptr, binding_type_t bindingType = binding_type_t::ANY) override;
+    documentation_callback_t documentationCallback = nullptr, BindingType type = BindingType::UNDEFINED) override;
   interactor& addBinding(const interaction_bind_t& bind, std::string command,
     std::string group = std::string(),
-    documentation_callback_t documentationCallback = nullptr, binding_type_t bindingType = binding_type_t::ANY) override;
+    documentation_callback_t documentationCallback = nullptr, BindingType type = BindingType::UNDEFINED) override;
   interactor& removeBinding(const interaction_bind_t& bind) override;
   std::vector<std::string> getBindGroups() const override;
   std::vector<interaction_bind_t> getBindsForGroup(std::string group) const override;
   std::vector<interaction_bind_t> getBinds() const override;
   std::pair<std::string, std::string> getBindingDocumentation(
     const interaction_bind_t& bind) const override;
-  binding_type_t getBindingType(const interaction_bind_t& bind) const override;
+  BindingType getBindingType(const interaction_bind_t& bind) const override;
 
   interactor& triggerModUpdate(InputModifier mod) override;
   interactor& triggerMouseButton(InputAction action, MouseButton button) override;

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -45,10 +45,10 @@ public:
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,
     std::string group = std::string(), documentation_callback_t documentationCallback = nullptr,
-    BindingType type = BindingType::UNDEFINED) override;
+    BindingType type = BindingType::OTHER) override;
   interactor& addBinding(const interaction_bind_t& bind, std::string command,
     std::string group = std::string(), documentation_callback_t documentationCallback = nullptr,
-    BindingType type = BindingType::UNDEFINED) override;
+    BindingType type = BindingType::OTHER) override;
   interactor& removeBinding(const interaction_bind_t& bind) override;
   std::vector<std::string> getBindGroups() const override;
   std::vector<interaction_bind_t> getBindsForGroup(std::string group) const override;

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -45,16 +45,17 @@ public:
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,
     std::string group = std::string(),
-    documentation_callback_t documentationCallback = nullptr) override;
+    documentation_callback_t documentationCallback = nullptr, binding_type_t bindingType = binding_type_t::ANY) override;
   interactor& addBinding(const interaction_bind_t& bind, std::string command,
     std::string group = std::string(),
-    documentation_callback_t documentationCallback = nullptr) override;
+    documentation_callback_t documentationCallback = nullptr, binding_type_t bindingType = binding_type_t::ANY) override;
   interactor& removeBinding(const interaction_bind_t& bind) override;
   std::vector<std::string> getBindGroups() const override;
   std::vector<interaction_bind_t> getBindsForGroup(std::string group) const override;
   std::vector<interaction_bind_t> getBinds() const override;
   std::pair<std::string, std::string> getBindingDocumentation(
     const interaction_bind_t& bind) const override;
+  binding_type_t getBindingType(const interaction_bind_t& bind) const override;
 
   interactor& triggerModUpdate(InputModifier mod) override;
   interactor& triggerMouseButton(InputAction action, MouseButton button) override;

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -158,7 +158,8 @@ public:
    * Adding commands for an existing bind will throw a interactor::already_exists_exception.
    */
   virtual interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,
-    std::string group = {}, documentation_callback_t documentationCallback = nullptr, BindingType type = BindingType::UNDEFINED) = 0;
+    std::string group = {}, documentation_callback_t documentationCallback = nullptr,
+    BindingType type = BindingType::UNDEFINED) = 0;
 
   /**
    * See addBinding
@@ -168,13 +169,15 @@ public:
    * Adding command for an existing bind will throw a interactor::already_exists_exception.
    */
   virtual interactor& addBinding(const interaction_bind_t& bind, std::string command,
-    std::string group = {}, documentation_callback_t documentationCallback = nullptr, BindingType type = BindingType::UNDEFINED) = 0;
+    std::string group = {}, documentation_callback_t documentationCallback = nullptr,
+    BindingType type = BindingType::UNDEFINED) = 0;
 
   /**
    * Convenience initializer list signature for add binding method
    */
   interactor& addBinding(const interaction_bind_t& bind, std::initializer_list<std::string> list,
-    std::string group = {}, documentation_callback_t documentationCallback = nullptr, BindingType type = BindingType::UNDEFINED)
+    std::string group = {}, documentation_callback_t documentationCallback = nullptr,
+    BindingType type = BindingType::UNDEFINED)
   {
     return this->addBinding(
       bind, std::vector<std::string>(list), std::move(group), std::move(documentationCallback));
@@ -225,8 +228,7 @@ public:
    *
    * Getting type for a bind that does not exists will throw a does_not_exists_exception.
    */
-  [[nodiscard]] virtual BindingType getBindingType(
-    const interaction_bind_t& bind) const = 0;
+  [[nodiscard]] virtual BindingType getBindingType(const interaction_bind_t& bind) const = 0;
   ///@}
 
   ///@{ @name Animation

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -14,6 +14,19 @@
 
 namespace f3d
 {
+
+/**
+ * Enumeration of binding types.
+ */
+enum class binding_type_t : std::uint8_t
+{
+  ANY = 0,
+  CYCLIC = 1,
+  NUMERICAL = 2,
+  TOGGLE = 3,
+  LAUNCHER = 4,
+};
+
 struct interaction_bind_t
 {
   /**
@@ -132,6 +145,9 @@ public:
    * the first is the doc itself, the second is the current value as a string, if any.
    * Use `getBindingDocumentation` to access this doc.
    *
+   * bindingType is an optional type to provide, it can be used for presenting the
+   * binding in a coherent way in outputs and cheatsheet.
+   *
    * When the corresponding bind happens, the provided commands will be triggered using
    * triggerCommand. Considering checking if an interaction exists or removing it before adding it
    * to avoid potential conflicts.
@@ -142,7 +158,7 @@ public:
    * Adding commands for an existing bind will throw a interactor::already_exists_exception.
    */
   virtual interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,
-    std::string group = {}, documentation_callback_t documentationCallback = nullptr) = 0;
+    std::string group = {}, documentation_callback_t documentationCallback = nullptr, binding_type_t bindingType = binding_type_t::ANY) = 0;
 
   /**
    * See addBinding
@@ -152,13 +168,13 @@ public:
    * Adding command for an existing bind will throw a interactor::already_exists_exception.
    */
   virtual interactor& addBinding(const interaction_bind_t& bind, std::string command,
-    std::string group = {}, documentation_callback_t documentationCallback = nullptr) = 0;
+    std::string group = {}, documentation_callback_t documentationCallback = nullptr, binding_type_t bindingType = binding_type_t::ANY) = 0;
 
   /**
    * Convenience initializer list signature for add binding method
    */
   interactor& addBinding(const interaction_bind_t& bind, std::initializer_list<std::string> list,
-    std::string group = {}, documentation_callback_t documentationCallback = nullptr)
+    std::string group = {}, documentation_callback_t documentationCallback = nullptr, binding_type_t bindingType = binding_type_t::ANY)
   {
     return this->addBinding(
       bind, std::vector<std::string>(list), std::move(group), std::move(documentationCallback));
@@ -201,6 +217,15 @@ public:
    * Getting documentation for a bind that does not exists will throw a does_not_exists_exception.
    */
   [[nodiscard]] virtual std::pair<std::string, std::string> getBindingDocumentation(
+    const interaction_bind_t& bind) const = 0;
+  ///@}
+
+  /**
+   * Get the type of a binding.
+   *
+   * Getting type for a bind that does not exists will throw a does_not_exists_exception.
+   */
+  [[nodiscard]] virtual binding_type_t getBindingType(
     const interaction_bind_t& bind) const = 0;
   ///@}
 

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -178,8 +178,8 @@ public:
     std::string group = {}, documentation_callback_t documentationCallback = nullptr,
     BindingType type = BindingType::OTHER)
   {
-    return this->addBinding(
-      bind, std::vector<std::string>(list), std::move(group), std::move(documentationCallback), type);
+    return this->addBinding(bind, std::vector<std::string>(list), std::move(group),
+      std::move(documentationCallback), type);
   }
 
   /**

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -15,18 +15,6 @@
 namespace f3d
 {
 
-/**
- * Enumeration of binding types.
- */
-enum class binding_type_t : std::uint8_t
-{
-  ANY = 0,
-  CYCLIC = 1,
-  NUMERICAL = 2,
-  TOGGLE = 3,
-  LAUNCHER = 4,
-};
-
 struct interaction_bind_t
 {
   /**
@@ -124,6 +112,18 @@ public:
   using documentation_callback_t = std::function<std::pair<std::string, std::string>()>;
 
   /**
+   * Enumeration of binding types.
+   */
+  enum class BindingType : std::uint8_t
+  {
+    UNDEFINED = 0,
+    CYCLIC = 1,
+    NUMERICAL = 2,
+    TOGGLE = 3,
+    LAUNCHER = 4,
+  };
+
+  /**
    * Remove all existing interaction commands and add all default bindings
    * see INTERACTIONS.md for details.
    */
@@ -145,8 +145,8 @@ public:
    * the first is the doc itself, the second is the current value as a string, if any.
    * Use `getBindingDocumentation` to access this doc.
    *
-   * bindingType is an optional type to provide, it can be used for presenting the
-   * binding in a coherent way in outputs and cheatsheet.
+   * type is an optional type of binding to provide, it can be used for presenting the
+   * binding in a coherent way in logs and cheatsheet.
    *
    * When the corresponding bind happens, the provided commands will be triggered using
    * triggerCommand. Considering checking if an interaction exists or removing it before adding it
@@ -158,7 +158,7 @@ public:
    * Adding commands for an existing bind will throw a interactor::already_exists_exception.
    */
   virtual interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,
-    std::string group = {}, documentation_callback_t documentationCallback = nullptr, binding_type_t bindingType = binding_type_t::ANY) = 0;
+    std::string group = {}, documentation_callback_t documentationCallback = nullptr, BindingType type = BindingType::UNDEFINED) = 0;
 
   /**
    * See addBinding
@@ -168,13 +168,13 @@ public:
    * Adding command for an existing bind will throw a interactor::already_exists_exception.
    */
   virtual interactor& addBinding(const interaction_bind_t& bind, std::string command,
-    std::string group = {}, documentation_callback_t documentationCallback = nullptr, binding_type_t bindingType = binding_type_t::ANY) = 0;
+    std::string group = {}, documentation_callback_t documentationCallback = nullptr, BindingType type = BindingType::UNDEFINED) = 0;
 
   /**
    * Convenience initializer list signature for add binding method
    */
   interactor& addBinding(const interaction_bind_t& bind, std::initializer_list<std::string> list,
-    std::string group = {}, documentation_callback_t documentationCallback = nullptr, binding_type_t bindingType = binding_type_t::ANY)
+    std::string group = {}, documentation_callback_t documentationCallback = nullptr, BindingType type = BindingType::UNDEFINED)
   {
     return this->addBinding(
       bind, std::vector<std::string>(list), std::move(group), std::move(documentationCallback));
@@ -225,7 +225,7 @@ public:
    *
    * Getting type for a bind that does not exists will throw a does_not_exists_exception.
    */
-  [[nodiscard]] virtual binding_type_t getBindingType(
+  [[nodiscard]] virtual BindingType getBindingType(
     const interaction_bind_t& bind) const = 0;
   ///@}
 

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -116,11 +116,10 @@ public:
    */
   enum class BindingType : std::uint8_t
   {
-    UNDEFINED = 0,
-    CYCLIC = 1,
-    NUMERICAL = 2,
-    TOGGLE = 3,
-    LAUNCHER = 4,
+    CYCLIC = 0,
+    NUMERICAL = 1,
+    TOGGLE = 2,
+    OTHER = 3,
   };
 
   /**
@@ -159,7 +158,7 @@ public:
    */
   virtual interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,
     std::string group = {}, documentation_callback_t documentationCallback = nullptr,
-    BindingType type = BindingType::UNDEFINED) = 0;
+    BindingType type = BindingType::OTHER) = 0;
 
   /**
    * See addBinding
@@ -170,17 +169,17 @@ public:
    */
   virtual interactor& addBinding(const interaction_bind_t& bind, std::string command,
     std::string group = {}, documentation_callback_t documentationCallback = nullptr,
-    BindingType type = BindingType::UNDEFINED) = 0;
+    BindingType type = BindingType::OTHER) = 0;
 
   /**
    * Convenience initializer list signature for add binding method
    */
   interactor& addBinding(const interaction_bind_t& bind, std::initializer_list<std::string> list,
     std::string group = {}, documentation_callback_t documentationCallback = nullptr,
-    BindingType type = BindingType::UNDEFINED)
+    BindingType type = BindingType::OTHER)
   {
     return this->addBinding(
-      bind, std::vector<std::string>(list), std::move(group), std::move(documentationCallback));
+      bind, std::vector<std::string>(list), std::move(group), std::move(documentationCallback), type);
   }
 
   /**

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -58,6 +58,7 @@ public:
   {
     std::vector<std::string> CommandVector;
     documentation_callback_t DocumentationCallback;
+    binding_type_t BindingType;
   };
 
   internals(options& options, window_impl& window, scene_impl& scene, interactor_impl& inter)
@@ -1240,10 +1241,10 @@ interactor& interactor_impl::initBindings()
 //----------------------------------------------------------------------------
 interactor& interactor_impl::addBinding(const interaction_bind_t& bind,
   std::vector<std::string> commands, std::string group,
-  documentation_callback_t documentationCallback)
+  documentation_callback_t documentationCallback, binding_type_t bindingType)
 {
   const auto [it, success] = this->Internals->Bindings.insert(
-    { bind, { std::move(commands), std::move(documentationCallback) } });
+    { bind, { std::move(commands), std::move(documentationCallback), std::move(bindingType) } });
   if (!success)
   {
     throw interactor::already_exists_exception(
@@ -1265,10 +1266,10 @@ interactor& interactor_impl::addBinding(const interaction_bind_t& bind,
 
 //----------------------------------------------------------------------------
 interactor& interactor_impl::addBinding(const interaction_bind_t& bind, std::string command,
-  std::string group, documentation_callback_t documentationCallback)
+  std::string group, documentation_callback_t documentationCallback, binding_type_t bindingType)
 {
   return this->addBinding(bind, std::vector<std::string>{ std::move(command) }, std::move(group),
-    std::move(documentationCallback));
+    std::move(documentationCallback), std::move(bindingType));
 }
 
 //----------------------------------------------------------------------------
@@ -1344,6 +1345,19 @@ std::pair<std::string, std::string> interactor_impl::getBindingDocumentation(
   }
   const auto& docFunc = it->second.DocumentationCallback;
   return docFunc ? docFunc() : std::make_pair(std::string(), std::string());
+}
+
+//----------------------------------------------------------------------------
+binding_type_t interactor_impl::getBindingType(
+  const interaction_bind_t& bind) const
+{
+  const auto& it = this->Internals->Bindings.find(bind);
+  if (it == this->Internals->Bindings.end())
+  {
+    throw interactor_impl::does_not_exists_exception(
+      std::string("Bind: ") + bind.format() + " does not exists");
+  }
+  return it->second.BindingType;
 }
 
 //----------------------------------------------------------------------------

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -1244,7 +1244,7 @@ interactor& interactor_impl::addBinding(const interaction_bind_t& bind,
   documentation_callback_t documentationCallback, BindingType type)
 {
   const auto [it, success] = this->Internals->Bindings.insert(
-    { bind, { std::move(commands), std::move(documentationCallback), std::move(type) } });
+    { bind, { std::move(commands), std::move(documentationCallback), type } });
   if (!success)
   {
     throw interactor::already_exists_exception(
@@ -1269,7 +1269,7 @@ interactor& interactor_impl::addBinding(const interaction_bind_t& bind, std::str
   std::string group, documentation_callback_t documentationCallback, BindingType type)
 {
   return this->addBinding(bind, std::vector<std::string>{ std::move(command) }, std::move(group),
-    std::move(documentationCallback), std::move(type));
+    std::move(documentationCallback), type);
 }
 
 //----------------------------------------------------------------------------

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -1348,8 +1348,7 @@ std::pair<std::string, std::string> interactor_impl::getBindingDocumentation(
 }
 
 //----------------------------------------------------------------------------
-f3d::interactor::BindingType interactor_impl::getBindingType(
-  const interaction_bind_t& bind) const
+f3d::interactor::BindingType interactor_impl::getBindingType(const interaction_bind_t& bind) const
 {
   const auto& it = this->Internals->Bindings.find(bind);
   if (it == this->Internals->Bindings.end())

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -58,7 +58,7 @@ public:
   {
     std::vector<std::string> CommandVector;
     documentation_callback_t DocumentationCallback;
-    binding_type_t BindingType;
+    BindingType Type;
   };
 
   internals(options& options, window_impl& window, scene_impl& scene, interactor_impl& inter)
@@ -1241,10 +1241,10 @@ interactor& interactor_impl::initBindings()
 //----------------------------------------------------------------------------
 interactor& interactor_impl::addBinding(const interaction_bind_t& bind,
   std::vector<std::string> commands, std::string group,
-  documentation_callback_t documentationCallback, binding_type_t bindingType)
+  documentation_callback_t documentationCallback, BindingType type)
 {
   const auto [it, success] = this->Internals->Bindings.insert(
-    { bind, { std::move(commands), std::move(documentationCallback), std::move(bindingType) } });
+    { bind, { std::move(commands), std::move(documentationCallback), std::move(type) } });
   if (!success)
   {
     throw interactor::already_exists_exception(
@@ -1266,10 +1266,10 @@ interactor& interactor_impl::addBinding(const interaction_bind_t& bind,
 
 //----------------------------------------------------------------------------
 interactor& interactor_impl::addBinding(const interaction_bind_t& bind, std::string command,
-  std::string group, documentation_callback_t documentationCallback, binding_type_t bindingType)
+  std::string group, documentation_callback_t documentationCallback, BindingType type)
 {
   return this->addBinding(bind, std::vector<std::string>{ std::move(command) }, std::move(group),
-    std::move(documentationCallback), std::move(bindingType));
+    std::move(documentationCallback), std::move(type));
 }
 
 //----------------------------------------------------------------------------
@@ -1348,7 +1348,7 @@ std::pair<std::string, std::string> interactor_impl::getBindingDocumentation(
 }
 
 //----------------------------------------------------------------------------
-binding_type_t interactor_impl::getBindingType(
+f3d::interactor::BindingType interactor_impl::getBindingType(
   const interaction_bind_t& bind) const
 {
   const auto& it = this->Internals->Bindings.find(bind);
@@ -1357,7 +1357,7 @@ binding_type_t interactor_impl::getBindingType(
     throw interactor_impl::does_not_exists_exception(
       std::string("Bind: ") + bind.format() + " does not exists");
   }
-  return it->second.BindingType;
+  return it->second.Type;
 }
 
 //----------------------------------------------------------------------------

--- a/library/testing/TestSDKInteractorDocumentation.cxx
+++ b/library/testing/TestSDKInteractorDocumentation.cxx
@@ -54,8 +54,8 @@ int TestSDKInteractorDocumentation(int argc, char* argv[])
     test.expect<f3d::interactor::does_not_exists_exception>(
       "Empty group", [&]() { std::ignore = inter.getBindsForGroup("Camera"); });
 
-    test.expect<f3d::interactor::does_not_exists_exception>(
-      "Empty documentation", [&]() { std::ignore = inter.getBindingDocumentation({ mod_t::ANY, "5" }); });
+    test.expect<f3d::interactor::does_not_exists_exception>("Empty documentation",
+      [&]() { std::ignore = inter.getBindingDocumentation({ mod_t::ANY, "5" }); });
 
     test.expect<f3d::interactor::does_not_exists_exception>(
       "Empty type", [&]() { std::ignore = inter.getBindingType({ mod_t::ANY, "5" }); });

--- a/library/testing/TestSDKInteractorDocumentation.cxx
+++ b/library/testing/TestSDKInteractorDocumentation.cxx
@@ -59,8 +59,10 @@ int TestSDKInteractorDocumentation(int argc, char* argv[])
   }
 
   // Add a dummy binding
-  inter.addBinding({ mod_t::ANY, "DummyBind" }, "DummyCommand", "DummyGroup",
-    []() -> std::pair<std::string, std::string> { return std::pair("DummyDoc", "DummyVal"); }, f3d::interactor::BindingType::LAUNCHER);
+  inter.addBinding(
+    { mod_t::ANY, "DummyBind" }, "DummyCommand", "DummyGroup",
+    []() -> std::pair<std::string, std::string> { return std::pair("DummyDoc", "DummyVal"); },
+    f3d::interactor::BindingType::LAUNCHER);
 
   {
     // Test dummy binding
@@ -69,7 +71,8 @@ int TestSDKInteractorDocumentation(int argc, char* argv[])
     test("Dummy nBinds DummyGroup", inter.getBindsForGroup("DummyGroup").size() == 1);
     const auto& [doc, val] = inter.getBindingDocumentation({ mod_t::ANY, "DummyBind" });
     test("Dummy doc and val", doc == "DummyDoc" && val == "DummyVal");
-    test("Dummy binding type", inter.getBindingType({ mod_t::ANY, "DummyBind" }) == f3d::interactor::BindingType::LAUNCHER);
+    test("Dummy binding type",
+      inter.getBindingType({ mod_t::ANY, "DummyBind" }) == f3d::interactor::BindingType::LAUNCHER);
   }
 
   // Initialize two times

--- a/library/testing/TestSDKInteractorDocumentation.cxx
+++ b/library/testing/TestSDKInteractorDocumentation.cxx
@@ -60,7 +60,7 @@ int TestSDKInteractorDocumentation(int argc, char* argv[])
 
   // Add a dummy binding
   inter.addBinding({ mod_t::ANY, "DummyBind" }, "DummyCommand", "DummyGroup",
-    []() -> std::pair<std::string, std::string> { return std::pair("DummyDoc", "DummyVal"); });
+    []() -> std::pair<std::string, std::string> { return std::pair("DummyDoc", "DummyVal"); }, f3d::interactor::BindingType::LAUNCHER);
 
   {
     // Test dummy binding
@@ -69,6 +69,7 @@ int TestSDKInteractorDocumentation(int argc, char* argv[])
     test("Dummy nBinds DummyGroup", inter.getBindsForGroup("DummyGroup").size() == 1);
     const auto& [doc, val] = inter.getBindingDocumentation({ mod_t::ANY, "DummyBind" });
     test("Dummy doc and val", doc == "DummyDoc" && val == "DummyVal");
+    test("Dummy binding type", inter.getBindingType({ mod_t::ANY, "DummyBind" }) == f3d::interactor::BindingType::LAUNCHER);
   }
 
   // Initialize two times

--- a/library/testing/TestSDKInteractorDocumentation.cxx
+++ b/library/testing/TestSDKInteractorDocumentation.cxx
@@ -55,14 +55,17 @@ int TestSDKInteractorDocumentation(int argc, char* argv[])
       "Empty group", [&]() { std::ignore = inter.getBindsForGroup("Camera"); });
 
     test.expect<f3d::interactor::does_not_exists_exception>(
-      "Empty bind", [&]() { std::ignore = inter.getBindingDocumentation({ mod_t::ANY, "5" }); });
+      "Empty documentation", [&]() { std::ignore = inter.getBindingDocumentation({ mod_t::ANY, "5" }); });
+
+    test.expect<f3d::interactor::does_not_exists_exception>(
+      "Empty type", [&]() { std::ignore = inter.getBindingType({ mod_t::ANY, "5" }); });
   }
 
   // Add a dummy binding
   inter.addBinding(
     { mod_t::ANY, "DummyBind" }, "DummyCommand", "DummyGroup",
     []() -> std::pair<std::string, std::string> { return std::pair("DummyDoc", "DummyVal"); },
-    f3d::interactor::BindingType::LAUNCHER);
+    f3d::interactor::BindingType::CYCLIC);
 
   {
     // Test dummy binding
@@ -72,7 +75,7 @@ int TestSDKInteractorDocumentation(int argc, char* argv[])
     const auto& [doc, val] = inter.getBindingDocumentation({ mod_t::ANY, "DummyBind" });
     test("Dummy doc and val", doc == "DummyDoc" && val == "DummyVal");
     test("Dummy binding type",
-      inter.getBindingType({ mod_t::ANY, "DummyBind" }) == f3d::interactor::BindingType::LAUNCHER);
+      inter.getBindingType({ mod_t::ANY, "DummyBind" }) == f3d::interactor::BindingType::CYCLIC);
   }
 
   // Initialize two times

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -297,16 +297,21 @@ PYBIND11_MODULE(pyf3d, module)
     .value("OTHER", f3d::interactor::BindingType::OTHER)
     .export_values();
 
-  interactor.def("add_binding",
+  interactor
+    .def("add_binding",
       py::overload_cast<const f3d::interaction_bind_t&, std::string, std::string,
         std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(
         &f3d::interactor::addBinding),
-      "Add a binding command", py::arg("bind"), py::arg("command"), py::arg("group"), py::arg("documentationCallback") = nullptr, py::arg("type") = f3d::interactor::BindingType::OTHER)
+      "Add a binding command", py::arg("bind"), py::arg("command"), py::arg("group"),
+      py::arg("documentationCallback") = nullptr,
+      py::arg("type") = f3d::interactor::BindingType::OTHER)
     .def("add_binding",
       py::overload_cast<const f3d::interaction_bind_t&, std::vector<std::string>, std::string,
         std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(
         &f3d::interactor::addBinding),
-      "Add binding commands", py::arg("bind"), py::arg("command"), py::arg("group"), py::arg("documentationCallback") = nullptr, py::arg("type") = f3d::interactor::BindingType::OTHER);
+      "Add binding commands", py::arg("bind"), py::arg("command"), py::arg("group"),
+      py::arg("documentationCallback") = nullptr,
+      py::arg("type") = f3d::interactor::BindingType::OTHER);
 
   py::enum_<f3d::interactor::MouseButton>(interactor, "MouseButton")
     .value("LEFT", f3d::interactor::MouseButton::LEFT)

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -285,17 +285,25 @@ PYBIND11_MODULE(pyf3d, module)
       "Remove all bindings and add default bindings")
     .def("add_binding",
       py::overload_cast<const f3d::interaction_bind_t&, std::string, std::string,
-        std::function<std::pair<std::string, std::string>()>>(&f3d::interactor::addBinding),
+        std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(&f3d::interactor::addBinding),
       "Add a binding command")
     .def("add_binding",
       py::overload_cast<const f3d::interaction_bind_t&, std::vector<std::string>, std::string,
-        std::function<std::pair<std::string, std::string>()>>(&f3d::interactor::addBinding),
+        std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(&f3d::interactor::addBinding),
       "Add binding commands")
     .def("remove_binding", &f3d::interactor::removeBinding, "Remove interaction commands")
     .def("get_bind_groups", &f3d::interactor::getBindGroups)
     .def("get_binds_for_group", &f3d::interactor::getBindsForGroup)
     .def("get_binds", &f3d::interactor::getBinds)
     .def("get_binding_documentation", &f3d::interactor::getBindingDocumentation);
+
+  py::enum_<f3d::interactor::BindingType>(interactor, "BindingType")
+    .value("UNDEFINED", f3d::interactor::BindingType::UNDEFINED)
+    .value("CYCLIC", f3d::interactor::BindingType::CYCLIC)
+    .value("NUMERICAL", f3d::interactor::BindingType::NUMERICAL)
+    .value("TOGGLE", f3d::interactor::BindingType::TOGGLE)
+    .value("LAUNCHER", f3d::interactor::BindingType::LAUNCHER)
+    .export_values();
 
   py::enum_<f3d::interactor::MouseButton>(interactor, "MouseButton")
     .value("LEFT", f3d::interactor::MouseButton::LEFT)

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -285,11 +285,13 @@ PYBIND11_MODULE(pyf3d, module)
       "Remove all bindings and add default bindings")
     .def("add_binding",
       py::overload_cast<const f3d::interaction_bind_t&, std::string, std::string,
-        std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(&f3d::interactor::addBinding),
+        std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(
+        &f3d::interactor::addBinding),
       "Add a binding command")
     .def("add_binding",
       py::overload_cast<const f3d::interaction_bind_t&, std::vector<std::string>, std::string,
-        std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(&f3d::interactor::addBinding),
+        std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(
+        &f3d::interactor::addBinding),
       "Add binding commands")
     .def("remove_binding", &f3d::interactor::removeBinding, "Remove interaction commands")
     .def("get_bind_groups", &f3d::interactor::getBindGroups)

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -283,16 +283,6 @@ PYBIND11_MODULE(pyf3d, module)
     .def("trigger_command", &f3d::interactor::triggerCommand, "Trigger a command")
     .def("init_bindings", &f3d::interactor::initBindings,
       "Remove all bindings and add default bindings")
-    .def("add_binding",
-      py::overload_cast<const f3d::interaction_bind_t&, std::string, std::string,
-        std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(
-        &f3d::interactor::addBinding),
-      "Add a binding command")
-    .def("add_binding",
-      py::overload_cast<const f3d::interaction_bind_t&, std::vector<std::string>, std::string,
-        std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(
-        &f3d::interactor::addBinding),
-      "Add binding commands")
     .def("remove_binding", &f3d::interactor::removeBinding, "Remove interaction commands")
     .def("get_bind_groups", &f3d::interactor::getBindGroups)
     .def("get_binds_for_group", &f3d::interactor::getBindsForGroup)
@@ -301,12 +291,22 @@ PYBIND11_MODULE(pyf3d, module)
     .def("get_binding_type", &f3d::interactor::getBindingType);
 
   py::enum_<f3d::interactor::BindingType>(interactor, "BindingType")
-    .value("UNDEFINED", f3d::interactor::BindingType::UNDEFINED)
     .value("CYCLIC", f3d::interactor::BindingType::CYCLIC)
     .value("NUMERICAL", f3d::interactor::BindingType::NUMERICAL)
     .value("TOGGLE", f3d::interactor::BindingType::TOGGLE)
-    .value("LAUNCHER", f3d::interactor::BindingType::LAUNCHER)
+    .value("OTHER", f3d::interactor::BindingType::OTHER)
     .export_values();
+
+  interactor.def("add_binding",
+      py::overload_cast<const f3d::interaction_bind_t&, std::string, std::string,
+        std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(
+        &f3d::interactor::addBinding),
+      "Add a binding command", py::arg("bind"), py::arg("command"), py::arg("group"), py::arg("documentationCallback") = nullptr, py::arg("type") = f3d::interactor::BindingType::OTHER)
+    .def("add_binding",
+      py::overload_cast<const f3d::interaction_bind_t&, std::vector<std::string>, std::string,
+        std::function<std::pair<std::string, std::string>()>, f3d::interactor::BindingType>(
+        &f3d::interactor::addBinding),
+      "Add binding commands", py::arg("bind"), py::arg("command"), py::arg("group"), py::arg("documentationCallback") = nullptr, py::arg("type") = f3d::interactor::BindingType::OTHER);
 
   py::enum_<f3d::interactor::MouseButton>(interactor, "MouseButton")
     .value("LEFT", f3d::interactor::MouseButton::LEFT)

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -295,7 +295,8 @@ PYBIND11_MODULE(pyf3d, module)
     .def("get_bind_groups", &f3d::interactor::getBindGroups)
     .def("get_binds_for_group", &f3d::interactor::getBindsForGroup)
     .def("get_binds", &f3d::interactor::getBinds)
-    .def("get_binding_documentation", &f3d::interactor::getBindingDocumentation);
+    .def("get_binding_documentation", &f3d::interactor::getBindingDocumentation)
+    .def("get_binding_type", &f3d::interactor::getBindingType);
 
   py::enum_<f3d::interactor::BindingType>(interactor, "BindingType")
     .value("UNDEFINED", f3d::interactor::BindingType::UNDEFINED)

--- a/python/testing/test_interactor.py
+++ b/python/testing/test_interactor.py
@@ -51,30 +51,35 @@ def test_binding():
         "dummy command",
         "DummyGroup",
         doc_fn,
+        f3d.Interactor.BindingType.UNDEFINED,
     )
     inter.add_binding(
         f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.NONE, "P"),
         "dummy command",
         "DummyGroup",
         doc_fn,
+        f3d.Interactor.BindingType.CYCLIC,
     )
     inter.add_binding(
         f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.CTRL, "P"),
         "dummy command",
         "DummyGroup",
         doc_fn,
+        f3d.Interactor.BindingType.NUMERICAL,
     )
     inter.add_binding(
         f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.SHIFT, "P"),
         "dummy command",
         "DummyGroup",
         doc_fn,
+        f3d.Interactor.BindingType.TOGGLE,
     )
     inter.add_binding(
         f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.CTRL_SHIFT, "P"),
         ["dummy command", "dummy command"],
         "DummyGroup",
         doc_fn,
+        f3d.Interactor.BindingType.LAUNCHER,
     )
     assert len(inter.get_bind_groups()) == 1
     assert len(inter.get_binds()) == 5

--- a/python/testing/test_interactor.py
+++ b/python/testing/test_interactor.py
@@ -83,6 +83,8 @@ def test_binding():
     )
     assert len(inter.get_bind_groups()) == 1
     assert len(inter.get_binds()) == 5
+    assert inter.get_binding_documentation(f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.CTRL, "P")) == doc_fn()
+    assert inter.get_binding_type(f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.CTRL, "P")) == f3d.Interactor.BindingType.NUMERICAL
 
     inter.init_bindings()
 

--- a/python/testing/test_interactor.py
+++ b/python/testing/test_interactor.py
@@ -51,7 +51,6 @@ def test_binding():
         "dummy command",
         "DummyGroup",
         doc_fn,
-        f3d.Interactor.BindingType.UNDEFINED,
     )
     inter.add_binding(
         f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.NONE, "P"),
@@ -79,7 +78,7 @@ def test_binding():
         ["dummy command", "dummy command"],
         "DummyGroup",
         doc_fn,
-        f3d.Interactor.BindingType.LAUNCHER,
+        f3d.Interactor.BindingType.OTHER,
     )
     assert len(inter.get_bind_groups()) == 1
     assert len(inter.get_binds()) == 5

--- a/python/testing/test_interactor.py
+++ b/python/testing/test_interactor.py
@@ -83,8 +83,18 @@ def test_binding():
     )
     assert len(inter.get_bind_groups()) == 1
     assert len(inter.get_binds()) == 5
-    assert inter.get_binding_documentation(f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.CTRL, "P")) == doc_fn()
-    assert inter.get_binding_type(f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.CTRL, "P")) == f3d.Interactor.BindingType.NUMERICAL
+    assert (
+        inter.get_binding_documentation(
+            f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.CTRL, "P")
+        )
+        == doc_fn()
+    )
+    assert (
+        inter.get_binding_type(
+            f3d.InteractionBind(f3d.InteractionBind.ModifierKeys.CTRL, "P")
+        )
+        == f3d.Interactor.BindingType.NUMERICAL
+    )
 
     inter.init_bindings()
 


### PR DESCRIPTION
### Describe your changes

Add an optional argument to the `interactor::addBinding` API to specify the binding type.
It is intended to be used for UI/UX purpose.

### Issue ticket number and link if any

Related to #2394

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
