### PR TITLE
CI/doc: Update to use 9.5.2 instead of 9.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
         vtk_version:
           [
             "${{needs.default_versions.outputs.vtk_commit_sha}}",
-            v9.5.0,
+            v9.5.2,
             v9.4.2,
             v9.3.1,
             v9.2.6,
@@ -309,7 +309,7 @@ jobs:
         vtk_version:
           [
             "${{needs.default_versions.outputs.vtk_commit_sha}}",
-            v9.5.0,
+            v9.5.2,
             v9.4.2,
             v9.3.1,
             v9.2.6,
@@ -387,7 +387,7 @@ jobs:
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
           blosc_version: ${{needs.default_versions.outputs.blosc_version}}
           tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          vtk_version: v9.5.0
+          vtk_version: v9.5.2
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
 
   #----------------------------------------------------------------------------
@@ -405,7 +405,7 @@ jobs:
         vtk_version:
           [
             "${{needs.default_versions.outputs.vtk_commit_sha}}",
-            v9.5.0,
+            v9.5.2,
             v9.4.2,
             v9.3.1,
             v9.2.6,
@@ -607,7 +607,7 @@ jobs:
         vtk_version:
           [
             "${{needs.default_versions.outputs.vtk_commit_sha}}",
-            v9.5.0,
+            v9.5.2,
             v9.4.2,
             v9.3.1,
             v9.2.6,
@@ -659,7 +659,7 @@ jobs:
       matrix:
         vtk_version: [
             "${{needs.default_versions.outputs.vtk_commit_sha}}",
-            v9.5.0,
+            v9.5.2,
             v9.4.2,
             v9.3.1,
           ] # VTK 9.2.6 not compatible with recent clang version on macOS

--- a/doc/dev/BUILD.md
+++ b/doc/dev/BUILD.md
@@ -10,7 +10,7 @@ please take a look at our [getting started guide](GETTING_STARTED.md).
 ## Dependencies
 
 - [CMake](https://cmake.org) >= 3.1.
-- [VTK](https://vtk.org) >= 9.2.6 (9.5.0 recommended).
+- [VTK](https://vtk.org) >= 9.2.6 (9.5.2 recommended).
 - A C++17 compiler.
 - A CMake-compatible build system (Visual Studio, XCode, Ninja, Make, etc.).
 - Optionally, [Assimp](https://www.assimp.org/) >= 5.4.0 (6.0.2 recommended).
@@ -28,7 +28,7 @@ F3D is tested continuously against versions recommended by the [VFX reference pl
 
 ## VTK compatibility
 
-As stated in the dependencies, F3D is compatible with VTK >= 9.2.6, however, some features may not be available. We suggest using VTK 9.5.0 with RenderingRayTracing, IOExodus, IOHDF, IONetCDF and IOOpenVDB modules enabled in order to get as many features as possible in F3D.
+As stated in the dependencies, F3D is compatible with VTK >= 9.2.6, however, some features may not be available. We suggest using VTK 9.5.2 with RenderingRayTracing, IOExodus, IOHDF, IONetCDF and IOOpenVDB modules enabled in order to get as many features as possible in F3D.
 
 ## Configuration and building
 

--- a/doc/dev/GETTING_STARTED.md
+++ b/doc/dev/GETTING_STARTED.md
@@ -125,7 +125,7 @@ mkdir dev
 cd dev
 mkdir vtk
 cd vtk
-git clone --depth 1 --branch v9.5.0 https://gitlab.kitware.com/vtk/vtk.git src
+git clone --depth 1 --branch v9.5.2 https://gitlab.kitware.com/vtk/vtk.git src
 mkdir build
 mkdir install
 cd ..


### PR DESCRIPTION
### Describe your changes

Use v9.5.2 instead of v9.5.0 in CI and doc

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/CONTRIBUTING.html#continuous-integration) for more info.
