### PR TITLE
Native: Use Legacy reader instead of Parallel Legacy reader

### DIFF
--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -44,7 +44,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: dependencies/vtk_install
-        key: vtk-${{ inputs.vtk_version }}-${{inputs.zlib_version}}-${{inputs.blosc_version}}-${{inputs.tbb_version}}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}${{ inputs.ospray_version != '' && format('-ospray-{0}', inputs.ospray_version) || '' }}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
+        key: vtk-${{ inputs.vtk_version }}-${{inputs.zlib_version}}-${{inputs.blosc_version}}-${{inputs.tbb_version}}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}${{ inputs.ospray_version != '' && format('-ospray-{0}', inputs.ospray_version) || '' }}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'
@@ -108,10 +108,10 @@ runs:
         -DVTK_MODULE_ENABLE_VTK_IOHDF=YES
         -DVTK_MODULE_ENABLE_VTK_IOImage=YES
         -DVTK_MODULE_ENABLE_VTK_IOImport=YES
+        -DVTK_MODULE_ENABLE_VTK_IOLegacy=YES
         -DVTK_MODULE_ENABLE_VTK_IONetCDF=YES
         -DVTK_MODULE_ENABLE_VTK_IOOpenVDB=${{ inputs.openvdb_version != '' && 'YES' || 'DEFAULT' }}
         -DVTK_MODULE_ENABLE_VTK_IOPLY=YES
-        -DVTK_MODULE_ENABLE_VTK_IOParallel=YES
         -DVTK_MODULE_ENABLE_VTK_IOXML=YES
         -DVTK_MODULE_ENABLE_VTK_ImagingCore=YES
         -DVTK_MODULE_ENABLE_VTK_ImagingHybrid=YES

--- a/.github/workflows/versions.json
+++ b/.github/workflows/versions.json
@@ -45,6 +45,6 @@
     "zlib": "v1.2.13"
   },
   "vtk_commit_sha": "f2897dc025ab604a8edeff3f04bd07936edbc4a8",
-  "docker_timestamp": "20250203_0",
+  "docker_timestamp": "20250203_1",
   "global_cache_index": "1"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,10 @@ find_package(VTK 9.3.0 REQUIRED
     InteractionStyle
     InteractionWidgets
     IOCityGML
+    IOLegacy
     IOGeometry
     IOImage
     IOImport
-    IOParallel
     IOPLY
     IOXML
     RenderingAnnotation
@@ -78,7 +78,6 @@ find_package(VTK 9.3.0 REQUIRED
     RenderingOpenGL2
     RenderingVolumeOpenGL2
     TestingCore
-    jsoncpp
   OPTIONAL_COMPONENTS
     opengl
     IOExodus

--- a/plugins/native/CMakeLists.txt
+++ b/plugins/native/CMakeLists.txt
@@ -110,7 +110,7 @@ f3d_plugin_declare_reader(
   SCORE 99
   EXTENSIONS vtk
   MIMETYPES application/vnd.vtk
-  VTK_READER vtkPDataSetReader
+  VTK_READER vtkDataSetReader
   FORMAT_DESCRIPTION "VTK Legacy"
 )
 
@@ -206,7 +206,7 @@ f3d_plugin_build(
   NAME native
   VERSION 1.0
   DESCRIPTION "Native VTK I/O support"
-  VTK_MODULES IOXML IOParallel IOCityGML IOImage IOGeometry IOPLY
+  VTK_MODULES IOXML IOLegacy IOCityGML IOImage IOGeometry IOPLY
   MIMETYPE_XML_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/f3d-3d-formats.xml"
     "${CMAKE_CURRENT_SOURCE_DIR}/f3d-3d-image-formats.xml"


### PR DESCRIPTION
### Describe your changes

Use vtkDataSetReader instead of vtkPDataSetReader to read legacy .vtk format,
which remove a module from our needs.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [x] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
