### PR TITLE
fix separator in reader list table

### DIFF
--- a/application/F3DOptionsTools.cxx
+++ b/application/F3DOptionsTools.cxx
@@ -348,8 +348,9 @@ void PrintReadersList()
   plugColSize += colGap;
   streamColSize += colGap;
 
-  std::string separator =
-    std::string(nameColSize + extsColSize + descColSize + mimeColSize + plugColSize - colGap, '-');
+  std::string separator = std::string(
+    nameColSize + extsColSize + descColSize + mimeColSize + plugColSize + streamColSize - colGap,
+    '-');
 
   // Print the rows split in 3 columns
   std::stringstream headerLine;


### PR DESCRIPTION
### Describe your changes

Fix minor table formatting issue where separator length wasn't accounting for recently added column

before:
```
Name          Plugin     Description                                Supports Stream    Exts     Mime-types           
--------------------------------------------------------------------------------------------------
Alembic       alembic    Alembic                                    YES                abc      application/vnd.abc  
3DS           native     Autodesk 3D Studio                         YES                3ds      application/vnd.3ds  
CityGML       native     CityGML                                    YES                gml      application/gml+xml
```
after:
```
Name          Plugin     Description                                Supports Stream    Exts     Mime-types           
---------------------------------------------------------------------------------------------------------------------
Alembic       alembic    Alembic                                    YES                abc      application/vnd.abc  
3DS           native     Autodesk 3D Studio                         YES                3ds      application/vnd.3ds  
CityGML       native     CityGML                                    YES                gml      application/gml+xml  
```

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
