### PR TITLE
FreeBSD: prefer not using /proc by default

### DIFF
--- a/application/F3DSystemTools.cxx
+++ b/application/F3DSystemTools.cxx
@@ -15,6 +15,10 @@
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
+#ifdef __FreeBSD__
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#endif
 
 namespace fs = std::filesystem;
 
@@ -45,6 +49,14 @@ fs::path GetApplicationPath()
   try
   {
 #if defined(__FreeBSD__)
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+    char buf[PATH_MAX];
+    std::size_t len = sizeof(buf);
+    if (sysctl(mib, 4, buf, &len, nullptr, 0) == 0)
+    {
+      return fs::path(buf);
+    }
+    // Fallback to procfs if sysctl fails
     return fs::canonical("/proc/curproc/file");
 #else
     return fs::canonical("/proc/self/exe");


### PR DESCRIPTION
On FreeBSD procfs has been deprecated for a while, the recommanded way to get the information f3d is looking for is via sysctl(3).

### Describe your changes

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
