### PR TITLE
Reset camera (if it is necessary) after toggling volume rendering

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -1066,6 +1066,7 @@ f3d_test(NAME TestInteractionConsoleCamera DATA f3d.glb INTERACTION UI) #Escape;
 f3d_test(NAME TestInteractionConsoleScrollbar DATA f3d.glb INTERACTION UI) #Escape;a;Enter;Grab scrollbar
 f3d_test(NAME TestInteractionConsoleEmptyCommand DATA f3d.glb INTERACTION UI) #Escape;Enter
 f3d_test(NAME TestInteractionConsoleOverCheatSheet DATA f3d.glb INTERACTION UI) #h;Escape;Enter
+f3d_test(NAME TestInteractionCorrectCameraForVolumeSwitch ARGS --no-config -v DATA dragon.vtu INTERACTION UI) #v
 
 # Need SSIM comparison for some reason
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20240729)

--- a/library/private/camera_impl.h
+++ b/library/private/camera_impl.h
@@ -79,6 +79,11 @@ public:
    */
   vtkCamera* GetVTKCamera() const;
 
+  /**
+   * Check if camera was successfully reset with resetToBounds.
+   */
+  bool GetSuccessfullyReset() const;
+
 private:
   class internals;
   std::unique_ptr<internals> Internals;

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -653,6 +653,13 @@ vtkRenderWindow* window_impl::GetRenderWindow()
 bool window_impl::render()
 {
   this->UpdateDynamicOptions();
+  const options& opt = this->Internals->Options;
+  if ((!opt.scene.camera.index.has_value()) && (!this->Internals->Camera->GetSuccessfullyReset()))
+  {
+    // Camera wasn't successfully reset last time, it could be a chance that update of dynamic
+    // options will enable successful reset of camera
+    this->Internals->Camera->resetToBounds();
+  }
   this->Internals->RenWin->Render();
   return true;
 }

--- a/testing/baselines/TestInteractionCorrectCameraForVolumeSwitch.png
+++ b/testing/baselines/TestInteractionCorrectCameraForVolumeSwitch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a9421ed9dc6922703dda1d5c545f20c4a89200040768471ee9e85b22c6fcf48
+size 23390

--- a/testing/recordings/TestInteractionCorrectCameraForVolumeSwitch.log
+++ b/testing/recordings/TestInteractionCorrectCameraForVolumeSwitch.log
@@ -1,0 +1,8 @@
+# StreamVersion 1.2
+ExposeEvent 0 599 0 0 0 0 0
+RenderEvent 0 599 0 0 0 0 0
+TimerEvent 0 599 0 0 0 0 0
+TimerEvent 0 599 0 0 0 0 0
+KeyPressEvent 1481 -57 0 118 1 v 0
+CharEvent 1481 -57 0 118 1 v 0
+KeyReleaseEvent 1481 -57 0 118 1 v 0


### PR DESCRIPTION
### Describe your changes
When volume rendering is being disabled camera aren't being reset. In case if volume rendering is not supported it could cause camera to be set to 0,0,1 which is incorrect in almost all cases of rendering normally visible 3D model
### Issue ticket number and link if any
https://github.com/f3d-app/f3d/issues/2373

Needs: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12565

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `timestamp`

### Continuous integration

\ci full
