### PR TITLE
Enforce blending function for external windows

### DIFF
--- a/vtkext/private/module/vtkF3DExternalRenderWindow.cxx
+++ b/vtkext/private/module/vtkF3DExternalRenderWindow.cxx
@@ -1,6 +1,13 @@
 #include <vtkObjectFactory.h>
 #include <vtkOpenGLFramebufferObject.h>
 #include <vtkOpenGLState.h>
+#include <vtkVersion.h>
+
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 20240914)
+#include <vtk_glad.h>
+#else
+#include <vtk_glew.h>
+#endif
 
 #include "vtkF3DExternalRenderWindow.h"
 
@@ -18,6 +25,10 @@ vtkF3DExternalRenderWindow::~vtkF3DExternalRenderWindow() = default;
 //------------------------------------------------------------------------------
 void vtkF3DExternalRenderWindow::Start()
 {
+  this->GetState()->vtkglEnable(GL_BLEND);
+  this->GetState()->vtkglBlendFuncSeparate(
+    GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+
   // creates or resizes the framebuffer
   this->Size[0] = (this->Size[0] > 0 ? this->Size[0] : 300);
   this->Size[1] = (this->Size[1] > 0 ? this->Size[1] : 300);


### PR DESCRIPTION
### Describe your changes

When using F3D in an external context, we do not control the OpenGL state at the beginning of the rendering pipeline. It's important to enforce the correct blending function in order to avoid blending artifacts.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
