### PR TITLE
CI: Move from checkboxes to labels for CI triggering

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,16 +12,5 @@
 
 ### Continuous integration
 
-Please check the checkbox of the CI you want to run, then push again on your branch.
-
-- [ ] Style checks
-- [ ] Fast CI
-- [ ] Coverage cached CI
-- [ ] Analysis cached CI
-- [ ] WASM docker CI
-- [ ] Android docker CI
-- [ ] macOS Intel cached CI
-- [ ] macOS ARM cached CI
-- [ ] Windows cached CI
-- [ ] Linux cached CI
-- [ ] Other cached CI
+Please write a comment to run CI, eg: `\label ci:fast`.
+See [here](https://f3d.app/CONTRIBUTING.html#continuous-integration) for more info.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,5 @@
 
 ### Continuous integration
 
-Please write a comment to run CI, eg: `\label ci:fast`.
+Please write a comment to run CI, eg: `\ci fast`.
 See [here](https://f3d.app/CONTRIBUTING.html#continuous-integration) for more info.

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -16,7 +16,7 @@ jobs:
   default_versions:
     runs-on: ubuntu-22.04
     name: Set default versions
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
+    if: contains(github.event.pull_request.labels.*.name, 'ci:full')
     outputs:
       timestamp: ${{ steps.set_default_versions.outputs.timestamp }}
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -16,7 +16,7 @@ jobs:
   default_versions:
     runs-on: ubuntu-22.04
     name: Set default versions
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:docker')) }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
     outputs:
       timestamp: ${{ steps.set_default_versions.outputs.timestamp }}
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,6 +1,6 @@
 on:
   pull_request_target:
-    types: [assigned, opened, synchronize, reopened]
+    types: [assigned, opened, synchronize, reopened, labeled]
     branches:
       - master
       - release
@@ -11,38 +11,12 @@ on:
 name: Build docker images
 jobs:
   #----------------------------------------------------------------------------
-  # Detect checkboxes are checked
-  #----------------------------------------------------------------------------
-  detect_checkboxes:
-    name: Detect Checkboxes
-    runs-on: ubuntu-latest
-    outputs:
-      checked: ${{ steps.detect.outputs.checked }}
-      unchecked: ${{ steps.detect.outputs.unchecked }}
-
-    permissions:
-      pull-requests: write
-
-    steps:
-      - name: Checkbox Trigger
-        id: detect
-        uses: AhmedBaset/checklist@3
-        with:
-          token: ${{ github.token }}
-
-      - name: list changes
-        run: |
-          echo "checked=${{ steps.detect.outputs.checked }}"
-          echo "unchecked=${{ steps.detect.outputs.unchecked }}"
-
-  #----------------------------------------------------------------------------
   # Default versions: Set default version for all dependencies
   #----------------------------------------------------------------------------
   default_versions:
     runs-on: ubuntu-22.04
     name: Set default versions
-    needs: detect_checkboxes
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'docker CI')) }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:docker')) }}
     outputs:
       timestamp: ${{ steps.set_default_versions.outputs.timestamp }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
   default_versions:
     runs-on: ubuntu-22.04
     name: Set default versions
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full_run')) || (github.ref == 'refs/heads/master') }}
     outputs:
       alembic_min_version: ${{ steps.set_default_versions.outputs.alembic_min_version }}
       alembic_version: ${{ steps.set_default_versions.outputs.alembic_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ jobs:
   default_versions:
     runs-on: ubuntu-22.04
     name: Set default versions
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     outputs:
       alembic_min_version: ${{ steps.set_default_versions.outputs.alembic_min_version }}
       alembic_version: ${{ steps.set_default_versions.outputs.alembic_version }}
@@ -76,7 +80,11 @@ jobs:
   cache_lfs:
     runs-on: ubuntu-22.04
     name: Update LFS data cache
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     outputs:
       lfs_sha: ${{ steps.lfs_sha_recover.outputs.lfs_sha }}
     steps:
@@ -99,7 +107,10 @@ jobs:
   cache_dependencies:
     name: Cache dependencies
     needs: [default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -173,7 +184,10 @@ jobs:
   cache_vtk_dependency:
     name: Cache VTK dependency
     needs: [default_versions, cache_dependencies]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -280,7 +294,10 @@ jobs:
   #----------------------------------------------------------------------------
   windows:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -334,7 +351,11 @@ jobs:
   #----------------------------------------------------------------------------
   linux_fast:
     needs: [cache_lfs, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
 
@@ -368,7 +389,10 @@ jobs:
   #----------------------------------------------------------------------------
   linux:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -560,7 +584,10 @@ jobs:
   #----------------------------------------------------------------------------
   macos:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -609,7 +636,10 @@ jobs:
   #----------------------------------------------------------------------------
   macos_arm:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -667,7 +697,9 @@ jobs:
   #----------------------------------------------------------------------------
   python-packaging:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -723,7 +755,10 @@ jobs:
   #----------------------------------------------------------------------------
   coverage:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
 
@@ -767,7 +802,9 @@ jobs:
   # https://stackoverflow.com/questions/60097307/memory-sanitizer-reports-use-of-uninitialized-value-in-global-object-constructio
   sanitizer:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -811,7 +848,9 @@ jobs:
   #----------------------------------------------------------------------------
   static-analysis:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
 
@@ -852,7 +891,9 @@ jobs:
   #----------------------------------------------------------------------------
   external-build:
     needs: [cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
 
@@ -896,7 +937,9 @@ jobs:
   # android: Check build of F3D for android
   #----------------------------------------------------------------------------
   android:
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -923,7 +966,9 @@ jobs:
   #----------------------------------------------------------------------------
   webassembly:
     needs: [default_versions, check_docker_images]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
   #----------------------------------------------------------------------------
   cache_dependencies:
     name: Cache dependencies
-    needs: [default_versions]
+    needs: default_versions
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -937,6 +937,7 @@ jobs:
   # android: Check build of F3D for android
   #----------------------------------------------------------------------------
   android:
+    needs: [default_versions, check_docker_images]
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,8 +279,7 @@ jobs:
   # Windows CI: Build and test, cross-vtk build matrix
   #----------------------------------------------------------------------------
   windows:
-    needs:
-      [cache_lfs, cache_vtk_dependency, default_versions]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions]
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
@@ -560,8 +559,7 @@ jobs:
   # MacOS CI: Build and test, cross-vtk build matrix
   #----------------------------------------------------------------------------
   macos:
-    needs:
-      [cache_lfs, cache_vtk_dependency, default_versions]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions]
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
@@ -610,8 +608,7 @@ jobs:
   # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
   #----------------------------------------------------------------------------
   macos_arm:
-    needs:
-      [cache_lfs, cache_vtk_dependency, default_versions]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions]
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
@@ -769,8 +766,7 @@ jobs:
   # "memory" returns false positives in VTK:
   # https://stackoverflow.com/questions/60097307/memory-sanitizer-reports-use-of-uninitialized-value-in-global-object-constructio
   sanitizer:
-    needs:
-      [cache_lfs, cache_vtk_dependency, default_versions]
+    needs: [cache_lfs, cache_vtk_dependency, default_versions]
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     paths-ignore:
       - "doc/**"
       - "_config.yml"
@@ -48,8 +48,7 @@ jobs:
   default_versions:
     runs-on: ubuntu-22.04
     name: Set default versions
-    needs: detect_checkboxes
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'CI')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci')) || (github.ref == 'refs/heads/master') }}
     outputs:
       alembic_min_version: ${{ steps.set_default_versions.outputs.alembic_min_version }}
       alembic_version: ${{ steps.set_default_versions.outputs.alembic_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   default_versions:
     runs-on: ubuntu-22.04
     name: Set default versions
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:versions')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     outputs:
       alembic_min_version: ${{ steps.set_default_versions.outputs.alembic_min_version }}
       alembic_version: ${{ steps.set_default_versions.outputs.alembic_version }}
@@ -76,7 +76,7 @@ jobs:
   cache_lfs:
     runs-on: ubuntu-22.04
     name: Update LFS data cache
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:cached')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     outputs:
       lfs_sha: ${{ steps.lfs_sha_recover.outputs.lfs_sha }}
     steps:
@@ -99,7 +99,7 @@ jobs:
   cache_dependencies:
     name: Cache dependencies
     needs: [default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:cached')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -173,7 +173,7 @@ jobs:
   cache_vtk_dependency:
     name: Cache VTK dependency
     needs: [default_versions, cache_dependencies]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:cached')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -281,7 +281,7 @@ jobs:
   windows:
     needs:
       [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:windows')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -335,7 +335,7 @@ jobs:
   #----------------------------------------------------------------------------
   linux_fast:
     needs: [cache_lfs, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
 
@@ -369,7 +369,7 @@ jobs:
   #----------------------------------------------------------------------------
   linux:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:linux')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -562,7 +562,7 @@ jobs:
   macos:
     needs:
       [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:macos_intel')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -612,7 +612,7 @@ jobs:
   macos_arm:
     needs:
       [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:macos_arm')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -670,7 +670,7 @@ jobs:
   #----------------------------------------------------------------------------
   python-packaging:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:other')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -726,7 +726,7 @@ jobs:
   #----------------------------------------------------------------------------
   coverage:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:coverage')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
 
@@ -771,7 +771,7 @@ jobs:
   sanitizer:
     needs:
       [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:other')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -815,7 +815,7 @@ jobs:
   #----------------------------------------------------------------------------
   static-analysis:
     needs: [cache_lfs, cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:analysis')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
 
@@ -856,7 +856,7 @@ jobs:
   #----------------------------------------------------------------------------
   external-build:
     needs: [cache_vtk_dependency, default_versions]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:other')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
 
@@ -900,7 +900,7 @@ jobs:
   # android: Check build of F3D for android
   #----------------------------------------------------------------------------
   android:
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:android')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -927,7 +927,7 @@ jobs:
   #----------------------------------------------------------------------------
   webassembly:
     needs: [default_versions, check_docker_images]
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:wasm')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,39 +16,12 @@ concurrency:
 
 jobs:
   #----------------------------------------------------------------------------
-  # Detect checkboxes are checked
-  #----------------------------------------------------------------------------
-  detect_checkboxes:
-    name: Detect Checkboxes
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    outputs:
-      checked: ${{ steps.detect.outputs.checked }}
-      unchecked: ${{ steps.detect.outputs.unchecked }}
-
-    permissions:
-      pull-requests: write
-
-    steps:
-      - name: Checkbox Trigger
-        id: detect
-        uses: AhmedBaset/checklist@3
-        with:
-          token: ${{ github.token }}
-
-      - name: list changes
-        run: |
-          echo "checked=${{ steps.detect.outputs.checked }}"
-          echo "unchecked=${{ steps.detect.outputs.unchecked }}"
-          echo "${{ github.ref }}"
-
-  #----------------------------------------------------------------------------
   # Default versions: Set default version for all dependencies
   #----------------------------------------------------------------------------
   default_versions:
     runs-on: ubuntu-22.04
     name: Set default versions
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:full_run')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:versions')) || (github.ref == 'refs/heads/master') }}
     outputs:
       alembic_min_version: ${{ steps.set_default_versions.outputs.alembic_min_version }}
       alembic_version: ${{ steps.set_default_versions.outputs.alembic_version }}
@@ -103,8 +76,7 @@ jobs:
   cache_lfs:
     runs-on: ubuntu-22.04
     name: Update LFS data cache
-    needs: detect_checkboxes
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'CI')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:cached')) || (github.ref == 'refs/heads/master') }}
     outputs:
       lfs_sha: ${{ steps.lfs_sha_recover.outputs.lfs_sha }}
     steps:
@@ -126,8 +98,8 @@ jobs:
   #----------------------------------------------------------------------------
   cache_dependencies:
     name: Cache dependencies
-    needs: [default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'cached CI')) || (github.ref == 'refs/heads/master') }}
+    needs: [default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:cached')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -200,8 +172,8 @@ jobs:
   #----------------------------------------------------------------------------
   cache_vtk_dependency:
     name: Cache VTK dependency
-    needs: [default_versions, detect_checkboxes, cache_dependencies]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'cached CI')) || (github.ref == 'refs/heads/master') }}
+    needs: [default_versions, cache_dependencies]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:cached')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -308,8 +280,8 @@ jobs:
   #----------------------------------------------------------------------------
   windows:
     needs:
