### PR TITLE
TestSDKTriggerInteractions: use offscreen

### DIFF
--- a/library/testing/TestSDKTriggerInteractions.cxx
+++ b/library/testing/TestSDKTriggerInteractions.cxx
@@ -18,7 +18,7 @@ struct TestTriggerHelper
   template<typename Func>
   void operator()(Func&& func) const
   {
-    f3d::engine engine = f3d::engine::create();
+    f3d::engine engine = f3d::engine::create(true);
     engine.getWindow().setSize(300, 300);
     engine.getScene().add(this->DataPath);
 


### PR DESCRIPTION
### Describe your changes

TestSDKTriggerInteractions fails regularly on egl/osmesa build.
This test actually use whatever context VTK provides, but since we dont run Xvfb.

It seems to fails in a regular fashion, this may be indicative of a small buf in the recent onscreen egl stack in VTK.

Using offscreen to alleviate the issue in F3D.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
