### PR TITLE
Do not throw if cache path is empty

### DIFF
--- a/application/testing/CMakeLists.txt
+++ b/application/testing/CMakeLists.txt
@@ -1648,7 +1648,7 @@ set_tests_properties(f3d::TestNoFileFileNameTemplate PROPERTIES PASS_REGULAR_EXP
 set_tests_properties(f3d::TestNoFileFileNameTemplate PROPERTIES ENVIRONMENT "CTEST_F3D_NO_DATA_FORCE_RENDER=1")
 
 if(NOT WIN32)
-  f3d_test(NAME TestInvalidCache ENV "HOME=" REGEXP "Could not use default cache directory" NO_BASELINE)
+  f3d_test(NAME TestHDRINoCachePath ENV "HOME=" DATA dragon.vtu ARGS -f --hdri-file=${F3D_SOURCE_DIR}/testing/data/palermo_park_1k.hdr REGEXP "Cannot cache .* as no cache path has been set." NO_BASELINE LONG_TIMEOUT)
 
   add_test(NAME f3d::TestHOMEOutput COMMAND $<TARGET_FILE:f3d> ${F3D_SOURCE_DIR}/testing/data/suzanne.stl --output=~/Testing/Temporary/TestHOMEOutput.png --resolution=300,300 --no-config)
   set_tests_properties(f3d::TestHOMEOutput PROPERTIES ENVIRONMENT "HOME=${CMAKE_BINARY_DIR}")

--- a/library/src/engine.cxx
+++ b/library/src/engine.cxx
@@ -84,19 +84,17 @@ engine::engine(
     }
   }
 #endif
-  if (cachePath.empty())
-  {
-    delete Internals;
-    throw engine::cache_exception(
-      "Could not setup cache, please set the appropriate environment variable");
-  }
-  cachePath /= "f3d";
 
   this->Internals->Options = std::make_unique<options>();
 
   this->Internals->Window =
     std::make_unique<detail::window_impl>(*this->Internals->Options, windowType, offscreen, loader);
-  this->Internals->Window->SetCachePath(cachePath);
+
+  if (!cachePath.empty())
+  {
+    cachePath /= "f3d";
+    this->Internals->Window->SetCachePath(cachePath);
+  }
 
   this->Internals->Scene =
     std::make_unique<detail::scene_impl>(*this->Internals->Options, *this->Internals->Window);

--- a/library/testing/TestSDKEngineExceptions.cxx
+++ b/library/testing/TestSDKEngineExceptions.cxx
@@ -72,12 +72,5 @@ int TestSDKEngineExceptions([[maybe_unused]] int argc, [[maybe_unused]] char* ar
   test.expect<f3d::engine::plugin_exception>("load plugin with invalid long name",
     [&]() { f3d::engine::loadPlugin("/" + std::string(257, 'x') + "/file.ext"); });
 
-#if defined(__linux__) || defined(__FreeBSD__)
-  // Test error handling without "HOME" set
-  unsetenv("HOME");
-  test.expect<f3d::engine::cache_exception>(
-    "Create engine without HOME set", [&]() { std::ignore = f3d::engine::createNone(); });
-#endif
-
   return test.result();
 }


### PR DESCRIPTION
### Describe your changes

On Android, caches are local to app, so it's the app responsibility to set the cache path using `f3d::engine::setCachePath` right after engine initialization.  
Do not throw if the cache path cannot be retrieved using env vars.

Supersedes #2024 

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
