### PR TITLE
Exclude STL from doxygen

### DIFF
--- a/library/public/camera.h
+++ b/library/public/camera.h
@@ -4,8 +4,10 @@
 #include "export.h"
 #include "types.h"
 
+/// @cond
 #include <array>
 #include <string>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/context.h
+++ b/library/public/context.h
@@ -4,8 +4,10 @@
 #include "exception.h"
 #include "export.h"
 
+/// @cond
 #include <functional>
 #include <string>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/engine.h
+++ b/library/public/engine.h
@@ -9,9 +9,11 @@
 #include "scene.h"
 #include "window.h"
 
+/// @cond
 #include <map>
 #include <string>
 #include <vector>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/exception.h
+++ b/library/public/exception.h
@@ -1,8 +1,10 @@
 #ifndef f3d_exception_h
 #define f3d_exception_h
 
+/// @cond
 #include <stdexcept>
 #include <string>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/image.h
+++ b/library/public/image.h
@@ -4,9 +4,11 @@
 #include "exception.h"
 #include "export.h"
 
+/// @cond
 #include <filesystem>
 #include <string>
 #include <vector>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -7,10 +7,12 @@
 #include "options.h"
 #include "window.h"
 
+/// @cond
 #include <functional>
 #include <string>
 #include <utility>
 #include <vector>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/log.h
+++ b/library/public/log.h
@@ -3,8 +3,10 @@
 
 #include "export.h"
 
+/// @cond
 #include <sstream>
 #include <string>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/options.h.in
+++ b/library/public/options.h.in
@@ -5,12 +5,14 @@
 #include "export.h"
 #include "types.h"
 
+/// @cond
 #include <array>
 #include <filesystem>
 #include <optional>
 #include <string>
 #include <variant>
 #include <vector>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/scene.h
+++ b/library/public/scene.h
@@ -5,9 +5,11 @@
 #include "export.h"
 #include "types.h"
 
+/// @cond
 #include <filesystem>
 #include <string>
 #include <vector>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/types.h
+++ b/library/public/types.h
@@ -4,12 +4,14 @@
 #include "exception.h"
 #include "export.h"
 
+/// @cond
 #include <algorithm>
 #include <array>
 #include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/utils.h
+++ b/library/public/utils.h
@@ -4,6 +4,7 @@
 #include "exception.h"
 #include "export.h"
 
+/// @cond
 #include <filesystem>
 #include <map>
 #include <optional>
@@ -11,6 +12,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+/// @endcond
 
 namespace f3d
 {

--- a/library/public/window.h
+++ b/library/public/window.h
@@ -5,7 +5,9 @@
 #include "export.h"
 #include "image.h"
 
+/// @cond
 #include <string>
+/// @endcond
 
 namespace f3d
 {


### PR DESCRIPTION
### Describe your changes

Listing STL headers adds noise in the documentation and is introducing issues with the upcoming markdown documentation.  
Let's exclude them.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/doc/dev/CODING_STYLE.html) of my code
- [ ] I have added [tests](https://f3d.app/doc/dev/TESTING.html) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/CONTRIBUTING.html#continuous-integration) for more info.