-      [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Windows cached CI')) || (github.ref == 'refs/heads/master') }}
+      [cache_lfs, cache_vtk_dependency, default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:windows')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -362,9 +334,8 @@ jobs:
   # Linux fast CI: Build and test a single fast CI
   #----------------------------------------------------------------------------
   linux_fast:
-    needs: [cache_lfs, default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Fast CI')) || (github.ref == 'refs/heads/master') }}
-
+    needs: [cache_lfs, default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (github.ref == 'refs/heads/master') }}
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
 
@@ -397,10 +368,8 @@ jobs:
   # Linux CI: Build and test, cross-vtk build matrix
   #----------------------------------------------------------------------------
   linux:
-    needs:
-      [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Linux cached CI')) || (github.ref == 'refs/heads/master') }}
-
+    needs: [cache_lfs, cache_vtk_dependency, default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:linux')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -592,9 +561,8 @@ jobs:
   #----------------------------------------------------------------------------
   macos:
     needs:
-      [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'macOS Intel cached CI')) || (github.ref == 'refs/heads/master') }}
-
+      [cache_lfs, cache_vtk_dependency, default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:macos_intel')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -643,9 +611,8 @@ jobs:
   #----------------------------------------------------------------------------
   macos_arm:
     needs:
-      [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'macOS ARM cached CI')) || (github.ref == 'refs/heads/master') }}
-
+      [cache_lfs, cache_vtk_dependency, default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:macos_arm')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -702,10 +669,8 @@ jobs:
   # Python packaging: Build and test the Python wheel
   #----------------------------------------------------------------------------
   python-packaging:
-    needs:
-      [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Other cached CI')) || (github.ref == 'refs/heads/master') }}
-
+    needs: [cache_lfs, cache_vtk_dependency, default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:other')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -760,10 +725,8 @@ jobs:
   # Coverage: Build and test on linux with last VTK with coverage option
   #----------------------------------------------------------------------------
   coverage:
-    needs:
-      [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Coverage cached CI')) || (github.ref == 'refs/heads/master') }}
-
+    needs: [cache_lfs, cache_vtk_dependency, default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:coverage')) || (github.ref == 'refs/heads/master') }}
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
 
@@ -807,9 +770,8 @@ jobs:
   # https://stackoverflow.com/questions/60097307/memory-sanitizer-reports-use-of-uninitialized-value-in-global-object-constructio
   sanitizer:
     needs:
-      [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Other cached CI')) || (github.ref == 'refs/heads/master') }}
-
+      [cache_lfs, cache_vtk_dependency, default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:other')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -852,10 +814,8 @@ jobs:
   # static-analysis: Run static analysis on linux
   #----------------------------------------------------------------------------
   static-analysis:
-    needs:
-      [cache_lfs, cache_vtk_dependency, default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Analysis cached CI')) || (github.ref == 'refs/heads/master') }}
-
+    needs: [cache_lfs, cache_vtk_dependency, default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:analysis')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
 
@@ -895,9 +855,8 @@ jobs:
   # external-build: Check build of F3D as sub-project
   #----------------------------------------------------------------------------
   external-build:
-    needs: [cache_vtk_dependency, default_versions, detect_checkboxes]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Other cached CI')) || (github.ref == 'refs/heads/master') }}
-
+    needs: [cache_vtk_dependency, default_versions]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:other')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
 
@@ -941,9 +900,7 @@ jobs:
   # android: Check build of F3D for android
   #----------------------------------------------------------------------------
   android:
-    needs: [default_versions, detect_checkboxes, check_docker_images]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Android docker CI')) || (github.ref == 'refs/heads/master') }}
-
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:android')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -969,9 +926,8 @@ jobs:
   # webassembly: Build webassembly artifacts
   #----------------------------------------------------------------------------
   webassembly:
-    needs: [default_versions, detect_checkboxes, check_docker_images]
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'WASM docker CI')) || (github.ref == 'refs/heads/master') }}
-
+    needs: [default_versions, check_docker_images]
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:wasm')) || (github.ref == 'refs/heads/master') }}
     strategy:
       fail-fast: false
 

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -15,7 +15,6 @@ jobs:
         shell: bash
         run: |
           label=$(cut -d " " -f2- <<< "${{ github.event.comment.body }}")
-          echo $label
           gh issue edit ${{ github.event.issue.number }} --add-label "$label"
         env:
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -1,9 +1,4 @@
-on:
-  pull_request_target:
-    types: [issue_comment]
-    branches:
-      - master
-      - release
+on: issue_comment
 name: Labelize
 jobs:
   #----------------------------------------------------------------------------

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -8,8 +8,8 @@ jobs:
     name: Labelize
     runs-on: ubuntu-latest
     if: |
-      ${{ github.event.issue.pull_request }} &&
-      ${{ contains(github.event.comment.body, '\ci') }}
+      github.event.issue.pull_request == &&
+      contains(github.event.comment.body, '\ci')
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.F3D_CI_LABEL }}
@@ -32,9 +32,7 @@ jobs:
           reactions: eyes
 
       - name: Add label on PR
-        if: |
-          ${{ contains(github.event.comment.body, '\ci') }} &&
-          ${{!contains(env.F3D_LABEL_COMMENT, '-')}}
+        if: ${{ contains(github.event.comment.body, '\ci') && !contains(env.F3D_LABEL_COMMENT, '-')}}
         shell: bash
         run: gh issue edit ${{ github.event.issue.number }} --add-label "ci:${{env.F3D_LABEL_COMMENT}}"
 
@@ -52,4 +50,4 @@ jobs:
         if: failure()
         uses: GrantBirki/comment@v2.1.1
         with:
-          body: ❌ Invalid ci command "${{env.F3D_LABEL_COMMENT}}"
+          body: ❌ Invalid CI command "${{env.F3D_LABEL_COMMENT}}"

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       ${{ github.event.issue.pull_request }} &&
-      contains(github.event.comment.body, '\ci')
+      ${{ contains(github.event.comment.body, '\ci') }}
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.F3D_CI_LABEL }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Add label on PR
         if: |
-          contains(github.event.comment.body, '\ci') &&
+          ${{ contains(github.event.comment.body, '\ci') }} &&
           ${{!contains(env.F3D_LABEL_COMMENT, '-')}}
         shell: bash
         run: gh issue edit ${{ github.event.issue.number }} --add-label "ci:${{env.F3D_LABEL_COMMENT}}"

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Add ack reaction
         uses: GrantBirki/comment@v2.1.1
         with:
-          comment-id: ${{ github.event.issue.id }}
+          comment-id: ${{ github.event.issue.number }}
           reactions: eyes
 
       - name: Create comment for invalid command
         if: failure()
         uses: GrantBirki/comment@v2.1.1
         with:
-          body: Invalid ci command ${{env.F3D_LABEL_COMMENT}}
+          body: ❌Invalid ci command "${{env.F3D_LABEL_COMMENT}}"

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -13,3 +13,5 @@ jobs:
       - name: Comment on PR
         shell: bash
         run: gh issue edit ${{ github.event.issue.number }} --add-label "ci:fast"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -16,7 +16,6 @@ jobs:
 
     steps:
       - name: Analyze comment
-        if: contains(github.event.comment.body, '\ci')
         shell: bash
         run: |
           label="${{github.event.comment.body}}"
@@ -25,21 +24,18 @@ jobs:
           echo "F3D_LABEL_COMMENT=$label" >> $GITHUB_ENV
 
       - name: Add ack reaction
-        if: contains(github.event.comment.body, '\ci')
         uses: GrantBirki/comment@v2.1.1
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: eyes
 
       - name: Add label on PR
-        if: ${{ contains(github.event.comment.body, '\ci') && !contains(env.F3D_LABEL_COMMENT, '-')}}
+        if: ${{!contains(env.F3D_LABEL_COMMENT, '-')}}
         shell: bash
         run: gh issue edit ${{ github.event.issue.number }} --add-label "ci:${{env.F3D_LABEL_COMMENT}}"
 
       - name: Remove label on PR
-        if: |
-          contains(github.event.comment.body, '\ci') &&
-          contains(env.F3D_LABEL_COMMENT, '-')
+        if: contains(env.F3D_LABEL_COMMENT, '-')
         shell: bash
         run: |
           label="${{env.F3D_LABEL_COMMENT}}"

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -11,8 +11,12 @@ jobs:
 
     steps:
       - name: Comment on PR
+        if: contains(github.event.comment.body, '\label ci:')
         shell: bash
-        run: gh issue edit ${{ github.event.issue.number }} --add-label "ci:fast"
+        run: |
+          label=${${{ github.event.comment.body }}#* }
+          echo $label
+          gh issue edit ${{ github.event.issue.number }} --add-label "$label"
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.F3D_CI_LABEL }}

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -14,7 +14,7 @@ jobs:
         if: contains(github.event.comment.body, '\label ci:')
         shell: bash
         run: |
-          label=${${{ github.event.comment.body }}#* }
+          label=$(cut -d " " -f2- <<< "${{ github.event.comment.body }}")
           echo $label
           gh issue edit ${{ github.event.issue.number }} --add-label "$label"
         env:

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -14,4 +14,5 @@ jobs:
         shell: bash
         run: gh issue edit ${{ github.event.issue.number }} --add-label "ci:fast"
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -1,0 +1,20 @@
+on:
+  pull_request_target:
+    types: [issue_comment]
+    branches:
+      - master
+      - release
+name: Labelize
+jobs:
+  #----------------------------------------------------------------------------
+  # Labelize
+  #----------------------------------------------------------------------------
+  labelize:
+    name: Labelize
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }}
+
+    steps:
+      - name: Comment on PR
+        shell: bash
+        run: gh issue edit ${{ github.event.issue.number }} --add-label "ci:fast"

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -22,24 +22,29 @@ jobs:
           label=${label%% *}
           echo "F3D_LABEL_COMMENT=$label" >> $GITHUB_ENV
 
