### PR TITLE
Revert "CI: Use another trigger-workflow-and-wait action (#2729)"

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -58,7 +58,7 @@ jobs:
       # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
       - name: Trigger docker images build
         if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1'}}
-        uses: rolkool/trigger-workflow-and-wait@master
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: f3d-app
           repo: f3d-docker-images

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "WEBSITE_SKIP_DEPLOY=${{ github.ref == 'refs/heads/master' && github.event_name == 'push' && 'false' || 'true' }}" >> $GITHUB_ENV
 
       - name: Trigger docker images build
-        uses: rolkool/trigger-workflow-and-wait@master
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: f3d-app
           repo: f3d-website

--- a/.github/workflows/nightly_vtk_master.yml
+++ b/.github/workflows/nightly_vtk_master.yml
@@ -356,7 +356,7 @@ jobs:
     steps:
       # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
       - name: Trigger docker images build
-        uses: rolkool/trigger-workflow-and-wait@master
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: f3d-app
           repo: f3d-docker-images


### PR DESCRIPTION
This reverts commit b2174b4f7db0acbf286b967a722dfaba3d652abe.

### Describe your changes

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
