### PR TITLE
Fix addBuffer wasm API

### DIFF
--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -159,8 +159,8 @@ EMSCRIPTEN_BINDINGS(f3d)
       "addBuffer",
       +[](f3d::scene& scene, emscripten::val jsbuf) -> f3d::scene&
       {
-        std::vector<std::byte> data = emscripten::vecFromJSArray<std::byte>(jsbuf);
-        return scene.add(data.data(), data.size());
+        std::vector<unsigned char> data = emscripten::vecFromJSArray<unsigned char>(jsbuf);
+        return scene.add(reinterpret_cast<std::byte*>(data.data()), data.size());
       },
       emscripten::return_value_policy::reference())
     .function("clear", &f3d::scene::clear, emscripten::return_value_policy::reference())


### PR DESCRIPTION
### Describe your changes

`std::byte` is not known by emscripten so we have to get `unsigned char` and cast.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
