### PR TITLE
CI: Add support for global cache index

### DIFF
--- a/.github/actions/alembic-install-dep/action.yml
+++ b/.github/actions/alembic-install-dep/action.yml
@@ -11,6 +11,9 @@ inputs:
   imath_version:
     description: "Version of imath to build against"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -20,13 +23,14 @@ runs:
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
         [[ "${{ inputs.imath_version }}" ]] || { echo "imath_version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache Alembic
       id: cache-alembic
       uses: actions/cache/restore@v4
       with:
         path: dependencies/alembic_install
-        key: alembic-${{inputs.version}}-${{inputs.imath_version}}-${{runner.os}}-${{inputs.cpu}}-1
+        key: alembic-${{inputs.version}}-${{inputs.imath_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
 
     - name: Checkout Alembic
       if: steps.cache-alembic.outputs.cache-hit != 'true'

--- a/.github/actions/assimp-install-dep/action.yml
+++ b/.github/actions/assimp-install-dep/action.yml
@@ -8,6 +8,9 @@ inputs:
   version:
     description: "Version of assimp to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -16,13 +19,14 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache ASSIMP
       id: cache-assimp
       uses: actions/cache/restore@v4
       with:
         path: dependencies/assimp_install
-        key: assimp-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-1
+        key: assimp-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
 
     - name: Checkout ASSIMP
       if: steps.cache-assimp.outputs.cache-hit != 'true'

--- a/.github/actions/blosc-install-dep/action.yml
+++ b/.github/actions/blosc-install-dep/action.yml
@@ -11,6 +11,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build against"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -20,13 +23,14 @@ runs:
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
         [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache blosc
       id: cache-blosc
       uses: actions/cache/restore@v4
       with:
         path: dependencies/blosc_install
-        key: blosc-${{inputs.version}}-${{inputs.zlib_version}}-${{runner.os}}-${{inputs.cpu}}-1
+        key: blosc-${{inputs.version}}-${{inputs.zlib_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
 
     # Dependents: openvdb vtk
     - name: Checkout blosc

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -50,6 +50,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -83,6 +86,7 @@ runs:
         usd_version: ${{inputs.usd_version}}
         webp_version: ${{inputs.webp_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
@@ -93,6 +97,7 @@ runs:
         tbb_version: ${{inputs.tbb_version}}
         vtk_version: ${{inputs.vtk_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     # coverage build is done in source as it seems to be required for codecov
     # CMAKE_MODULE_PATH is required because of

--- a/.github/actions/draco-install-dep/action.yml
+++ b/.github/actions/draco-install-dep/action.yml
@@ -8,6 +8,9 @@ inputs:
   version:
     description: "Version of draco to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -16,13 +19,14 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache Draco
       id: cache-draco
       uses: actions/cache/restore@v4
       with:
         path: dependencies/draco_install
-        key: draco-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-4
+        key: draco-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     - name: Checkout Draco
       if: steps.cache-draco.outputs.cache-hit != 'true'

--- a/.github/actions/external-build-ci/action.yml
+++ b/.github/actions/external-build-ci/action.yml
@@ -13,6 +13,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -42,6 +45,7 @@ runs:
         blosc_version: ${{inputs.blosc_version}}
         tbb_version: ${{inputs.tbb_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install VTK dependency
       uses: ./source/f3d/.github/actions/vtk-install-dep
@@ -50,6 +54,7 @@ runs:
         tbb_version: ${{inputs.tbb_version}}
         vtk_version: ${{inputs.vtk_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -35,6 +35,9 @@ inputs:
   webp_version:
     description: "Version of webp to build"
     required: false
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -45,6 +48,7 @@ runs:
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.occt_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install Assimp dependency
       if: inputs.assimp_version != ''
@@ -52,6 +56,7 @@ runs:
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.assimp_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install Draco dependency
       if: inputs.draco_version != ''
@@ -59,6 +64,7 @@ runs:
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.draco_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install Imath dependency
       if: inputs.imath_version != ''
@@ -66,6 +72,7 @@ runs:
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.imath_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install OpenEXR dependency
       if: inputs.openexr_version != ''
@@ -74,6 +81,7 @@ runs:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.openexr_version}}
         imath_version: ${{inputs.imath_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install Alembic dependency
       if: inputs.alembic_version != ''
@@ -82,12 +90,14 @@ runs:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.alembic_version}}
         imath_version: ${{inputs.imath_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install pybind11 dependency
       if: inputs.pybind11_version != ''
       uses: ./source/.github/actions/pybind11-install-dep
       with:
         version: ${{inputs.pybind11_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install USD dependency
       if: inputs.usd_version != ''
@@ -97,6 +107,7 @@ runs:
         version: ${{inputs.usd_version}}
         openexr_version: ${{inputs.openexr_version}}
         tbb_version: ${{inputs.tbb_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install webp dependency
       if: inputs.webp_version != ''
@@ -104,3 +115,4 @@ runs:
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.webp_version}}
+        global_cache_index: ${{inputs.global_cache_index}}

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -83,6 +83,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -118,6 +121,7 @@ runs:
         usd_version: ${{inputs.usd_version}}
         webp_version: ${{inputs.webp_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
@@ -129,6 +133,7 @@ runs:
         tbb_version: ${{inputs.tbb_version}}
         vtk_version: ${{inputs.vtk_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Set up Python
       if: |

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -51,6 +51,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -71,6 +74,7 @@ runs:
         openvdb_version: ${{inputs.openvdb_version}}
         tbb_version: ${{inputs.tbb_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install Raytracing Dependencies
       if: inputs.ospray_version != ''
@@ -78,6 +82,7 @@ runs:
       with:
         version: ${{inputs.ospray_version}}
         cpu: ${{inputs.cpu}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install F3D dependencies
       if: inputs.optional_deps_label == 'optional-deps'
@@ -94,3 +99,4 @@ runs:
         tbb_version: ${{inputs.tbb_version}}
         usd_version: ${{inputs.usd_version}}
         webp_version: ${{inputs.webp_version}}
+        global_cache_index: ${{inputs.global_cache_index}}

--- a/.github/actions/imath-install-dep/action.yml
+++ b/.github/actions/imath-install-dep/action.yml
@@ -8,6 +8,9 @@ inputs:
   version:
     description: "Version of imath to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -16,13 +19,14 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache Imath
       id: cache-imath
       uses: actions/cache/restore@v4
       with:
         path: dependencies/imath_install
-        key: imath-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-1
+        key: imath-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     # Dependents: alembic openexr
     - name: Checkout Imath

--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -8,6 +8,9 @@ inputs:
   version:
     description: "Version of occt to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -16,13 +19,14 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache OCCT
       id: cache-occt
       uses: actions/cache/restore@v4
       with:
         path: dependencies/occt_install
-        key: occt-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-5
+        key: occt-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     - name: Checkout OCCT
       if: steps.cache-occt.outputs.cache-hit != 'true'

--- a/.github/actions/openexr-install-dep/action.yml
+++ b/.github/actions/openexr-install-dep/action.yml
@@ -11,6 +11,9 @@ inputs:
   imath_version:
     description: "Version of imath to build against"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -19,13 +22,14 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache OpenEXR
       id: cache-openexr
       uses: actions/cache/restore@v4
       with:
         path: dependencies/openexr_install
-        key: openexr-${{inputs.version}}-${{inputs.imath_version}}-${{runner.os}}-${{inputs.cpu}}-2
+        key: openexr-${{inputs.version}}-${{inputs.imath_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     # Dependents: usd
     - name: Checkout OpenEXR

--- a/.github/actions/openvdb-install-dep/action.yml
+++ b/.github/actions/openvdb-install-dep/action.yml
@@ -17,6 +17,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build against"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -28,13 +31,14 @@ runs:
         [[ "${{ inputs.blosc_version }}" ]] || { echo "blosc_version input is empty" ; exit 1; }
         [[ "${{ inputs.tbb_version }}" ]] || { echo "tbb_version input is empty" ; exit 1; }
         [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache OpenVDB
       id: cache-openvdb
       uses: actions/cache/restore@v4
       with:
         path: dependencies/openvdb_install
-        key: openvdb-${{inputs.version}}-${{inputs.zlib_version}}-${{inputs.blosc_version}}-${{inputs.tbb_version}}-${{runner.os}}-${{inputs.cpu}}-0
+        key: openvdb-${{inputs.version}}-${{inputs.zlib_version}}-${{inputs.blosc_version}}-${{inputs.tbb_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     # Dependents: vtk
     - name: Checkout OpenVDB

--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -16,13 +19,14 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache ospray
       id: cache-ospray
       uses: actions/cache/restore@v4
       with:
         path: dependencies/ospray_install
-        key: ospray-sb-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-0
+        key: ospray-sb-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     # Dependents: vtk
     - name: Checkout ospray

--- a/.github/actions/pybind11-install-dep/action.yml
+++ b/.github/actions/pybind11-install-dep/action.yml
@@ -4,16 +4,25 @@ inputs:
   version:
     description: "Version of pybind11 to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
   steps:
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+
     - name: Cache pybind11
       id: cache-pybind11
       uses: actions/cache/restore@v4
       with:
         path: dependencies/pybind11_install
-        key: pybind11-${{inputs.version}}-${{runner.os}}-1
+        key: pybind11-${{inputs.version}}-${{runner.os}}-${{inputs.global_cache_index}}-0
 
     - name: Checkout pybind11
       if: steps.cache-pybind11.outputs.cache-hit != 'true'

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -49,6 +49,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -83,6 +86,7 @@ runs:
         usd_version: ${{inputs.usd_version}}
         webp_version: ${{inputs.webp_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
@@ -92,6 +96,7 @@ runs:
         tbb_version: ${{inputs.tbb_version}}
         vtk_version: ${{inputs.vtk_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -40,6 +40,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -71,6 +74,7 @@ runs:
         tbb_version: ${{inputs.tbb_version}}
         webp_version: ${{inputs.webp_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
@@ -79,6 +83,7 @@ runs:
         tbb_version: ${{inputs.tbb_version}}
         vtk_version: ${{inputs.vtk_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -43,6 +43,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -76,6 +79,7 @@ runs:
         usd_version: ${{inputs.usd_version}}
         webp_version: ${{inputs.webp_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
@@ -85,6 +89,7 @@ runs:
         tbb_version: ${{inputs.tbb_version}}
         vtk_version: ${{inputs.vtk_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/tbb-install-dep/action.yml
+++ b/.github/actions/tbb-install-dep/action.yml
@@ -8,6 +8,9 @@ inputs:
   version:
     description: "Version of tbb to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -16,13 +19,14 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache TBB
       id: cache-tbb
       uses: actions/cache/restore@v4
       with:
         path: dependencies/tbb_install
-        key: tbb-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-3
+        key: tbb-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     # Dependents: usd openvdb vtk
     # v2021.13.0 somehow cause memory issue in draco and alembic

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -14,6 +14,9 @@ inputs:
   tbb_version:
     description: "Version of tbb to build against"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -24,13 +27,14 @@ runs:
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
         [[ "${{ inputs.openexr_version }}" ]] || { echo "openexr_version input is empty" ; exit 1; }
         [[ "${{ inputs.tbb_version }}" ]] || { echo "tbb_version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache USD
       id: cache-usd
       uses: actions/cache/restore@v4
       with:
         path: dependencies/usd_install
-        key: usd-${{inputs.version}}-${{inputs.openexr_version}}-${{inputs.tbb_version}}-${{runner.os}}-${{inputs.cpu}}-1
+        key: usd-${{inputs.version}}-${{inputs.openexr_version}}-${{inputs.tbb_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     - name: Checkout USD
       if: steps.cache-usd.outputs.cache-hit != 'true'

--- a/.github/actions/vtk-dependencies/action.yml
+++ b/.github/actions/vtk-dependencies/action.yml
@@ -21,6 +21,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -37,12 +40,14 @@ runs:
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.tbb_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install zlib
       uses: ./.actions/zlib-install-dep
       with:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install blosc
       uses: ./.actions/blosc-install-dep
@@ -50,6 +55,7 @@ runs:
         cpu: ${{inputs.cpu}}
         version: ${{inputs.blosc_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install OpenVDB
       if: inputs.openvdb_version != ''
@@ -60,3 +66,4 @@ runs:
         blosc_version: ${{inputs.blosc_version}}
         tbb_version: ${{inputs.tbb_version}}
         zlib_version: ${{inputs.zlib_version}}
+        global_cache_index: ${{inputs.global_cache_index}}

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -23,6 +23,9 @@ inputs:
   zlib_version:
     description: "Version of zlib to build against"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -34,13 +37,14 @@ runs:
         [[ "${{ inputs.tbb_version }}" ]] || { echo "tbb_version input is empty" ; exit 1; }
         [[ "${{ inputs.vtk_version }}" ]] || { echo "vtk_version input is empty" ; exit 1; }
         [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache VTK
       id: cache-vtk
       uses: actions/cache/restore@v4
       with:
         path: dependencies/vtk_install
-        key: vtk-${{ inputs.vtk_version }}-${{inputs.zlib_version}}-${{inputs.blosc_version}}-${{inputs.tbb_version}}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}${{ inputs.ospray_version != '' && format('-ospray-{0}', inputs.ospray_version) || '' }}-${{runner.os}}-${{inputs.cpu}}-0
+        key: vtk-${{ inputs.vtk_version }}-${{inputs.zlib_version}}-${{inputs.blosc_version}}-${{inputs.tbb_version}}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}${{ inputs.ospray_version != '' && format('-ospray-{0}', inputs.ospray_version) || '' }}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'

--- a/.github/actions/webp-install-dep/action.yml
+++ b/.github/actions/webp-install-dep/action.yml
@@ -8,6 +8,9 @@ inputs:
   version:
     description: "Version of WebP to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -16,13 +19,14 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache WebP
       id: cache-webp
       uses: actions/cache/restore@v4
       with:
         path: dependencies/webp_install
-        key: webp-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-1
+        key: webp-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     - name: Checkout WebP
       if: steps.cache-webp.outputs.cache-hit != 'true'

--- a/.github/actions/zlib-install-dep/action.yml
+++ b/.github/actions/zlib-install-dep/action.yml
@@ -8,6 +8,9 @@ inputs:
   version:
     description: "Version of zlib to build"
     required: true
+  global_cache_index:
+    description: "Global cache index"
+    required: true
 
 runs:
   using: "composite"
@@ -16,13 +19,14 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
+        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
 
     - name: Cache zlib
       id: cache-zlib
       uses: actions/cache/restore@v4
       with:
         path: dependencies/zlib_install
-        key: zlib-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-5
+        key: zlib-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
 
     # Dependents: blosc openvdb vtk
     - name: Checkout zlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       zlib_version: ${{ steps.set_default_versions.outputs.zlib_version }}
       vtk_commit_sha: ${{ steps.set_default_versions.outputs.vtk_commit_sha }}
       docker_timestamp: ${{ steps.set_default_versions.outputs.docker_timestamp }}
+      global_cache_index: ${{ steps.set_default_versions.outputs.global_cache_index }}
 
     steps:
       - name: Checkout
@@ -186,6 +187,7 @@ jobs:
           usd_version: ${{matrix.usd_version}}
           webp_version: ${{matrix.webp_version}}
           zlib_version: ${{matrix.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Cache VTK Dependency: Checkout and compile VTK if not cached
@@ -278,6 +280,7 @@ jobs:
           blosc_version: ${{matrix.blosc_version}}
           tbb_version: ${{matrix.tbb_version}}
           zlib_version: ${{matrix.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
       - name: Install Raytracing Dependencies
         if: matrix.ospray_version != ''
@@ -285,6 +288,7 @@ jobs:
         with:
           version: ${{matrix.ospray_version}}
           cpu: ${{matrix.cpu}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
       - name: VTK dependency
         uses: ./source/.github/actions/vtk-install-dep
@@ -296,6 +300,7 @@ jobs:
           ospray_version: ${{matrix.ospray_version}}
           tbb_version: ${{matrix.tbb_version}}
           zlib_version: ${{matrix.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Windows CI: Build and test, cross-vtk build matrix
@@ -356,6 +361,7 @@ jobs:
           usd_version: ${{needs.default_versions.outputs.usd_version}}
           webp_version: ${{needs.default_versions.outputs.webp_version}}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Linux fast CI: Build and test a single fast CI
@@ -395,6 +401,7 @@ jobs:
           tbb_version: ${{needs.default_versions.outputs.tbb_version}}
           vtk_version: v9.5.2
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Linux CI: Build and test, cross-vtk build matrix
@@ -597,6 +604,7 @@ jobs:
           usd_version: ${{matrix.usd_version}}
           webp_version: ${{matrix.webp_version}}
           zlib_version: ${{matrix.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # MacOS CI: Build and test, cross-vtk build matrix
@@ -652,6 +660,7 @@ jobs:
           usd_version: ${{needs.default_versions.outputs.usd_version}}
           webp_version: ${{needs.default_versions.outputs.webp_version}}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
@@ -718,6 +727,7 @@ jobs:
           usd_version: ${{needs.default_versions.outputs.usd_version}}
           webp_version: ${{needs.default_versions.outputs.webp_version}}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Python packaging: Build and test the Python wheel
@@ -780,6 +790,7 @@ jobs:
           vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
           webp_version: ${{needs.default_versions.outputs.webp_version}}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Coverage: Build and test on linux with last VTK with coverage option
@@ -825,6 +836,7 @@ jobs:
           vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
           webp_version: ${{needs.default_versions.outputs.webp_version}}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -876,6 +888,7 @@ jobs:
           vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
           webp_version: ${{needs.default_versions.outputs.webp_version}}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # static-analysis: Run static analysis on linux
@@ -921,6 +934,7 @@ jobs:
           vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
           webp_version: ${{needs.default_versions.outputs.webp_version}}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # external-build: Check build of F3D as sub-project
@@ -954,6 +968,7 @@ jobs:
           tbb_version: ${{needs.default_versions.outputs.tbb_version}}
           vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Check android/wasm docker images

--- a/.github/workflows/nightly_vtk_master.yml
+++ b/.github/workflows/nightly_vtk_master.yml
@@ -57,6 +57,7 @@ jobs:
       webp_version: ${{ steps.set_default_versions.outputs.webp_version }}
       zlib_version: ${{ steps.set_default_versions.outputs.zlib_version }}
       docker_timestamp: ${{ steps.set_default_versions.outputs.docker_timestamp }}
+      global_cache_index: ${{ steps.set_default_versions.outputs.global_cache_index }}
 
     steps:
       - name: Checkout
@@ -139,6 +140,7 @@ jobs:
           usd_version: ${{needs.default_versions.outputs.usd_version}}
           webp_version: ${{ needs.default_versions.outputs.webp_version }}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Linux CI: Build and test
@@ -194,6 +196,7 @@ jobs:
           usd_version: ${{needs.default_versions.outputs.usd_version}}
           webp_version: ${{ needs.default_versions.outputs.webp_version }}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # MacOS CI: Build and test
@@ -239,6 +242,7 @@ jobs:
           usd_version: ${{needs.default_versions.outputs.usd_version}}
           webp_version: ${{ needs.default_versions.outputs.webp_version }}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # MacOS arm64 CI: Build and test
@@ -284,6 +288,7 @@ jobs:
           usd_version: ${{needs.default_versions.outputs.usd_version}}
           webp_version: ${{ needs.default_versions.outputs.webp_version }}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -339,6 +344,7 @@ jobs:
           usd_version: ${{needs.default_versions.outputs.usd_version}}
           webp_version: ${{ needs.default_versions.outputs.webp_version }}
           zlib_version: ${{needs.default_versions.outputs.zlib_version}}
+          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Build android/wasm docker images

--- a/.github/workflows/versions.json
+++ b/.github/workflows/versions.json
@@ -44,5 +44,6 @@
     "zlib": "v1.2.13"
   },
   "vtk_commit_sha": "01b47f3856dcd5d0fd353037236f2d09a8c513af",
-  "docker_timestamp": "20251021_0"
+  "docker_timestamp": "20251021_0",
+  "global_cache_index": "0"
 }


### PR DESCRIPTION
### Describe your changes

Add a `global_cache_index` field in versions.json for easier invalidation of caches at PR level.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