+      - name: Add ack reaction
+        if: contains(github.event.comment.body, '\ci')
+        uses: GrantBirki/comment@v2.1.1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: eyes
+
       - name: Add label on PR
-        if: ${{!contains(env.F3D_LABEL_COMMENT, '-')}}
+        if: |
+          contains(github.event.comment.body, '\ci') &&
+          ${{!contains(env.F3D_LABEL_COMMENT, '-')}}
         shell: bash
         run: gh issue edit ${{ github.event.issue.number }} --add-label "ci:${{env.F3D_LABEL_COMMENT}}"
 
       - name: Remove label on PR
-        if: contains(env.F3D_LABEL_COMMENT, '-')
+        if: |
+          contains(github.event.comment.body, '\ci') &&
+          contains(env.F3D_LABEL_COMMENT, '-')
         shell: bash
         run: |
           label="${{env.F3D_LABEL_COMMENT}}"
           label=${label#*-}
           gh issue edit ${{ github.event.issue.number }} --remove-label "ci:$label"
-
-      - name: Add ack reaction
-        uses: GrantBirki/comment@v2.1.1
-        with:
-          comment-id: ${{ github.event.comment.id }}
-          reactions: eyes
 
       - name: Create comment for invalid command
         if: failure()

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -7,7 +7,9 @@ jobs:
   labelize:
     name: Labelize
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request }}
+    if: |
+      ${{ github.event.issue.pull_request }} &&
+      contains(github.event.comment.body, '\ci')
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.F3D_CI_LABEL }}

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -15,4 +15,4 @@ jobs:
         run: gh issue edit ${{ github.event.issue.number }} --add-label "ci:fast"
         env:
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.F3D_CI_LABEL }}

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -48,4 +48,5 @@ jobs:
         with:
           body: |
             > ${{github.event.comment.body}}
