### PR TITLE
Add module label to vkext tests

### DIFF
--- a/vtkext/private/module/Testing/CMakeLists.txt
+++ b/vtkext/private/module/Testing/CMakeLists.txt
@@ -39,6 +39,13 @@ vtk_add_test_cxx(vtkextPrivateTests tests
 vtk_test_cxx_executable(vtkextPrivateTests tests)
 set_target_properties(vtkextPrivateTests PROPERTIES CXX_STANDARD 20)
 
+foreach(test ${test_sources})
+  get_filename_component (TName ${test} NAME_WE)
+  set_tests_properties(f3d::vtkextPrivateCxx-${TName} PROPERTIES
+          LABELS "module"
+  )
+endforeach()
+
 if(UNIX)
   # On windows, the default window output message does not redirect to cout
   set_tests_properties(f3d::vtkextPrivateCxx-TestF3DLog PROPERTIES PASS_REGULAR_EXPRESSION "Test Info Test Warning Test Error\nTest Debug Test Info Test Warning Test Error\nTest Warning Test Error\nTest Error\nTest Info Coloring Test Warning Coloring Test Error Coloring\n")

--- a/vtkext/public/module/Testing/CMakeLists.txt
+++ b/vtkext/public/module/Testing/CMakeLists.txt
@@ -13,6 +13,13 @@ vtk_add_test_cxx(vtkextTests tests
   ${F3D_SOURCE_DIR}/testing/ ${CMAKE_BINARY_DIR}/Testing/Temporary/)
 vtk_test_cxx_executable(vtkextTests tests)
 
+foreach(test ${vtkextTests_list})
+  get_filename_component (TName ${test} NAME_WE)
+  set_tests_properties(f3d::vtkextCxx-${TName} PROPERTIES
+          LABELS "module"
+  )
+endforeach()
+
 if(NOT ANDROID AND NOT EMSCRIPTEN AND NOT F3D_SANITIZER STREQUAL "address")
   set_target_properties(vtkextTests PROPERTIES CXX_STANDARD 20)
 endif()


### PR DESCRIPTION
### Describe your changes
Add module label to the vkext* CMakeList files so you can run `ctest -L module`. Follow-up/extension of ISSUE-2925. I validated the correct tests run when executing just the module tests.

### Issue ticket number and link if any
https://github.com/f3d-app/f3d/issues/2925

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
