### PR TITLE
Revert "CI: codespell continue-on-error (#2742)"

### DIFF
--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -30,7 +30,6 @@ jobs:
       # Run codespell first to avoid issues with style check on same location
       - name: Codespell in place
         shell: bash
-        continue-on-error: true
         run: |
           pip install codespell
           codespell -fHw .


### PR DESCRIPTION
This reverts commit 3f7330209a6ef6272fc5ec4de315e318533abac5.

### Describe your changes

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
