### PR TITLE
Set HEX Color from command without required to escape it

### DIFF
--- a/doc/user/COMMANDS.md
+++ b/doc/user/COMMANDS.md
@@ -148,6 +148,8 @@ Command syntax is similar to bash, as in they will be split by "token" to be pro
 - Quotes inside quotes are supported as well, eg: `set render.hdri.file "/path/to/file'with'quotes.png"`.
 - Quotes and spaces can be escaped, eg: `set render.hdri.file /path/to/file\ with\ spaces\ and\ \'quotes\".png`.
 - Comment are supported using `#`, Any character after will be ignored. Use `\#` to add it verbatim.
+> Comments are only supported in command script, in interactive console `#` and all characters after will be handled
+as standard character.
 - Escapes can be escaped too: eg: `set render.hdri.file C:\\path\\to\\windows\\file.png`.
 - Other escaped character will be processed as if the escape was not present, eg: `set scene.up.direction +\Z`
 - Unfinished quoted section is invalid, eg: `set scene.up.direction "+Z`

--- a/doc/user/COMMANDS.md
+++ b/doc/user/COMMANDS.md
@@ -148,8 +148,8 @@ Command syntax is similar to bash, as in they will be split by "token" to be pro
 - Quotes inside quotes are supported as well, eg: `set render.hdri.file "/path/to/file'with'quotes.png"`.
 - Quotes and spaces can be escaped, eg: `set render.hdri.file /path/to/file\ with\ spaces\ and\ \'quotes\".png`.
 - Comment are supported using `#`, Any character after will be ignored. Use `\#` to add it verbatim.
-> Comments are only supported in command script, in interactive console `#` and all characters after will be handled
-as standard character.
+  > Comments are only supported in command script, in interactive console `#` and all characters after will be handled
+  > as standard character.
 - Escapes can be escaped too: eg: `set render.hdri.file C:\\path\\to\\windows\\file.png`.
 - Other escaped character will be processed as if the escape was not present, eg: `set scene.up.direction +\Z`
 - Unfinished quoted section is invalid, eg: `set scene.up.direction "+Z`

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -43,7 +43,7 @@ public:
       nullptr) override;
   interactor& removeCommand(const std::string& action) override;
   std::vector<std::string> getCommandActions() const override;
-  bool triggerCommand(std::string_view command, bool skipComment = false) override;
+  bool triggerCommand(std::string_view command, bool keepComments = false) override;
 
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -43,7 +43,7 @@ public:
       nullptr) override;
   interactor& removeCommand(const std::string& action) override;
   std::vector<std::string> getCommandActions() const override;
-  bool triggerCommand(std::string_view command, bool keepComments = false) override;
+  bool triggerCommand(std::string_view command, bool keepComments = true) override;
 
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -43,7 +43,7 @@ public:
       nullptr) override;
   interactor& removeCommand(const std::string& action) override;
   std::vector<std::string> getCommandActions() const override;
-  bool triggerCommand(std::string_view command) override;
+  bool triggerCommand(std::string_view command, bool skipComment=false) override;
 
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -43,7 +43,7 @@ public:
       nullptr) override;
   interactor& removeCommand(const std::string& action) override;
   std::vector<std::string> getCommandActions() const override;
-  bool triggerCommand(std::string_view command, bool skipComment=false) override;
+  bool triggerCommand(std::string_view command, bool skipComment = false) override;
 
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -104,8 +104,8 @@ public:
    *
    * If the command fails, it prints a debug log explaining why.
    *
-   * When keepComments argument is true, comments are supported with `#`, any characters after are ignored
-   * otherwise '#' and any characters after will be handled as standard character
+   * When keepComments argument is true, comments are supported with `#`, any characters after are
+   * ignored otherwise '#' and any characters after will be handled as standard character
    *
    * Return true if the command succeeded, false otherwise.
    * Throw an interactor::command_runtime_exception if the command callback

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -110,7 +110,7 @@ public:
    * Note that default commands will never throw this exception, but adding commands
    * without exception catching may trigger this behavior.
    */