+
             ❌ Invalid CI command "${{env.F3D_LABEL_COMMENT}}"

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -14,7 +14,7 @@ jobs:
         if: contains(github.event.comment.body, '\label ci:')
         shell: bash
         run: |
-          label=$(cut -d " " -f2- <<< "${{ github.event.comment.body }}")
+          label=$(cut -d " " -f2 <<< "${{ github.event.comment.body }}")
           gh issue edit ${{ github.event.issue.number }} --add-label "$label"
         env:
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -8,7 +8,7 @@ jobs:
     name: Labelize
     runs-on: ubuntu-latest
     if: |
-      github.event.issue.pull_request == &&
+      github.event.issue.pull_request &&
       contains(github.event.comment.body, '\ci')
     env:
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Add label on PR
         if: ${{!contains(env.F3D_LABEL_COMMENT, '-')}}
         shell: bash
-        run: gh issue edit ${{ github.event.issue.number }} --add-label "${{env.F3D_LABEL_COMMENT}}"
+        run: gh issue edit ${{ github.event.issue.number }} --add-label "ci:${{env.F3D_LABEL_COMMENT}}"
 
       - name: Remove label on PR
         if: contains(env.F3D_LABEL_COMMENT, '-')
@@ -33,4 +33,4 @@ jobs:
         run: |
           label="${{env.F3D_LABEL_COMMENT}}"
           label=${label#*-}
-          gh issue edit ${{ github.event.issue.number }} --remove-label "$label"
+          gh issue edit ${{ github.event.issue.number }} --remove-label "ci:$label"

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -8,14 +8,29 @@ jobs:
     name: Labelize
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request }}
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.F3D_CI_LABEL }}
 
     steps:
