### PR TITLE
Add support for scene hierarchy QuakeMDL importer

### DIFF
--- a/application/testing/tests.native.cmake
+++ b/application/testing/tests.native.cmake
@@ -68,7 +68,6 @@ if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20240707)
   f3d_test(NAME TestQuakeMDLActorCollection DATA zombie.mdl ARGS --scalar-coloring)
 endif()
 
-# Scene hierarchy test for QuakeMDL importer
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.6.20260306)
   f3d_test(NAME TestQuakeMDLSceneHierarchy DATA zombie.mdl ARGS --scene-hierarchy UI)
 endif()

--- a/plugins/native/module/vtkF3DQuakeMDLImporter.cxx
+++ b/plugins/native/module/vtkF3DQuakeMDLImporter.cxx
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkF3DQuakeMDLImporter);
@@ -694,10 +695,6 @@ int vtkF3DQuakeMDLImporter::ImportBegin()
 //----------------------------------------------------------------------------
 void vtkF3DQuakeMDLImporter::ImportActors(vtkRenderer* renderer)
 {
-  // Initialize the scene hierarchy
-  this->SceneHierarchy = vtkSmartPointer<vtkDataAssembly>::New();
-  this->SceneHierarchy->SetAttribute(vtkDataAssembly::GetRootNode(), "label", "root");
-
   vtkNew<vtkActor> actor;
   vtkNew<vtkPolyDataMapper> mapper;
   mapper->SetInputData(this->Internals->AnimationFrames[0][0]);
@@ -712,9 +709,13 @@ void vtkF3DQuakeMDLImporter::ImportActors(vtkRenderer* renderer)
   this->ActorCollection->AddItem(actor);
 #endif
 
-  // Create hierarchy node for the model actor
-  int nodeId = this->SceneHierarchy->AddNode("model", vtkDataAssembly::GetRootNode());
-  this->SceneHierarchy->SetAttribute(nodeId, "label", "model");
+  std::filesystem::path p(this->GetFileName());
+  std::string modelName = p.stem().string();
+
+  this->SceneHierarchy = vtkSmartPointer<vtkDataAssembly>::New();
+  this->SceneHierarchy->SetAttribute(vtkDataAssembly::GetRootNode(), "label", "root");
+  int nodeId = this->SceneHierarchy->AddNode(modelName.c_str(), vtkDataAssembly::GetRootNode());
+  this->SceneHierarchy->SetAttribute(nodeId, "label", modelName.c_str());
   this->SceneHierarchy->SetAttribute(nodeId, "flat_actor_id", 0);
 }
 

--- a/testing/baselines/TestQuakeMDLSceneHierarchy.png
+++ b/testing/baselines/TestQuakeMDLSceneHierarchy.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b52527b7b8118b1c5bb6c63a02f0275f3089ea131079f37a0d656799f51de4eb
-size 26345
+oid sha256:30dd51785a41601a1cf95ff607b6e026f6fd913b108f36faa8a8b3de59dabfe4
+size 25803


### PR DESCRIPTION
### Describe your changes
For Quake MDL specifically, the structure is inherently flat — each file represents a single renderable object with no internal hierarchy. As a result, the node tree will always consist of a single node.
At the moment, this node is assigned the default name "model" since the MDL format does not provide explicit node or object names.
- Add support for scene hierarchy QuakeMDL importer.
- Enhanced QuakeMDL test coverage: Added unit test verification for scene hierarchy nodes and actor attributes

### Issue ticket number and link if any

closes #2949 

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
