### PR TITLE
Alembic skip topology

### DIFF
--- a/plugins/alembic/module/vtkF3DAlembicReader.cxx
+++ b/plugins/alembic/module/vtkF3DAlembicReader.cxx
@@ -222,7 +222,7 @@ class vtkF3DAlembicReader::vtkInternals
     polydata->SetPoints(points);
 
     vtkIdType numCells = static_cast<vtkIdType>(data.Indices.size());
-    vtkIdType totalConnectivitySize = 
+    vtkIdType totalConnectivitySize =
       std::accumulate(data.Indices.begin(), data.Indices.end(), vtkIdType(0),
         [](vtkIdType sum, const auto& face) { return sum + static_cast<vtkIdType>(face.size()); });
 


### PR DESCRIPTION
### Describe your changes
I added a cache to avoid rebuilding the entire mesh topology.
In case the topology is constant a lookup table is used to retrieve the object mesh, avoiding the call to PointDuplicateAccumulator which is expensive
### Issue ticket number and link if any
Issure: [#2719](https://github.com/f3d-app/f3d/issues/2719)
### Checklist for finalizing the PR

- [X ] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

\ci fast
