### PR TITLE
Reduce VRAM usage

### DIFF
--- a/vtkext/private/module/vtkF3DHexagonalBokehBlurPass.cxx
+++ b/vtkext/private/module/vtkF3DHexagonalBokehBlurPass.cxx
@@ -72,42 +72,42 @@ void vtkF3DHexagonalBokehBlurPass::InitializeGraphicsResources(
   {
     this->BackgroundTexture = vtkSmartPointer<vtkTextureObject>::New();
     this->BackgroundTexture->SetContext(renWin);
-    this->BackgroundTexture->SetFormat(GL_RGBA);
-    this->BackgroundTexture->SetInternalFormat(GL_RGBA32F);
-    this->BackgroundTexture->SetDataType(GL_FLOAT);
+    this->BackgroundTexture->SetFormat(GL_RGB);
+    this->BackgroundTexture->SetInternalFormat(GL_RGB16F);
+    this->BackgroundTexture->SetDataType(GL_HALF_FLOAT);
     this->BackgroundTexture->SetMinificationFilter(vtkTextureObject::Linear);
     this->BackgroundTexture->SetMagnificationFilter(vtkTextureObject::Linear);
     this->BackgroundTexture->SetWrapS(vtkTextureObject::ClampToEdge);
     this->BackgroundTexture->SetWrapT(vtkTextureObject::ClampToEdge);
-    this->BackgroundTexture->Allocate2D(width, height, 4, VTK_FLOAT);
+    this->BackgroundTexture->Allocate2D(width, height, 3, VTK_FLOAT);
   }
 
   if (this->VerticalBlurTexture == nullptr)
   {
     this->VerticalBlurTexture = vtkSmartPointer<vtkTextureObject>::New();
     this->VerticalBlurTexture->SetContext(renWin);
-    this->VerticalBlurTexture->SetFormat(GL_RGBA);
-    this->VerticalBlurTexture->SetInternalFormat(GL_RGBA32F);
-    this->VerticalBlurTexture->SetDataType(GL_FLOAT);
+    this->VerticalBlurTexture->SetFormat(GL_RGB);
+    this->VerticalBlurTexture->SetInternalFormat(GL_RGB16F);
+    this->VerticalBlurTexture->SetDataType(GL_HALF_FLOAT);
     this->VerticalBlurTexture->SetMinificationFilter(vtkTextureObject::Linear);
     this->VerticalBlurTexture->SetMagnificationFilter(vtkTextureObject::Linear);
     this->VerticalBlurTexture->SetWrapS(vtkTextureObject::ClampToEdge);
     this->VerticalBlurTexture->SetWrapT(vtkTextureObject::ClampToEdge);
-    this->VerticalBlurTexture->Allocate2D(width, height, 4, VTK_FLOAT);
+    this->VerticalBlurTexture->Allocate2D(width, height, 3, VTK_FLOAT);
   }
 
   if (this->DiagonalBlurTexture == nullptr)
   {
     this->DiagonalBlurTexture = vtkSmartPointer<vtkTextureObject>::New();
     this->DiagonalBlurTexture->SetContext(renWin);
-    this->DiagonalBlurTexture->SetFormat(GL_RGBA);
-    this->DiagonalBlurTexture->SetInternalFormat(GL_RGBA32F);
-    this->DiagonalBlurTexture->SetDataType(GL_FLOAT);
+    this->DiagonalBlurTexture->SetFormat(GL_RGB);
+    this->DiagonalBlurTexture->SetInternalFormat(GL_RGB16F);
+    this->DiagonalBlurTexture->SetDataType(GL_HALF_FLOAT);
     this->DiagonalBlurTexture->SetMinificationFilter(vtkTextureObject::Linear);
     this->DiagonalBlurTexture->SetMagnificationFilter(vtkTextureObject::Linear);
     this->DiagonalBlurTexture->SetWrapS(vtkTextureObject::ClampToEdge);
     this->DiagonalBlurTexture->SetWrapT(vtkTextureObject::ClampToEdge);
-    this->DiagonalBlurTexture->Allocate2D(width, height, 4, VTK_FLOAT);
+    this->DiagonalBlurTexture->Allocate2D(width, height, 3, VTK_FLOAT);
   }
 
   if (this->FrameBufferObject == nullptr)

--- a/vtkext/private/module/vtkF3DOverlayRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DOverlayRenderPass.cxx
@@ -99,7 +99,6 @@ void vtkF3DOverlayRenderPass::Initialize(const vtkRenderState* s)
 
   this->OverlayPass = vtkSmartPointer<vtkFramebufferPass>::New();
   this->OverlayPass->SetDelegatePass(overlayCamP);
-  this->OverlayPass->SetColorFormat(vtkTextureObject::Float32);
 }
 
 // ----------------------------------------------------------------------------

--- a/vtkext/private/module/vtkF3DRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DRenderPass.cxx
@@ -121,7 +121,7 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
   vtkNew<vtkCameraPass> bgCamP;
   bgCamP->SetDelegatePass(bgP);
   this->BackgroundPass = vtkSmartPointer<vtkFramebufferPass>::New();
-  this->BackgroundPass->SetColorFormat(vtkTextureObject::Float32);
+  this->BackgroundPass->SetColorFormat(vtkTextureObject::Float16);
 
   if (this->UseBlurBackground)
   {

--- a/vtkext/private/module/vtkF3DTAAResolvePass.cxx
+++ b/vtkext/private/module/vtkF3DTAAResolvePass.cxx
@@ -42,6 +42,9 @@ void vtkF3DTAAResolvePass::Render(const vtkRenderState* state)
   {
     this->HistoryTexture = vtkSmartPointer<vtkTextureObject>::New();
     this->HistoryTexture->SetContext(renWin);
+    this->HistoryTexture->SetFormat(GL_RGBA);
+    this->HistoryTexture->SetInternalFormat(GL_RGBA16F);
+    this->HistoryTexture->SetDataType(GL_HALF_FLOAT);
     this->HistoryTexture->SetMinificationFilter(vtkTextureObject::Linear);
     this->HistoryTexture->SetMagnificationFilter(vtkTextureObject::Linear);
     this->HistoryTexture->SetWrapS(vtkTextureObject::ClampToEdge);
@@ -56,6 +59,9 @@ void vtkF3DTAAResolvePass::Render(const vtkRenderState* state)
   {
     this->ColorTexture = vtkSmartPointer<vtkTextureObject>::New();
     this->ColorTexture->SetContext(renWin);
+    this->ColorTexture->SetFormat(GL_RGBA);
+    this->ColorTexture->SetInternalFormat(GL_RGBA16F);
+    this->ColorTexture->SetDataType(GL_HALF_FLOAT);
     this->ColorTexture->SetMinificationFilter(vtkTextureObject::Linear);
     this->ColorTexture->SetMagnificationFilter(vtkTextureObject::Linear);
     this->ColorTexture->SetWrapS(vtkTextureObject::ClampToEdge);


### PR DESCRIPTION
### Describe your changes

When running this command:
```
f3d dragon.vtu--resolution=2500,1500 --hdri-file=palermo_park_1k.hdr -uatqxj --anti-aliasing-mode=taa
```

The VRAM usage is reduced from 1272MB to 1005MB without any visual change.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