-      - name: Comment on PR
-        if: contains(github.event.comment.body, '\label ci:')
+      - name: Analyze comment
+        if: contains(github.event.comment.body, '\ci')
         shell: bash
         run: |
-          label=$(cut -d " " -f2 <<< "${{ github.event.comment.body }}")
-          gh issue edit ${{ github.event.issue.number }} --add-label "$label"
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.F3D_CI_LABEL }}
+          label="${{github.event.comment.body}}"
+          label=${label#* }
+          label=${label%% *}
+          echo "F3D_LABEL_COMMENT=$label" >> $GITHUB_ENV
+
+      - name: Add label on PR
+        if: ${{!contains(env.F3D_LABEL_COMMENT, '-')}}
+        shell: bash
+        run: gh issue edit ${{ github.event.issue.number }} --add-label "${{env.F3D_LABEL_COMMENT}}"
+
+      - name: Remove label on PR
+        if: contains(env.F3D_LABEL_COMMENT, '-')
+        shell: bash
+        run: |
+          label="${{env.F3D_LABEL_COMMENT}}"
+          label=${label#*-}
+          gh issue edit ${{ github.event.issue.number }} --remove-label "$label"

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -46,4 +46,6 @@ jobs:
         if: failure()
         uses: GrantBirki/comment@v2.1.1
         with:
-          body: ❌ Invalid CI command "${{env.F3D_LABEL_COMMENT}}"
+          body: |
+            > ${{github.event.comment.body}}
+            ❌ Invalid CI command "${{env.F3D_LABEL_COMMENT}}"

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -34,3 +34,15 @@ jobs:
           label="${{env.F3D_LABEL_COMMENT}}"
           label=${label#*-}
           gh issue edit ${{ github.event.issue.number }} --remove-label "ci:$label"
+
+      - name: Add ack reaction
+        uses: GrantBirki/comment@v2.1.1
+        with:
+          comment-id: ${{ github.event.issue.id }}
+          reactions: eyes
+
+      - name: Create comment for invalid command
+        if: failure()
+        uses: GrantBirki/comment@v2.1.1
+        with:
+          body: Invalid ci command ${{env.F3D_LABEL_COMMENT}}

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Add ack reaction
         uses: GrantBirki/comment@v2.1.1
         with:
-          comment-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
           reactions: eyes
 
       - name: Create comment for invalid command
         if: failure()
         uses: GrantBirki/comment@v2.1.1
         with:
-          body: ❌Invalid ci command "${{env.F3D_LABEL_COMMENT}}"
+          body: ❌ Invalid ci command "${{env.F3D_LABEL_COMMENT}}"

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -12,7 +12,10 @@ jobs:
   style_checks:
     name: Formatting Check
     runs-on: ubuntu-latest
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
     env:
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -12,7 +12,7 @@ jobs:
   style_checks:
     name: Formatting Check
     runs-on: ubuntu-latest
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:style')) }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
     env:
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -12,7 +12,7 @@ jobs:
   style_checks:
     name: Formatting Check
     runs-on: ubuntu-latest
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) || (github.ref == 'refs/heads/master') }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:fast')) || (contains(github.event.pull_request.labels.*.name, 'ci:main')) || (contains(github.event.pull_request.labels.*.name, 'ci:full')) }}
     env:
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -1,36 +1,11 @@
 on:
   pull_request_target:
-    types: [assigned, opened, synchronize, reopened]
+    types: [assigned, opened, synchronize, reopened, labeled]
     branches:
       - master
       - release
 name: Style Checks
 jobs:
-  #----------------------------------------------------------------------------
-  # Detect checkboxes are checked
-  #----------------------------------------------------------------------------
-  detect_checkboxes:
-    name: Detect Checkboxes
-    runs-on: ubuntu-latest
-    outputs:
-      checked: ${{ steps.detect.outputs.checked }}
-      unchecked: ${{ steps.detect.outputs.unchecked }}
-
-    permissions:
-      pull-requests: write
-
-    steps:
-      - name: Checkbox Trigger
-        id: detect
-        uses: AhmedBaset/checklist@3
-        with:
-          token: ${{ github.token }}
-
-      - name: list changes
-        run: |
-          echo "checked=${{ steps.detect.outputs.checked }}"
-          echo "unchecked=${{ steps.detect.outputs.unchecked }}"
-
   #----------------------------------------------------------------------------
   # Style checks
   #----------------------------------------------------------------------------
@@ -38,7 +13,7 @@ jobs:
     name: Formatting Check
     runs-on: ubuntu-latest
     needs: detect_checkboxes
-    if: ${{ (contains(needs.detect_checkboxes.outputs.checked, 'Style checks')) }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:style')) }}
     env:
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -12,7 +12,6 @@ jobs:
   style_checks:
     name: Formatting Check
     runs-on: ubuntu-latest
-    needs: detect_checkboxes
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'ci:style')) }}
     env:
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 cmake_minimum_required(VERSION 3.21)
 include(CMakeDependentOption)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 3.21)
 include(CMakeDependentOption)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,9 +87,9 @@ Make sure to check the results for yourself and ask for help if needed.
 
 To run the CI, just add a comment like this in your PR:
 
