### PR TITLE
Slight fix to grammar and capitalization in README and CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ F3D uses [GitLab Flow](https://about.gitlab.com/topics/version-control/what-is-g
 - If you are a discord user, then you are most welcome to join the [F3D discord](https://discord.f3d.app)
 - When discussing a specific issue or pull request, create a dedicated thread in the "Contribute" channel
 - As a first message, post a link to the issue, a moderator will pin it to the thread
-- Discussing issue, design and investigation on discord is usually more efficient on discord than on github, but always try to write down the discussion conclusions on github
+- Discussing issues, design and investigation on discord is usually more efficient on discord than on github, but always try to write down the discussion conclusions on github
 
 ## Continuous Integration
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ but there is no plan to:
 
 # Contributing
 
-F3D as a community-driven, inclusive and beginner-friendly project. We love to see how the project is growing thanks to the contributions from the community. We would love to see your face in the list below! If you want to contribute to F3D, you are very welcome to! Take a look at our [contribution documentation](CONTRIBUTING.md), [governance documentation](doc/dev/10-GOVERNANCE.md) and [code of conduct](CODE_OF_CONDUCT.md).
+F3D is a community-driven, inclusive and beginner-friendly project. We love to see how the project is growing thanks to the contributions from the community. We would love to see your face in the list below! If you want to contribute to F3D, you are very welcome to! Take a look at our [contribution documentation](CONTRIBUTING.md), [governance documentation](doc/dev/10-GOVERNANCE.md) and [code of conduct](CODE_OF_CONDUCT.md).
 
 <a href="https://github.com/f3d-app/f3d/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=f3d-app/f3d" />


### PR DESCRIPTION
This PR fixes minor grammar/typo issues in the documentation:

- README.md: "F3D as a community-driven..." -> "F3D is a community-driven..."
- CONTRIBUTING.md: "Discussing issue" -> "Discussing issues"

No functional changes.