### PR TITLE
interactor: add missing set_camera locations (back, bottom, left)

### DIFF
--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -480,7 +480,9 @@ f3d_test(NAME TestCommandScriptJumpToStartKeyFrame SCRIPT DATA soldier_animation
 f3d_test(NAME TestCommandScriptJumpToPositiveOutsideKeyFrame SCRIPT DATA soldier_animations.mdl ARGS --animation-indices=2 --animation-progress)
 f3d_test(NAME TestCommandScriptJumpToNegativeOutsideKeyFrame SCRIPT DATA soldier_animations.mdl ARGS --animation-indices=2 --animation-progress)
 f3d_test(NAME TestCommandScriptJumpToKeyFrameNoAnimation SCRIPT DATA cow.vtp)
-f3d_test(NAME TestCommandScriptSetCamera SCRIPT DATA dragon.vtu) # set_camera top;toggle ui.scalar_bar;print_scene_info;increase_light_intensity
+f3d_test(NAME TestCommandScriptSetCameraBack SCRIPT DATA dragon.vtu) # set_camera back
+f3d_test(NAME TestCommandScriptSetCameraBottom SCRIPT DATA dragon.vtu) # set_camera bottom
+f3d_test(NAME TestCommandScriptSetCameraLeft SCRIPT DATA dragon.vtu) # set_camera left
 
 ## Tests to increase coverage
 # Output option test

--- a/testing/baselines/TestCommandScriptSetCamera.png
+++ b/testing/baselines/TestCommandScriptSetCamera.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebe9ca328d721b87d68aacf03afffb32efc866aa91d5e99927fd901f2a72df89
-size 23430

--- a/testing/baselines/TestCommandScriptSetCameraBack.png
+++ b/testing/baselines/TestCommandScriptSetCameraBack.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ebdffbe9f6592f3c9744fef4f72820c30c549b51e060d9779d8e03d0a691346
+size 23531

--- a/testing/baselines/TestCommandScriptSetCameraBottom.png
+++ b/testing/baselines/TestCommandScriptSetCameraBottom.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:105669c06e4d76e8aee681bdcf7c89af6aef738d5b63ac50a3e2fe3ef98c5437
+size 24271

--- a/testing/baselines/TestCommandScriptSetCameraLeft.png
+++ b/testing/baselines/TestCommandScriptSetCameraLeft.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:780ae72884671e82dda0d3bec38ad7cb632a6cc890774d77f5a822cfe9ce969c
+size 25214

--- a/testing/scripts/TestCommandScriptSetCamera.txt
+++ b/testing/scripts/TestCommandScriptSetCamera.txt
@@ -1,4 +1,0 @@
-set_camera top
-toggle ui.scalar_bar
-print_scene_info
-increase_light_intensity

--- a/testing/scripts/TestCommandScriptSetCameraBack.txt
+++ b/testing/scripts/TestCommandScriptSetCameraBack.txt
@@ -1,0 +1,1 @@
+set_camera back

--- a/testing/scripts/TestCommandScriptSetCameraBottom.txt
+++ b/testing/scripts/TestCommandScriptSetCameraBottom.txt
@@ -1,0 +1,1 @@
+set_camera bottom

--- a/testing/scripts/TestCommandScriptSetCameraLeft.txt
+++ b/testing/scripts/TestCommandScriptSetCameraLeft.txt
@@ -1,0 +1,1 @@
+set_camera left


### PR DESCRIPTION
### Describe your changes
Add VT_BACK, VT_BOTTOM, and VT_LEFT view types to the SetViewOrbit method along with their corresponding axis/up vectors. Wire them up in the set_camera command handler and update the command documentation and completion list to include the new locations.

### Issue ticket number and link if any
https://github.com/f3d-app/f3d/issues/2964

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
