### PR TITLE
fix: recompute axes grid bounds when switching files

### DIFF
--- a/application/testing/tests.interaction.cmake
+++ b/application/testing/tests.interaction.cmake
@@ -95,7 +95,7 @@ f3d_test(NAME TestInteractionResetCamera DATA dragon.vtu INTERACTION LONG_TIMEOU
 f3d_test(NAME TestInteractionResetCameraWithCameraIndex DATA CameraAnimated.glb ARGS --camera-index=0 INTERACTION) #MouseMovements;Return;
 f3d_test(NAME TestInteractionCameraUpdate DATA dragon.vtu INTERACTION) #MouseWheel;MouseWheel;MouseWheel;S
 f3d_test(NAME TestInteractionFocalPointPickingDefault DATA dragon.vtu INTERACTION LONG_TIMEOUT)
-f3d_test(NAME TestInteractionAxesGridSwitchFile DATA cow.vtp ARGS --no-config --axes-grid INTERACTION) #Right
+f3d_test(NAME TestInteractionAxesGridSwitchFile DATA cow.vtp multi/dragon.vtu ARGS --no-config --axes-grid INTERACTION) #Right
 f3d_test(NAME TestInteractionFocalPointPickingShift DATA dragon.vtu INTERACTION LONG_TIMEOUT)
 f3d_test(NAME TestInteractionFocalPointPickingPoints DATA pointsCloud.vtp INTERACTION THRESHOLD 0.05) # Threshold needed because sometime a point does not appear
 

--- a/application/testing/tests.interaction.cmake
+++ b/application/testing/tests.interaction.cmake
@@ -95,7 +95,7 @@ f3d_test(NAME TestInteractionResetCamera DATA dragon.vtu INTERACTION LONG_TIMEOU
 f3d_test(NAME TestInteractionResetCameraWithCameraIndex DATA CameraAnimated.glb ARGS --camera-index=0 INTERACTION) #MouseMovements;Return;
 f3d_test(NAME TestInteractionCameraUpdate DATA dragon.vtu INTERACTION) #MouseWheel;MouseWheel;MouseWheel;S
 f3d_test(NAME TestInteractionFocalPointPickingDefault DATA dragon.vtu INTERACTION LONG_TIMEOUT)
-f3d_test(NAME TestInteractionAxesGridSwitchFile DATA cow.vtp multi/dragon.vtu ARGS --no-config --axes-grid INTERACTION) #Right
+f3d_test(NAME TestInteractionAxesGridSwitchFile DATA cow.vtp multi/dragon.vtu ARGS --axes-grid INTERACTION) #Right
 f3d_test(NAME TestInteractionFocalPointPickingShift DATA dragon.vtu INTERACTION LONG_TIMEOUT)
 f3d_test(NAME TestInteractionFocalPointPickingPoints DATA pointsCloud.vtp INTERACTION THRESHOLD 0.05) # Threshold needed because sometime a point does not appear
 

--- a/application/testing/tests.interaction.cmake
+++ b/application/testing/tests.interaction.cmake
@@ -95,6 +95,7 @@ f3d_test(NAME TestInteractionResetCamera DATA dragon.vtu INTERACTION LONG_TIMEOU
 f3d_test(NAME TestInteractionResetCameraWithCameraIndex DATA CameraAnimated.glb ARGS --camera-index=0 INTERACTION) #MouseMovements;Return;
 f3d_test(NAME TestInteractionCameraUpdate DATA dragon.vtu INTERACTION) #MouseWheel;MouseWheel;MouseWheel;S
 f3d_test(NAME TestInteractionFocalPointPickingDefault DATA dragon.vtu INTERACTION LONG_TIMEOUT)
+f3d_test(NAME TestInteractionAxesGridSwitchFile DATA cow.vtp ARGS --no-config --axes-grid INTERACTION) #Right
 f3d_test(NAME TestInteractionFocalPointPickingShift DATA dragon.vtu INTERACTION LONG_TIMEOUT)
 f3d_test(NAME TestInteractionFocalPointPickingPoints DATA pointsCloud.vtp INTERACTION THRESHOLD 0.05) # Threshold needed because sometime a point does not appear
 

--- a/testing/baselines/TestInteractionAxesGridSwitchFile.png
+++ b/testing/baselines/TestInteractionAxesGridSwitchFile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17ac2913c3cffc1bf2f2a8c8b9f1e81b023508abb8e3fc9c4ed61309203a5bbb
+size 28100

--- a/testing/baselines/TestInteractionAxesGridSwitchFile.png
+++ b/testing/baselines/TestInteractionAxesGridSwitchFile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cacf9fb6dd925a4a3e56f2b8aa0e8c38f85e289864bf25b86a3b14218bd1340
+size 22926

--- a/testing/baselines/TestInteractionAxesGridSwitchFile.png
+++ b/testing/baselines/TestInteractionAxesGridSwitchFile.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:17ac2913c3cffc1bf2f2a8c8b9f1e81b023508abb8e3fc9c4ed61309203a5bbb
-size 28100

--- a/testing/baselines/TestInteractionAxesGridSwitchFile.png
+++ b/testing/baselines/TestInteractionAxesGridSwitchFile.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3cacf9fb6dd925a4a3e56f2b8aa0e8c38f85e289864bf25b86a3b14218bd1340
-size 22926

--- a/testing/recordings/TestInteractionAxesGridSwitchFile.log
+++ b/testing/recordings/TestInteractionAxesGridSwitchFile.log
@@ -1,0 +1,7 @@
+# StreamVersion 1.1
+ExposeEvent 0 599 0 0 0 0
+RenderEvent 0 599 0 0 0 0
+KeyPressEvent 300 300 0 0 1 Right
+CharEvent 300 300 0 0 1 Right
+KeyReleaseEvent 300 300 0 0 1 Right
+RenderEvent 300 300 0 0 1 Right

--- a/testing/recordings/TestInteractionAxesGridSwitchFile.log
+++ b/testing/recordings/TestInteractionAxesGridSwitchFile.log
@@ -1,7 +1,6 @@
 # StreamVersion 1.1
 ExposeEvent 0 599 0 0 0 0
 RenderEvent 0 599 0 0 0 0
-KeyPressEvent 300 300 0 0 1 Right
-CharEvent 300 300 0 0 1 Right
-KeyReleaseEvent 300 300 0 0 1 Right
-RenderEvent 300 300 0 0 1 Right
+KeyPressEvent 354 650 0 0 1 Right
+CharEvent 354 650 0 0 1 Right
+KeyReleaseEvent 354 650 0 0 1 Right

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -61,6 +61,7 @@
 #include <vtkShaderProperty.h>
 #include <vtkSkybox.h>
 #include <vtkSphericalHarmonics.h>
+#include <vtkStreamingDemandDrivenPipeline.h>
 #include <vtkTable.h>
 #include <vtkTextActor.h>
 #include <vtkTextProperty.h>
@@ -314,6 +315,10 @@ void vtkF3DRenderer::Initialize()
 #endif
 
   this->GridConfigured = false;
+  this->GridAxesConfigured = false;
+  this->UpDirectionConfigured = false;
+  this->AxesActorConfigured = false;
+  this->PointSpritesConfigured = false;
   this->CheatSheetConfigured = false;
   this->ActorsPropertiesConfigured = false;
   this->RenderPassesConfigured = false;
@@ -1076,11 +1081,29 @@ vtkBoundingBox vtkF3DRenderer::ComputeVisiblePropOrientedBounds(const vtkMatrix4
   {
     if (prop->GetVisibility() && prop->GetUseBounds())
     {
-      const double* bounds = prop->GetBounds();
-      if (bounds != nullptr && vtkMath::AreBoundsInitialized(bounds))
+      vtkProp3D* prop3d = vtkProp3D::SafeDownCast(prop);
+      if (prop3d)
       {
-        vtkProp3D* prop3d = vtkProp3D::SafeDownCast(prop);
-        if (prop3d)
+        if (vtkActor* actor = vtkActor::SafeDownCast(prop3d))
+        {
+          if (vtkMapper* mapper = actor->GetMapper())
+          {
+            if (vtkAlgorithm* alg = mapper->GetInputAlgorithm())
+            {
+              alg->UpdateInformation();
+              if (vtkStreamingDemandDrivenPipeline* sddp =
+                    vtkStreamingDemandDrivenPipeline::SafeDownCast(alg->GetExecutive()))
+              {
+                sddp->SetUpdateExtentToWholeExtent(0);
+              }
+              alg->Update();
+            }
+            mapper->Update();
+          }
+        }
+
+        const double* bounds = prop3d->GetBounds();
+        if (bounds != nullptr && vtkMath::AreBoundsInitialized(bounds))
         {
           if (isAxisAligned)
           {
@@ -2096,6 +2119,16 @@ void vtkF3DRenderer::UpdateActors()
     this->GridConfigured = false;
     this->GridAxesConfigured = false;
     this->MetaDataConfigured = false;
+    this->PointSpritesConfigured = false;
+    this->ColoringConfigured = false;
+    this->ColoringMappersConfigured = false;
+    this->ColoringPointSpritesMappersConfigured = false;
+    this->VolumePropsAndMappersConfigured = false;
+    this->ColorTransferFunctionConfigured = false;
+    this->OpacityTransferFunctionConfigured = false;
+    this->ScalarBarActorConfigured = false;
+    this->NormalGlyphsConfigured = false;
+    this->TextActorsConfigured = false;
   }
   this->ImporterTimeStamp = importerMTime;
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2094,7 +2094,7 @@ void vtkF3DRenderer::UpdateActors()
   {
     this->ActorsPropertiesConfigured = false;
     this->GridConfigured = false;
-    this->GridAxesConfigured = false; // fix: recompute axes grid on file switch
+    this->GridAxesConfigured = false;
     this->MetaDataConfigured = false;
   }
   this->ImporterTimeStamp = importerMTime;

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -61,7 +61,6 @@
 #include <vtkShaderProperty.h>
 #include <vtkSkybox.h>
 #include <vtkSphericalHarmonics.h>
-#include <vtkStreamingDemandDrivenPipeline.h>
 #include <vtkTable.h>
 #include <vtkTextActor.h>
 #include <vtkTextProperty.h>
@@ -1090,13 +1089,7 @@ vtkBoundingBox vtkF3DRenderer::ComputeVisiblePropOrientedBounds(const vtkMatrix4
           {
             if (vtkAlgorithm* alg = mapper->GetInputAlgorithm())
             {
-              alg->UpdateInformation();
-              if (vtkStreamingDemandDrivenPipeline* sddp =
-                    vtkStreamingDemandDrivenPipeline::SafeDownCast(alg->GetExecutive()))
-              {
-                sddp->SetUpdateExtentToWholeExtent(0);
-              }
-              alg->Update();
+              alg->UpdateWholeExtent();
             }
             mapper->Update();
           }

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -971,7 +971,27 @@ void vtkF3DRenderer::ConfigureGridAxesUsingCurrentActors()
 
     double orientation[3];
     vtkTransform::GetOrientation(orientation, upMatrixInv);
-    const vtkBoundingBox bbox = this->ComputeVisiblePropOrientedBounds(upMatrix);
+
+    const vtkBoundingBox& importerBbox = this->Importer->GetGeometryBoundingBox();
+    vtkBoundingBox bbox;
+    if (importerBbox.IsValid())
+    {
+      double bnds[6];
+      importerBbox.GetBounds(bnds);
+      const double corners[8][3] = {
+        { bnds[0], bnds[2], bnds[4] }, { bnds[1], bnds[2], bnds[4] },
+        { bnds[0], bnds[3], bnds[4] }, { bnds[1], bnds[3], bnds[4] },
+        { bnds[0], bnds[2], bnds[5] }, { bnds[1], bnds[2], bnds[5] },
+        { bnds[0], bnds[3], bnds[5] }, { bnds[1], bnds[3], bnds[5] }
+      };
+      for (int i = 0; i < 8; ++i)
+      {
+        double p[4] = { corners[i][0], corners[i][1], corners[i][2], 1.0 };
+        double q[4];
+        upMatrix->MultiplyPoint(p, q);
+        bbox.AddPoint(q[0], q[1], q[2]);
+      }
+    }
 
     if (!bbox.IsValid())
     {
@@ -1080,23 +1100,11 @@ vtkBoundingBox vtkF3DRenderer::ComputeVisiblePropOrientedBounds(const vtkMatrix4
   {
     if (prop->GetVisibility() && prop->GetUseBounds())
     {
-      vtkProp3D* prop3d = vtkProp3D::SafeDownCast(prop);
-      if (prop3d)
+      const double* bounds = prop->GetBounds();
+      if (bounds != nullptr && vtkMath::AreBoundsInitialized(bounds))
       {
-        if (vtkActor* actor = vtkActor::SafeDownCast(prop3d))
-        {
-          if (vtkMapper* mapper = actor->GetMapper())
-          {
-            if (vtkAlgorithm* alg = mapper->GetInputAlgorithm())
-            {
-              alg->UpdateWholeExtent();
-            }
-            mapper->Update();
-          }
-        }
-
-        const double* bounds = prop3d->GetBounds();
-        if (bounds != nullptr && vtkMath::AreBoundsInitialized(bounds))
+        vtkProp3D* prop3d = vtkProp3D::SafeDownCast(prop);
+        if (prop3d)
         {
           if (isAxisAligned)
           {

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2094,7 +2094,7 @@ void vtkF3DRenderer::UpdateActors()
   {
     this->ActorsPropertiesConfigured = false;
     this->GridConfigured = false;
-    this->GridAxesConfigured = false;   // fix: recompute axes grid on file switch
+    this->GridAxesConfigured = false; // fix: recompute axes grid on file switch
     this->MetaDataConfigured = false;
   }
   this->ImporterTimeStamp = importerMTime;

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2094,6 +2094,7 @@ void vtkF3DRenderer::UpdateActors()
   {
     this->ActorsPropertiesConfigured = false;
     this->GridConfigured = false;
+    this->GridAxesConfigured = false;   // fix: recompute axes grid on file switch
     this->MetaDataConfigured = false;
   }
   this->ImporterTimeStamp = importerMTime;


### PR DESCRIPTION
### Describe your changes

`GridAxesConfigured` was not being reset when the importer changed on file switch, so `ConfigureGridAxesUsingCurrentActors()` was never re-called with the new file's bounds. Added `this->GridAxesConfigured = false;` alongside the existing `this->GridConfigured = false;` in `UpdateActors()` in `vtkext/private/module/vtkF3DRenderer.cxx`.

### Issue ticket number and link if any

Fixes #2963

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [ ] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.