### PR TITLE
Hide overlay on console display

### DIFF
--- a/vtkext/private/module/F3DImguiStyle.h
+++ b/vtkext/private/module/F3DImguiStyle.h
@@ -63,6 +63,11 @@ constexpr ImVec4 GetBackgroundColor()
   // F3D black
   return DecomposeImv4(0x141414);
 }
+
+constexpr float GetDefaultMargin()
+{
+  return 5.f;
+}
 };
 
 #endif

--- a/vtkext/private/module/vtkF3DImguiActor.cxx
+++ b/vtkext/private/module/vtkF3DImguiActor.cxx
@@ -473,12 +473,12 @@ void vtkF3DImguiActor::RenderFileName()
   {
     const ImGuiViewport* viewport = ImGui::GetMainViewport();
 
-    constexpr float marginTop = 5.f;
+    constexpr float margin = F3DImguiStyle::GetDefaultMargin();
     ImVec2 winSize = ImGui::CalcTextSize(this->FileName.c_str());
     winSize.x += 2.f * ImGui::GetStyle().WindowPadding.x;
     winSize.y += 2.f * ImGui::GetStyle().WindowPadding.y;
 
-    ::SetupNextWindow(ImVec2(viewport->GetWorkCenter().x - 0.5f * winSize.x, marginTop), winSize);
+    ::SetupNextWindow(ImVec2(viewport->GetWorkCenter().x - 0.5f * winSize.x, margin), winSize);
     ImGui::SetNextWindowBgAlpha(0.9f);
 
     ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings |
@@ -495,13 +495,13 @@ void vtkF3DImguiActor::RenderMetaData()
 {
   const ImGuiViewport* viewport = ImGui::GetMainViewport();
 
-  constexpr float marginRight = 5.f;
+  constexpr float margin = F3DImguiStyle::GetDefaultMargin();
 
   ImVec2 winSize = ImGui::CalcTextSize(this->MetaData.c_str());
   winSize.x += 2.f * ImGui::GetStyle().WindowPadding.x;
   winSize.y += 2.f * ImGui::GetStyle().WindowPadding.y;
 
-  ::SetupNextWindow(ImVec2(viewport->WorkSize.x - winSize.x - marginRight,
+  ::SetupNextWindow(ImVec2(viewport->WorkSize.x - winSize.x - margin,
                       viewport->GetWorkCenter().y - 0.5f * winSize.y),
     winSize);
   ImGui::SetNextWindowBgAlpha(0.9f);
@@ -519,7 +519,7 @@ void vtkF3DImguiActor::RenderCheatSheet()
 {
   const ImGuiViewport* viewport = ImGui::GetMainViewport();
 
-  constexpr float margin = 5.f;
+  constexpr float margin = F3DImguiStyle::GetDefaultMargin();
   constexpr float padding = 16.f;
 
   float textHeight = 0.f;
@@ -654,8 +654,7 @@ void vtkF3DImguiActor::RenderFpsCounter()
 {
   const ImGuiViewport* viewport = ImGui::GetMainViewport();
 
-  constexpr float marginRight = 3.f;
-  constexpr float marginBottom = 3.f;
+  constexpr float margin = F3DImguiStyle::GetDefaultMargin();
 
   std::string fpsString = std::to_string(this->FpsValue);
   fpsString += " fps";
@@ -664,8 +663,8 @@ void vtkF3DImguiActor::RenderFpsCounter()
   winSize.x += 2.f * ImGui::GetStyle().WindowPadding.x;
   winSize.y += 2.f * ImGui::GetStyle().WindowPadding.y;
 
-  ImVec2 position(viewport->WorkSize.x - winSize.x - marginRight,
-    viewport->WorkSize.y - winSize.y - marginBottom);
+  ImVec2 position(
+    viewport->WorkSize.x - winSize.x - margin, viewport->WorkSize.y - winSize.y - margin);
 
   ::SetupNextWindow(position, winSize);
   ImGui::SetNextWindowBgAlpha(0.9f);

--- a/vtkext/private/module/vtkF3DImguiConsole.cxx
+++ b/vtkext/private/module/vtkF3DImguiConsole.cxx
@@ -210,8 +210,7 @@ void vtkF3DImguiConsole::ShowConsole(bool minimal)
 {
   const ImGuiViewport* viewport = ImGui::GetMainViewport();
 
-  constexpr float marginConsole = 30.f;
-  constexpr float marginTopRight = 5.f;
+  constexpr float margin = F3DImguiStyle::GetDefaultMargin();
   const float padding = ImGui::GetStyle().WindowPadding.x + ImGui::GetStyle().FramePadding.x;
 
   // explicitly calculate size of minimal console to avoid extra flashing frame
@@ -220,15 +219,15 @@ void vtkF3DImguiConsole::ShowConsole(bool minimal)
     if (this->Pimpl->NewError || this->Pimpl->NewWarning)
     {
       // prevent overlap with console badge in minimal console
-      ImGui::SetNextWindowPos(ImVec2(marginTopRight, marginTopRight));
-      ImGui::SetNextWindowSize(ImVec2(
-        viewport->WorkSize.x - 2.f * marginConsole, ImGui::CalcTextSize(">").y + 2.f * padding));
+      ImGui::SetNextWindowPos(ImVec2(margin, margin));
+      ImGui::SetNextWindowSize(
+        ImVec2(viewport->WorkSize.x - 2.f * margin, ImGui::CalcTextSize(">").y + 2.f * padding));
     }
     else
     {
-      ImGui::SetNextWindowPos(ImVec2(marginTopRight, marginTopRight));
-      ImGui::SetNextWindowSize(ImVec2(
-        viewport->WorkSize.x - 2.f * marginTopRight, ImGui::CalcTextSize(">").y + 2.f * padding));
+      ImGui::SetNextWindowPos(ImVec2(margin, margin));
+      ImGui::SetNextWindowSize(
+        ImVec2(viewport->WorkSize.x - 2.f * margin, ImGui::CalcTextSize(">").y + 2.f * padding));
     }
   }
   else
@@ -237,9 +236,9 @@ void vtkF3DImguiConsole::ShowConsole(bool minimal)
     this->Pimpl->NewError = false;
     this->Pimpl->NewWarning = false;
 
-    ImGui::SetNextWindowPos(ImVec2(marginConsole, marginConsole));
-    ImGui::SetNextWindowSize(ImVec2(
-      viewport->WorkSize.x - 2.f * marginConsole, viewport->WorkSize.y - 2.f * marginConsole));
+    ImGui::SetNextWindowPos(ImVec2(margin, margin));
+    ImGui::SetNextWindowSize(
+      ImVec2(viewport->WorkSize.x - 2.f * margin, viewport->WorkSize.y - 2.f * margin));
   }
 
   ImGui::SetNextWindowBgAlpha(0.9f);
@@ -377,14 +376,13 @@ void vtkF3DImguiConsole::ShowBadge()
 
   if (this->Pimpl->NewError || this->Pimpl->NewWarning)
   {
-    constexpr float marginTopRight = 5.f;
+    constexpr float margin = F3DImguiStyle::GetDefaultMargin();
     const float padding = ImGui::GetStyle().WindowPadding.x + ImGui::GetStyle().FramePadding.x;
     ImVec2 winSize = ImGui::CalcTextSize("!");
     winSize.x += 2.f * padding;
     winSize.y += 2.f * padding;
 
-    ImGui::SetNextWindowPos(
-      ImVec2(viewport->WorkSize.x - winSize.x - marginTopRight, marginTopRight));
+    ImGui::SetNextWindowPos(ImVec2(viewport->WorkSize.x - winSize.x - margin, margin));
     ImGui::SetNextWindowSize(winSize);
     ImGui::SetNextWindowBgAlpha(0.9f);
 

--- a/vtkext/private/module/vtkF3DUIActor.cxx
+++ b/vtkext/private/module/vtkF3DUIActor.cxx
@@ -146,6 +146,13 @@ int vtkF3DUIActor::RenderOverlay(vtkViewport* vp)
     this->RenderDropZone();
   }
 
+  if (this->ConsoleVisible)
+  {
+    this->RenderConsole(false);
+    this->EndFrame(renWin);
+    return 1;
+  }
+
   if (this->FileNameVisible)
   {
     this->RenderFileName();
@@ -166,12 +173,7 @@ int vtkF3DUIActor::RenderOverlay(vtkViewport* vp)
     this->RenderFpsCounter();
   }
 
-  // Only one console can be visible at a time, console has priority over minimal console
-  if (this->ConsoleVisible)
-  {
-    this->RenderConsole(false);
-  }
-  else if (this->MinimalConsoleVisible)
+  if (this->MinimalConsoleVisible)
   {
     this->RenderConsole(true);
   }


### PR DESCRIPTION
### Describe your changes

This PR add small improvements to Console display and create a new method to get F3D Default margin value in `F3DImguiStyle.h`

* Hide all overlays on console display
<img width="1011" height="645" alt="image" src="https://github.com/user-attachments/assets/3fd76f2e-b844-4a31-90d2-ed3327d41401" />

* Make console margin consistent with other Window (cheatsheet, metadata, etc..)

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [X] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/CONTRIBUTING.html#continuous-integration) for more info.