-  virtual bool triggerCommand(std::string_view command) = 0;
+  virtual bool triggerCommand(std::string_view command, bool skipComment=false) = 0;
   ///@}
 
   ///@{ @name Bindings

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -110,7 +110,7 @@ public:
    * Note that default commands will never throw this exception, but adding commands
    * without exception catching may trigger this behavior.
    */
-  virtual bool triggerCommand(std::string_view command, bool skipComment=false) = 0;
+  virtual bool triggerCommand(std::string_view command, bool skipComment = false) = 0;
   ///@}
 
   ///@{ @name Bindings

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -104,13 +104,16 @@ public:
    *
    * If the command fails, it prints a debug log explaining why.
    *
+   * When keepComments argument is true, comments are supported with `#`, any characters after are ignored
+   * otherwise '#' and any characters after will be handled as standard character
+   *
    * Return true if the command succeeded, false otherwise.
    * Throw an interactor::command_runtime_exception if the command callback
    * throw an unrecognized exception.
    * Note that default commands will never throw this exception, but adding commands
    * without exception catching may trigger this behavior.
    */
-  virtual bool triggerCommand(std::string_view command, bool keepComments = false) = 0;
+  virtual bool triggerCommand(std::string_view command, bool keepComments = true) = 0;
   ///@}
 
   ///@{ @name Bindings

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -110,7 +110,7 @@ public:
    * Note that default commands will never throw this exception, but adding commands
    * without exception catching may trigger this behavior.
    */
-  virtual bool triggerCommand(std::string_view command, bool skipComment = false) = 0;
+  virtual bool triggerCommand(std::string_view command, bool keepComments = false) = 0;
   ///@}
 
   ///@{ @name Bindings

--- a/library/public/utils.h
+++ b/library/public/utils.h
@@ -54,7 +54,7 @@ public:
    * `set scene.up.direction "+Z` -> tokenize_exception
    * `set scene.up.direction +Z\` -> tokenize_exception
    */
-  [[nodiscard]] static std::vector<std::string> tokenize(std::string_view str);
+  [[nodiscard]] static std::vector<std::string> tokenize(std::string_view str, bool skipComment=false);
   // clang-format on
 
   /**

--- a/library/public/utils.h
+++ b/library/public/utils.h
@@ -37,7 +37,8 @@ public:
    *  - Split by quoted section and remove the quotes
    *  - Supported quotes are: '"`
    *  - Use escaped \ quotes, spaces and escape to add them verbatim
-   *  - Comments are supported with `#`, any characters after are ignored
+   *  - When keepComments argument is true, comments are supported with `#`, any characters after are ignored
+   * otherwise '#' and any characters after will be handled as standard character
    *  - Use escaped \# to add it verbatim
    *  - Other escaped characters are also added verbatim
    * Throw a tokenize_exception if a quoted section is not closed or if finishing with an escape
@@ -54,7 +55,7 @@ public:
    * `set scene.up.direction "+Z` -> tokenize_exception
    * `set scene.up.direction +Z\` -> tokenize_exception
    */
-  [[nodiscard]] static std::vector<std::string> tokenize(std::string_view str, bool keepComments=false);
+  [[nodiscard]] static std::vector<std::string> tokenize(std::string_view str, bool keepComments = true);
   // clang-format on
 
   /**

--- a/library/public/utils.h
+++ b/library/public/utils.h
@@ -54,7 +54,7 @@ public:
    * `set scene.up.direction "+Z` -> tokenize_exception
    * `set scene.up.direction +Z\` -> tokenize_exception
    */
-  [[nodiscard]] static std::vector<std::string> tokenize(std::string_view str, bool skipComment=false);
+  [[nodiscard]] static std::vector<std::string> tokenize(std::string_view str, bool keepComments=false);
   // clang-format on
 
   /**

--- a/library/public/utils.h
+++ b/library/public/utils.h
@@ -39,7 +39,7 @@ public:
    *  - Use escaped \ quotes, spaces and escape to add them verbatim
    *  - When keepComments argument is true, comments are supported with `#`, any characters after are ignored
    * otherwise '#' and any characters after will be handled as standard character
