### PR TITLE
doc(integration): Don't use sudo for user files

### DIFF
--- a/doc/user/11-DESKTOP_INTEGRATION.md
+++ b/doc/user/11-DESKTOP_INTEGRATION.md
@@ -19,8 +19,8 @@ In other cases, the binary release archive can be used like this:
 ```bash
 export PATH=$PATH:~/.local/bin
 tar -xzvf f3d-1.3.0-Linux.tar.gz -C ~/.local/
-sudo update-mime-database ~/.local/share/mime/
-sudo update-desktop-database ~/.local/share/applications
+update-mime-database ~/.local/share/mime/
+update-desktop-database ~/.local/share/applications
 ```
 
 ### Rendering


### PR DESCRIPTION
### Describe your changes

Remove `sudo` from two commands in the Desktop Integration instructions which are generating new databases in the user's personal account space (`$HOME/.local/share/mime/` and `$HOME/.local/share/applications/`.)

#### Details

The Desktop Integration instructions for enabling thumbnails have a pretty serious error, instructing the user to run `update-mime-database` and `update-desktop-database` with `sudo` when updating their _user_ stores.

This will result in root-owned files being written to `$HOME/.local/share/`, which will prevent the user from being able to update them later as they won't have write access to those files. 

`sudo` shouldn't be used when writing to user datastores.

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
