### PR TITLE
DRAFT PR: adding interpolation to QuakeMDL animations with vtkInterpolateDataSe…

### DIFF
--- a/plugins/native/module/vtkF3DQuakeMDLImporter.cxx
+++ b/plugins/native/module/vtkF3DQuakeMDLImporter.cxx
@@ -15,6 +15,7 @@
 #include <vtkResourceStream.h>
 
 #include <vtkInterpolateDataSetAttributes.h>
+#include <vtkMathUtilities.h>
 
 #include <cstdint>
 #include <cstring>
@@ -757,25 +758,19 @@ bool vtkF3DQuakeMDLImporter::UpdateAtTimeValue(double timeValue)
 
     // Calculate interpolation factor (alpha)
     double alpha = 0.0;
-    if (frameIndex0 != frameIndex1 && (t1 - t0) > 1e-9)
+    if (frameIndex0 != frameIndex1)
     {
-      alpha = (clampedTime - t0) / (t1 - t0);
+      alpha = vtkMathUtilities::SafeDivision(clampedTime - t0, t1 - t0);
       alpha = std::max(0.0, std::min(1.0, alpha));
     }
 
     if (isMeshAnimation)
     {
-      if (frameIndex0 == frameIndex1 || alpha < 1e-9)
+      if (frameIndex0 == frameIndex1)
       {
         // No interpolation needed: use frame0
         this->Internals->Mapper->SetInputData(
           this->Internals->AnimationFrames[animIndex][frameIndex0]);
-      }
-      else if (alpha > 1.0 - 1e-9)
-      {
-        // Alpha is effectively 1.0: use frame1
-        this->Internals->Mapper->SetInputData(
-          this->Internals->AnimationFrames[animIndex][frameIndex1]);
       }
       else
       {


### PR DESCRIPTION
…tAttributes

Issue: #2138

### Describe your changes
- added interpolation to mesh animations in QuakeMDL 
- interpolation **NOT** added to **Texture animations**
- used vtkInterpolateDataSetAttributes for interpolation as suggested and took care of RAII
- added new import: `#include <vtkInterpolateDataSetAttributes.h>`
- added new vtkInternals struct member: `vtkSmartPointer<vtkInterpolateDataSetAttributes> Interpolator`

DRAFT PR for reviewing code not to be merged!
