### PR TITLE
QuakeMDL: Fix a wrong assert in groupskin code

### DIFF
--- a/plugins/native/module/vtkF3DQuakeMDLImporter.cxx
+++ b/plugins/native/module/vtkF3DQuakeMDLImporter.cxx
@@ -564,7 +564,7 @@ std::string vtkF3DQuakeMDLImporter::GetAnimationName(vtkIdType animationIndex)
 //----------------------------------------------------------------------------
 void vtkF3DQuakeMDLImporter::EnableAnimation(vtkIdType animationIndex)
 {
-  assert(animationIndex < static_cast<vtkIdType>(this->Internals->AnimationNames.size()));
+  assert(animationIndex < static_cast<vtkIdType>(this->Internals->AnimationNames.size() + this->Internals->GroupSkinAnimationNames.size()));
   assert(animationIndex >= 0);
   this->Internals->ActiveAnimation = animationIndex;
 }
@@ -578,7 +578,7 @@ void vtkF3DQuakeMDLImporter::DisableAnimation(vtkIdType vtkNotUsed(animationInde
 //----------------------------------------------------------------------------
 bool vtkF3DQuakeMDLImporter::IsAnimationEnabled(vtkIdType animationIndex)
 {
-  assert(animationIndex < static_cast<vtkIdType>(this->Internals->AnimationNames.size()));
+  assert(animationIndex < static_cast<vtkIdType>(this->Internals->AnimationNames.size() + this->Internals->GroupSkinAnimationNames.size()));
   assert(animationIndex >= 0);
   return this->Internals->ActiveAnimation == animationIndex;
 }


### PR DESCRIPTION
### Describe your changes

Follow-up of https://github.com/f3d-app/f3d/pull/2355 that fixes two wrong assert
that should take groupskin into account.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/CONTRIBUTING.html#continuous-integration) for more info.