-   *  - Use escaped \# to add it verbatim
+   *  - Use escaped \# to add it verbatim when using keepComments = true
    *  - Other escaped characters are also added verbatim
    * Throw a tokenize_exception if a quoted section is not closed or if finishing with an escape
    *

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -582,7 +582,7 @@ public:
       {
         // XXX: Ignore the boolean return of triggerCommand,
         // error is already logged by triggerCommand
-        this->Interactor.triggerCommand(this->CommandBuffer.value());
+        this->Interactor.triggerCommand(this->CommandBuffer.value(), true);
       }
       catch (const f3d::interactor::command_runtime_exception& ex)
       {
@@ -1180,7 +1180,7 @@ std::vector<std::string> interactor_impl::getCommandActions() const
 }
 
 //----------------------------------------------------------------------------
-bool interactor_impl::triggerCommand(std::string_view command)
+bool interactor_impl::triggerCommand(std::string_view command, bool skipComment)
 {
   log::debug("Command: ", command);
 
@@ -1194,7 +1194,7 @@ bool interactor_impl::triggerCommand(std::string_view command)
   std::vector<std::string> tokens;
   try
   {
-    tokens = utils::tokenize(command);
+    tokens = utils::tokenize(command, skipComment);
   }
   catch (const utils::tokenize_exception&)
   {

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -582,7 +582,7 @@ public:
       {
         // XXX: Ignore the boolean return of triggerCommand,
         // error is already logged by triggerCommand
-        this->Interactor.triggerCommand(this->CommandBuffer.value(), true);
+        this->Interactor.triggerCommand(this->CommandBuffer.value(), false);
       }
       catch (const f3d::interactor::command_runtime_exception& ex)
       {
@@ -1180,7 +1180,7 @@ std::vector<std::string> interactor_impl::getCommandActions() const
 }
 
 //----------------------------------------------------------------------------
-bool interactor_impl::triggerCommand(std::string_view command, bool skipComment)
+bool interactor_impl::triggerCommand(std::string_view command, bool keepComments)
 {
   log::debug("Command: ", command);
 
@@ -1194,7 +1194,7 @@ bool interactor_impl::triggerCommand(std::string_view command, bool skipComment)
   std::vector<std::string> tokens;
   try
   {
-    tokens = utils::tokenize(command, skipComment);
+    tokens = utils::tokenize(command, keepComments);
   }
   catch (const utils::tokenize_exception&)
   {

--- a/library/src/utils.cxx
+++ b/library/src/utils.cxx
@@ -103,9 +103,11 @@ std::vector<std::string> utils::tokenize(std::string_view str)
         escaped = false;
         break;
       case '#':
-        if (comment)
+        if (comment || color)
         {
           commented = true;
+          token.clear();
+          break;
         }
         if (!escaped && !quoted)
         {

--- a/library/src/utils.cxx
+++ b/library/src/utils.cxx
@@ -29,7 +29,6 @@ std::vector<std::string> utils::tokenize(std::string_view str, bool skipComment)
 {
   std::vector<std::string> tokens;
   std::string token;
-  const std::string colorHexTokens = "0123456789abcdefABCDEF";
   const auto accumulate = [&](const char& c) { token.push_back(c); };
   const auto emit = [&]()
   {

--- a/library/src/utils.cxx
+++ b/library/src/utils.cxx
@@ -109,7 +109,6 @@ std::vector<std::string> utils::tokenize(std::string_view str)
         }
         if (!escaped && !quoted)
         {
-          // we need to check next char in order to ensure that we are a comment
           comment = true;
         }
         else
@@ -125,6 +124,7 @@ std::vector<std::string> utils::tokenize(std::string_view str)
         {
           color = true;
           comment = false;
+          // Add missing previous '#' in order to be able to parse the HEX Color
           accumulate('#');
         }
         else if ((comment || color) && !isValidHexToken)

--- a/library/src/utils.cxx
+++ b/library/src/utils.cxx
@@ -25,7 +25,7 @@ unsigned int utils::textDistance(std::string_view strA, std::string_view strB)
 }
 
 //----------------------------------------------------------------------------
-std::vector<std::string> utils::tokenize(std::string_view str, bool skipComment)
+std::vector<std::string> utils::tokenize(std::string_view str, bool keepComments)
 {
   std::vector<std::string> tokens;
   std::string token;
@@ -82,7 +82,7 @@ std::vector<std::string> utils::tokenize(std::string_view str, bool skipComment)
         escaped = false;
         break;
       case '#':
-        if (!escaped && !quoted && !skipComment)
+        if (!escaped && !quoted && keepComments)
         {
           commented = true;
         }

--- a/library/testing/TestSDKUtils.cxx
+++ b/library/testing/TestSDKUtils.cxx
@@ -59,41 +59,17 @@ int TestSDKUtils([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     f3d::utils::tokenize(R"(set render.hdri.file file # A comment)") ==
       std::vector<std::string>{ "set", "render.hdri.file", "file" });
 
-  test("tokenize comments without space",
-    f3d::utils::tokenize(R"(set render.hdri.file file #This is a comment)") ==
-      std::vector<std::string>{ "set", "render.hdri.file", "file" });
-
-  test("tokenize comments without space with valid hex token as first letter",
-    f3d::utils::tokenize(R"(set render.hdri.file file #A comment)") ==
-      std::vector<std::string>{ "set", "render.hdri.file", "file" });
-
-  test("tokenize comments without space with valid hex token as two first letters",
-    f3d::utils::tokenize(R"(set render.hdri.file file #A1 comment)") ==
-      std::vector<std::string>{ "set", "render.hdri.file", "file" });
-
-  test("tokenize comments without space with valid hex token as three first letters",
-    f3d::utils::tokenize(R"(set render.hdri.file file #A1d comment)") ==
-      std::vector<std::string>{ "set", "render.hdri.file", "file" });
+  test("tokenize comments with skip comment flag",
+    f3d::utils::tokenize(R"(set render.hdri.file file # A comment)", true) ==
+      std::vector<std::string>{ "set", "render.hdri.file", "file", "#", "A", "comment" });
 
   test("tokenize base color",
     f3d::utils::tokenize(R"(set render.background.color #000)") ==
+      std::vector<std::string>{ "set", "render.background.color" });
+
+  test("tokenize base color with skip comment flag",
+    f3d::utils::tokenize(R"(set render.background.color #000)", true) ==
       std::vector<std::string>{ "set", "render.background.color", "#000" });
-
-  test("tokenize upper case color",
-    f3d::utils::tokenize(R"(set render.background.color #FFF)") ==
-      std::vector<std::string>{ "set", "render.background.color", "#FFF" });
-
-  test("tokenize lower case color",
-    f3d::utils::tokenize(R"(set render.background.color #fff)") ==
-      std::vector<std::string>{ "set", "render.background.color", "#fff" });
-
-  test("tokenize mixed case color",
-    f3d::utils::tokenize(R"(set render.background.color #fEf)") ==
-      std::vector<std::string>{ "set", "render.background.color", "#fEf" });
-
-  test("tokenize mixed letter and number color",
-    f3d::utils::tokenize(R"(set render.background.color #fE1)") ==
-      std::vector<std::string>{ "set", "render.background.color", "#fE1" });
 
   test("tokenize escaped comments",
     f3d::utils::tokenize(R"(set render.hdri.file fi\#le)") ==

--- a/library/testing/TestSDKUtils.cxx
+++ b/library/testing/TestSDKUtils.cxx
@@ -59,6 +59,26 @@ int TestSDKUtils([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     f3d::utils::tokenize(R"(set render.hdri.file file # A comment)") ==
       std::vector<std::string>{ "set", "render.hdri.file", "file" });
 
+  test("tokenize base color",
+    f3d::utils::tokenize(R"(set render.background.color #000)") ==
+      std::vector<std::string>{ "set", "render.background.color", "#000" });
+
+  test("tokenize upper case color",
+    f3d::utils::tokenize(R"(set render.background.color #FFF)") ==
+      std::vector<std::string>{ "set", "render.background.color", "#FFF" });
+
+  test("tokenize lower case color",
+    f3d::utils::tokenize(R"(set render.background.color #fff)") ==
+      std::vector<std::string>{ "set", "render.background.color", "#fff" });
+
+  test("tokenize mixed case color",
+    f3d::utils::tokenize(R"(set render.background.color #fEf)") ==
+      std::vector<std::string>{ "set", "render.background.color", "#fEf" });
+
+  test("tokenize mixed letter and number color",
+    f3d::utils::tokenize(R"(set render.background.color #fE1)") ==
+      std::vector<std::string>{ "set", "render.background.color", "#fE1" });
+
   test("tokenize escaped comments",
     f3d::utils::tokenize(R"(set render.hdri.file fi\#le)") ==
       std::vector<std::string>{ "set", "render.hdri.file", "fi#le" });

--- a/library/testing/TestSDKUtils.cxx
+++ b/library/testing/TestSDKUtils.cxx
@@ -64,15 +64,15 @@ int TestSDKUtils([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
       std::vector<std::string>{ "set", "render.hdri.file", "file" });
 
   test("tokenize comments without space with valid hex token as first letter",
-      f3d::utils::tokenize(R"(set render.hdri.file file #A comment)") ==
+    f3d::utils::tokenize(R"(set render.hdri.file file #A comment)") ==
       std::vector<std::string>{ "set", "render.hdri.file", "file"});
 
   test("tokenize comments without space with valid hex token as two first letters",
-      f3d::utils::tokenize(R"(set render.hdri.file file #A1 comment)") ==
+    f3d::utils::tokenize(R"(set render.hdri.file file #A1 comment)") ==
       std::vector<std::string>{ "set", "render.hdri.file", "file"});
 
   test("tokenize comments without space with valid hex token as three first letters",
-      f3d::utils::tokenize(R"(set render.hdri.file file #A1d comment)") ==
+    f3d::utils::tokenize(R"(set render.hdri.file file #A1d comment)") ==
       std::vector<std::string>{ "set", "render.hdri.file", "file"});
 
   test("tokenize base color",

--- a/library/testing/TestSDKUtils.cxx
+++ b/library/testing/TestSDKUtils.cxx
@@ -59,16 +59,16 @@ int TestSDKUtils([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     f3d::utils::tokenize(R"(set render.hdri.file file # A comment)") ==
       std::vector<std::string>{ "set", "render.hdri.file", "file" });
 
-  test("tokenize comments with skip comment flag",
-    f3d::utils::tokenize(R"(set render.hdri.file file # A comment)", true) ==
+  test("tokenize comments with keep comments flag",
+    f3d::utils::tokenize(R"(set render.hdri.file file # A comment)", false) ==
       std::vector<std::string>{ "set", "render.hdri.file", "file", "#", "A", "comment" });
 
   test("tokenize base color",
     f3d::utils::tokenize(R"(set render.background.color #000)") ==
       std::vector<std::string>{ "set", "render.background.color" });
 
-  test("tokenize base color with skip comment flag",
-    f3d::utils::tokenize(R"(set render.background.color #000)", true) ==
+  test("tokenize base color with keep comments flag",
+    f3d::utils::tokenize(R"(set render.background.color #000)", false) ==
       std::vector<std::string>{ "set", "render.background.color", "#000" });
 
   test("tokenize escaped comments",

--- a/library/testing/TestSDKUtils.cxx
+++ b/library/testing/TestSDKUtils.cxx
@@ -65,15 +65,15 @@ int TestSDKUtils([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
 
   test("tokenize comments without space with valid hex token as first letter",
     f3d::utils::tokenize(R"(set render.hdri.file file #A comment)") ==
-      std::vector<std::string>{ "set", "render.hdri.file", "file"});
+      std::vector<std::string>{ "set", "render.hdri.file", "file" });
 
   test("tokenize comments without space with valid hex token as two first letters",
     f3d::utils::tokenize(R"(set render.hdri.file file #A1 comment)") ==
-      std::vector<std::string>{ "set", "render.hdri.file", "file"});
+      std::vector<std::string>{ "set", "render.hdri.file", "file" });
 
   test("tokenize comments without space with valid hex token as three first letters",
     f3d::utils::tokenize(R"(set render.hdri.file file #A1d comment)") ==
-      std::vector<std::string>{ "set", "render.hdri.file", "file"});
+      std::vector<std::string>{ "set", "render.hdri.file", "file" });
 
   test("tokenize base color",
     f3d::utils::tokenize(R"(set render.background.color #000)") ==

--- a/library/testing/TestSDKUtils.cxx
+++ b/library/testing/TestSDKUtils.cxx
@@ -59,6 +59,22 @@ int TestSDKUtils([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     f3d::utils::tokenize(R"(set render.hdri.file file # A comment)") ==
       std::vector<std::string>{ "set", "render.hdri.file", "file" });
 
+  test("tokenize comments without space",
+    f3d::utils::tokenize(R"(set render.hdri.file file #This is a comment)") ==
+      std::vector<std::string>{ "set", "render.hdri.file", "file" });
+
+  test("tokenize comments without space with valid hex token as first letter",
+      f3d::utils::tokenize(R"(set render.hdri.file file #A comment)") ==
+      std::vector<std::string>{ "set", "render.hdri.file", "file"});
+
+  test("tokenize comments without space with valid hex token as two first letters",
+      f3d::utils::tokenize(R"(set render.hdri.file file #A1 comment)") ==
+      std::vector<std::string>{ "set", "render.hdri.file", "file"});
+
+  test("tokenize comments without space with valid hex token as three first letters",
+      f3d::utils::tokenize(R"(set render.hdri.file file #A1d comment)") ==
+      std::vector<std::string>{ "set", "render.hdri.file", "file"});
+
   test("tokenize base color",
     f3d::utils::tokenize(R"(set render.background.color #000)") ==
       std::vector<std::string>{ "set", "render.background.color", "#000" });

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -282,7 +282,8 @@ PYBIND11_MODULE(pyf3d, module)
       py::arg("callback"), py::arg("doc") = std::nullopt, py::arg("completionCallback") = nullptr)
     .def("remove_command", &f3d::interactor::removeCommand, "Remove a command")
     .def("get_command_actions", &f3d::interactor::getCommandActions, "Get all command actions")
-    .def("trigger_command", &f3d::interactor::triggerCommand, "Trigger a command", py::arg("command"), py::arg("keepComments") = true)
+    .def("trigger_command", &f3d::interactor::triggerCommand, "Trigger a command",
+      py::arg("command"), py::arg("keepComments") = true)
     .def("init_bindings", &f3d::interactor::initBindings,
       "Remove all bindings and add default bindings")
     .def("remove_binding", &f3d::interactor::removeBinding, "Remove interaction commands")

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -227,7 +227,7 @@ PYBIND11_MODULE(pyf3d, module)
   utils //
     .def_static("text_distance", &f3d::utils::textDistance)
     .def_static("collapse_path", &f3d::utils::collapsePath)
-    .def_static("tokenize", &f3d::utils::tokenize, py::arg("str"), py::arg("keepComments") = true)
+    .def_static("tokenize", &f3d::utils::tokenize, py::arg("str"), py::arg("keep_comments") = true)
     .def_static(
       "glob_to_regex", &f3d::utils::globToRegex, py::arg("glob"), py::arg("path_separator") = '/')
     .def_static("get_env", &f3d::utils::getEnv)

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -283,7 +283,7 @@ PYBIND11_MODULE(pyf3d, module)
     .def("remove_command", &f3d::interactor::removeCommand, "Remove a command")
     .def("get_command_actions", &f3d::interactor::getCommandActions, "Get all command actions")
     .def("trigger_command", &f3d::interactor::triggerCommand, "Trigger a command",
-      py::arg("command"), py::arg("keepComments") = true)
+      py::arg("command"), py::arg("keep_comments") = true)
     .def("init_bindings", &f3d::interactor::initBindings,
       "Remove all bindings and add default bindings")
     .def("remove_binding", &f3d::interactor::removeBinding, "Remove interaction commands")

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -227,6 +227,7 @@ PYBIND11_MODULE(pyf3d, module)
   utils //
     .def_static("text_distance", &f3d::utils::textDistance)
     .def_static("collapse_path", &f3d::utils::collapsePath)
+    .def_static("tokenize", &f3d::utils::tokenize, py::arg("str"), py::arg("keepComments") = true)
     .def_static(
       "glob_to_regex", &f3d::utils::globToRegex, py::arg("glob"), py::arg("path_separator") = '/')
     .def_static("get_env", &f3d::utils::getEnv)
@@ -281,7 +282,7 @@ PYBIND11_MODULE(pyf3d, module)
       py::arg("callback"), py::arg("doc") = std::nullopt, py::arg("completionCallback") = nullptr)
     .def("remove_command", &f3d::interactor::removeCommand, "Remove a command")
     .def("get_command_actions", &f3d::interactor::getCommandActions, "Get all command actions")
-    .def("trigger_command", &f3d::interactor::triggerCommand, "Trigger a command")
+    .def("trigger_command", &f3d::interactor::triggerCommand, "Trigger a command", py::arg("command"), py::arg("keepComments") = true)
     .def("init_bindings", &f3d::interactor::initBindings,
       "Remove all bindings and add default bindings")
     .def("remove_binding", &f3d::interactor::removeBinding, "Remove interaction commands")

--- a/python/testing/test_interactor.py
+++ b/python/testing/test_interactor.py
@@ -32,6 +32,13 @@ def test_command(capfd: pytest.CaptureFixture[str]):
     out, _err = capfd.readouterr()
     assert out == "['arg1', 'arg2']\n"
 
+    # Check a command can be triggered with #
+    inter.add_command("my_cmd", print_fn)
+    inter.trigger_command("my_cmd arg1 arg2 #000", False)
+    inter.remove_command("my_cmd")
+    out, _err = capfd.readouterr()
+    assert out == "['arg1', 'arg2', '#000']\n"
+
     # Smoke test
     inter.init_commands()
     inter.add_command("my_cmd2", print_fn, ["my_cmd2", "doc"], compl_fn)

--- a/python/testing/test_utils.py
+++ b/python/testing/test_utils.py
@@ -11,6 +11,13 @@ def test_text_distance():
 def test_collapse_path():
     assert f3d.Utils.collapse_path("/folder/../file.ext", ".") == Path("/file.ext")
 
+def test_tokenize():
+    out = f3d.Utils.tokenize("my_cmd arg1 arg2")
+    assert out == ["my_cmd", "arg1", "arg2"]
+
+    out = f3d.Utils.tokenize("my_cmd arg1 arg2 #000", False)
+    assert out == ["my_cmd", "arg1", "arg2", "#000"]
+
 
 def test_glob_to_regex():
     assert f3d.Utils.glob_to_regex("*vt?") == ".*vt."

--- a/python/testing/test_utils.py
+++ b/python/testing/test_utils.py
@@ -11,6 +11,7 @@ def test_text_distance():
 def test_collapse_path():
     assert f3d.Utils.collapse_path("/folder/../file.ext", ".") == Path("/file.ext")
 
+
 def test_tokenize():
     out = f3d.Utils.tokenize("my_cmd arg1 arg2")
     assert out == ["my_cmd", "arg1", "arg2"]


### PR DESCRIPTION
### Describe your changes

Hi ! This patch should fix the #2101 issue. I added some tests in order to cover more test case. Let me know If you have other tests to add.

Feel free to comment ! 

### Issue ticket number and link if any

* [comments and colors are not compatible in commands #2101
](https://github.com/f3d-app/f3d/issues/2101)

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [x] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/CONTRIBUTING.html#continuous-integration) for more info.

<img width="1012" height="647" alt="image" src="https://github.com/user-attachments/assets/9c3cc0a1-dcb8-40ae-9f62-6c0558a4861d" />

