### PR TITLE
occt/webifc: Increase number of lines (256) to find expected header info in CanReadFile

### DIFF
--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -932,8 +932,8 @@ bool vtkF3DOCCTReader::CanReadFile(vtkResourceStream* stream, vtkF3DOCCTReader::
   {
     // Only "ISO-10303-21" supported schema is STEP, check for it
     // FILE_SCHEMA appears in the HEADER section, typically within the first few lines.
-    // 32 lines is a generous upper bound to account for optional header entries.
-    constexpr int maxLines = 32;
+    // 256 lines is a generous upper bound to account for optional header entries.
+    constexpr int maxLines = 256;
     for (int i = 0; i < maxLines && parser->ReadLine(line) == vtkParseResult::EndOfLine; ++i)
     {
       if (line.find("FILE_SCHEMA") != std::string::npos)

--- a/plugins/webifc/module/vtkF3DWebIFCReader.cxx
+++ b/plugins/webifc/module/vtkF3DWebIFCReader.cxx
@@ -87,8 +87,8 @@ bool vtkF3DWebIFCReader::CanReadFile(vtkResourceStream* stream)
   }
 
   // FILE_SCHEMA appears in the HEADER section, typically within the first few lines.
-  // 32 lines is a generous upper bound to account for optional header entries.
-  constexpr int maxLines = 32;
+  // 256 lines is a generous upper bound to account for optional header entries.
+  constexpr int maxLines = 256;
   for (int i = 0; i < maxLines && parser->ReadLine(line) == vtkParseResult::EndOfLine; ++i)
   {
     if (line.find("FILE_SCHEMA") != std::string::npos)


### PR DESCRIPTION
### Describe your changes

Technically a header could contain as many lines as possible but we need to stop somewhere, 32 is not enough. 256 may be. Not adding a test for this, as it would be a bit pointless to test.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
