### PR TITLE
point-sprites-type: fix deprecated option

### DIFF
--- a/application/F3DOptionsTools.cxx
+++ b/application/F3DOptionsTools.cxx
@@ -585,7 +585,7 @@ std::vector<std::pair<std::string, std::string>> F3DOptionsTools::ConvertToLibf3
   else if (key == "point-sprites-type")
   {
     f3d::log::warn("--point-sprites-type is deprecated");
-    libf3dOptions.emplace_back(std::make_pair("model.point_sprites.mode", value));
+    libf3dOptions.emplace_back(std::make_pair("model.point_sprites.type", value));
   }
 
   // handle deprecated interaction-trackball option


### PR DESCRIPTION
### Describe your changes

Fix an incorrect replacement of deprecated option `point-sprites-type` and make it fonctionnal.
Deprecated option are not tested, so no test are impacted.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