-- `\label ci:fast`: Style checks and a fast linux job
-- `\label ci:main`: Cross platform CI that cover most usecases, including coverage, contains `ci:fast`.
-- `\label ci:full`: Complete CI, required before merge, contains `ci:main`.
+- `\ci fast`: Style checks and a fast linux job
+- `\ci main`: Cross platform CI that cover most usecases, including coverage, contains `ci:fast`.
+- `\ci full`: Complete CI, required before merge, contains `ci:main`.
 
 After this, the CI will always be run every time you push to your branch.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ To run the CI, just add a comment like this in your PR:
 - `\ci full`: Complete CI, required before merge, contains `ci:main`.
 
 After this, the CI will always be run every time you push to your branch.
+To remove a label, use the same syntax with a `-` before the label, eg: `\ci -fast`.
 
 F3D continuous integration will also check the coverage as it is a good way to evaluate if new features are being tested or not.
 When adding code to F3D, always try to cover it by adding/modifying [tests](doc/dev/TESTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,11 +81,15 @@ F3D uses [GitLab Flow](https://about.gitlab.com/topics/version-control/what-is-g
 ## Continuous Integration
 
 F3D has pretty extensive continuous integration trying to cover all usecases for F3D.
-It means that if the change in your pull request breaks continuous integration, it will not be merged until it passes successfully.
+It means that if the change in your pull request breaks continuous integration, it will not be merged until the full CI passes successfully.
 It also means that adding a new feature or behavior means adding an associated test.
 Make sure to check the results for yourself and ask for help if needed.
 
-To run the CI, just check the CI related checkboxes in your pull request and push anything to your branch.
+To run the CI, just add a comment like this in your PR:
+ - `\label ci:fast`: Style checks and a fast linux job
+ - `\label ci:main`: Cross platform CI that cover most usecases, including coverage, contains `ci:fast`.
+ - `\label ci:full`: Complete CI, required before merge, contains `ci:main`.
+
 After this, the CI will always be run every time you push to your branch.
 
 F3D continuous integration will also check the coverage as it is a good way to evaluate if new features are being tested or not.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,9 +86,10 @@ It also means that adding a new feature or behavior means adding an associated t
 Make sure to check the results for yourself and ask for help if needed.
 
 To run the CI, just add a comment like this in your PR:
- - `\label ci:fast`: Style checks and a fast linux job
- - `\label ci:main`: Cross platform CI that cover most usecases, including coverage, contains `ci:fast`.
- - `\label ci:full`: Complete CI, required before merge, contains `ci:main`.
+
+- `\label ci:fast`: Style checks and a fast linux job
+- `\label ci:main`: Cross platform CI that cover most usecases, including coverage, contains `ci:fast`.
+- `\label ci:full`: Complete CI, required before merge, contains `ci:main`.
 
 After this, the CI will always be run every time you push to your branch.
 


### PR DESCRIPTION
### Describe your changes
 - Completely remove the "detect checkboxes logic" from CI code
 - Trigger CI based on the presence of specific labels in the PR
 - Add a "Labelize" workflow that runs on comments and detect `\ci foo` comments
 - Labelize uses a PAT from me to add comments on the PRs (https://github.com/orgs/community/discussions/25565)
 - Remove checkboxes from PR template
 - Update doc
 - Checkbox are still required in this very PR because certains jobs use pull_request_target trigger
 - labels have been added to the repo and to this MR manually
 - PAT have been added to the repo
 - Tested here: https://github.com/mwestphal/f3d/pull/24

### Issue ticket number and link if any

related to https://github.com/f3d-app/f3d/issues/194

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please check the checkbox of the CI you want to run, then push again on your branch.

- [x] Style checks
- [x] Fast CI
- [x] Coverage cached CI
- [x] Analysis cached CI
- [x] WASM docker CI
- [x] Android docker CI
- [x] macOS Intel cached CI
- [x] macOS ARM cached CI
- [x] Windows cached CI
- [x] Linux cached CI
- [x] Other cached CI
