### PR TITLE
Fix HDRI cache and log forwarder on Android

### DIFF
--- a/java/F3DLogBindings.cxx
+++ b/java/F3DLogBindings.cxx
@@ -15,11 +15,22 @@ static void cpp_log_forwarder(f3d::log::VerboseLevel level, const std::string& m
   }
 
   JNIEnv* env;
+  bool needsDetach = false;
+  int envStatus = g_jvm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+
+  if (envStatus == JNI_EDETACHED)
+  {
 #ifdef __ANDROID__
-  if (g_jvm->AttachCurrentThread(&env, nullptr) != 0)
+    if (g_jvm->AttachCurrentThread(&env, nullptr) != 0)
 #else
-  if (g_jvm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr) != 0)
+    if (g_jvm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr) != 0)
 #endif
+    {
+      return;
+    }
+    needsDetach = true;
+  }
+  else if (envStatus != JNI_OK)
   {
     return;
   }
@@ -40,7 +51,10 @@ static void cpp_log_forwarder(f3d::log::VerboseLevel level, const std::string& m
   env->DeleteLocalRef(jLevel);
   env->DeleteLocalRef(jMessage);
 
-  g_jvm->DetachCurrentThread();
+  if (needsDetach)
+  {
+    g_jvm->DetachCurrentThread();
+  }
 }
 
 extern "C"

--- a/vtkext/private/module/vtkF3DCachedSpecularTexture.cxx
+++ b/vtkext/private/module/vtkF3DCachedSpecularTexture.cxx
@@ -43,8 +43,13 @@ void vtkF3DCachedSpecularTexture::Load(vtkRenderer* ren)
 
     this->TextureObject->SetContext(renWin);
     this->TextureObject->SetFormat(GL_RGB);
+#ifdef GL_ES_VERSION_3_0
+    this->TextureObject->SetInternalFormat(GL_RGB8);
+    this->TextureObject->SetDataType(GL_UNSIGNED_BYTE);
+#else
     this->TextureObject->SetInternalFormat(GL_RGB32F);
     this->TextureObject->SetDataType(GL_FLOAT);
+#endif
     this->TextureObject->SetWrapS(vtkTextureObject::ClampToEdge);
     this->TextureObject->SetWrapT(vtkTextureObject::ClampToEdge);
     this->TextureObject->SetWrapR(vtkTextureObject::ClampToEdge);

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -41,8 +41,10 @@
 #include <vtkObjectFactory.h>
 #include <vtkOpaquePass.h>
 #include <vtkOpenGLFXAAPass.h>
+#include <vtkOpenGLFramebufferObject.h>
 #include <vtkOpenGLRenderWindow.h>
 #include <vtkOpenGLRenderer.h>
+#include <vtkOpenGLState.h>
 #include <vtkOpenGLTexture.h>
 #include <vtkOrientationMarkerWidget.h>
 #include <vtkPBRLUTTexture.h>
@@ -158,24 +160,33 @@ std::string ComputeFileHash(const std::string& filepath)
 //----------------------------------------------------------------------------
 // Download texture from the GPU to a vtkImageData
 vtkSmartPointer<vtkImageData> SaveTextureToImage(
-  vtkTextureObject* tex, unsigned int target, unsigned int level, unsigned int size, int type)
+  vtkTextureObject* tex, unsigned int target, unsigned int level, unsigned int size)
 {
-  unsigned int dims[2] = { size, size };
-  vtkIdType incr[2] = { 0, 0 };
-
   unsigned int nbFaces = tex->GetTarget() == GL_TEXTURE_CUBE_MAP ? 6 : 1;
+  int type = tex->GetVTKDataType();
 
   vtkNew<vtkImageData> img;
   img->SetDimensions(size, size, nbFaces);
   img->AllocateScalars(type, tex->GetComponents());
 
+  tex->GetContext()->GetState()->PushFramebufferBindings();
+
+  vtkNew<vtkOpenGLFramebufferObject> fbo;
+  fbo->SetContext(tex->GetContext());
+  fbo->Bind();
+
   for (unsigned int i = 0; i < nbFaces; i++)
   {
-    vtkPixelBufferObject* pbo = tex->Download(target + i, level);
+    fbo->RemoveColorAttachment(0);
+    fbo->AddColorAttachment(0, tex, 0, target + i, level);
+    fbo->ActivateReadBuffer(0);
+    fbo->StartNonOrtho(size, size);
 
-    pbo->Download2D(type, img->GetScalarPointer(0, 0, i), dims, tex->GetComponents(), incr);
-    pbo->Delete();
+    glReadPixels(0, 0, size, size, tex->GetFormat(type, tex->GetComponents(), false),
+      tex->GetDataType(type), img->GetScalarPointer(0, 0, i));
   }
+
+  tex->GetContext()->GetState()->PopFramebufferBindings();
 
   return img;
 }
@@ -1394,8 +1405,8 @@ void vtkF3DRenderer::ConfigureHDRILUT()
 
       if (!this->CachePath.empty())
       {
-        vtkSmartPointer<vtkImageData> img = ::SaveTextureToImage(
-          lut->GetTextureObject(), GL_TEXTURE_2D, 0, lut->GetLUTSize(), VTK_UNSIGNED_SHORT);
+        vtkSmartPointer<vtkImageData> img =
+          ::SaveTextureToImage(lut->GetTextureObject(), GL_TEXTURE_2D, 0, lut->GetLUTSize());
         assert(img);
 
         vtkNew<vtkXMLImageDataWriter> writer;
@@ -1501,7 +1512,7 @@ void vtkF3DRenderer::ConfigureHDRISpecular()
         for (unsigned int i = 0; i < nbLevels; i++)
         {
           vtkSmartPointer<vtkImageData> img = ::SaveTextureToImage(
-            spec->GetTextureObject(), GL_TEXTURE_CUBE_MAP_POSITIVE_X, i, size >> i, VTK_FLOAT);
+            spec->GetTextureObject(), GL_TEXTURE_CUBE_MAP_POSITIVE_X, i, size >> i);
           assert(img);
           mb->SetBlock(i, img);
         }


### PR DESCRIPTION
### Describe your changes

Use a OpenGL ES compatible method to cache the HDRI.
Also fix a crash when using the log forwarder on Android.

### Issue ticket number and link if any

Fix https://github.com/f3d-app/f3d-android/issues/31

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
