### PR TITLE
ISSUE-3009: Fixing depth scalar

### DIFF
--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -68,7 +68,7 @@ f3d_test(NAME TestAnimationInputChangeColoring DATA v_rock2.mdl ARGS --scalar-co
 
 # Depth
 f3d_test(NAME TestDisplayDepth DATA dragon.vtu ARGS --display-depth)
-f3d_test(NAME TestDisplayDepthColorMap DATA dragon.vtu ARGS --display-depth --scalar-coloring=True)
+f3d_test(NAME TestDisplayDepthColorMap DATA dragon.vtu ARGS --display-depth --scalar-coloring=True --coloring-scalar-bar=True)
 f3d_test(NAME TestDisplayDepthCustomColorMap DATA dragon.vtu ARGS --display-depth --scalar-coloring --colormap=0,red,1,blue)
 f3d_test(NAME TestDisplayDepthWithGrid DATA cow.vtp ARGS --display-depth -g)
 

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -590,7 +590,6 @@ void window_impl::UpdateDynamicOptions()
   renderer->SetAntiAliasingMode(aaMode);
   renderer->SetUseToneMappingPass(opt.render.effect.tone_mapping);
   renderer->SetDisplayDepth(opt.render.effect.display_depth);
-  renderer->SetDisplayDepthScalarColoring(opt.model.scivis.enable);
   renderer->SetBlendingMode(blendMode);
   renderer->SetBackfaceType(opt.render.backface_type);
   renderer->SetFinalShader(opt.render.effect.final_shader);

--- a/testing/baselines/TestDisplayDepthColorMap.png
+++ b/testing/baselines/TestDisplayDepthColorMap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6bde799734028d30388b6337c7b6ec5e4f3b8858afe813d7ce8573f9f64fd3ca
-size 9509
+oid sha256:369c80378763b2406d83d23d019ddd23ea949b4db12344cc55e5e99ee4667830
+size 9030

--- a/testing/baselines/TestDisplayDepthColorMap.png
+++ b/testing/baselines/TestDisplayDepthColorMap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96a19dfc3308c67bf7341d704ff8b2e789102825a4b4b6626177f369871c79d0
-size 8235
+oid sha256:6bde799734028d30388b6337c7b6ec5e4f3b8858afe813d7ce8573f9f64fd3ca
+size 9509

--- a/testing/baselines/TestDisplayDepthColorMap.png
+++ b/testing/baselines/TestDisplayDepthColorMap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:369c80378763b2406d83d23d019ddd23ea949b4db12344cc55e5e99ee4667830
-size 9030
+oid sha256:332b9f6c2c6aeb0d6adfdb43c24e7da802b4e614cb92c4bad80588a553046379
+size 9025

--- a/vtkext/private/module/Testing/TestF3DRendererWithColoring.cxx
+++ b/vtkext/private/module/Testing/TestF3DRendererWithColoring.cxx
@@ -1,3 +1,4 @@
+#include <vtkGLTFReader.h>
 #include <vtkNew.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
@@ -12,79 +13,131 @@
 
 int TestF3DRendererWithColoring(int argc, char* argv[])
 {
-  vtkNew<vtkF3DRenderer> renderer;
-  vtkNew<vtkF3DMetaImporter> importer;
-  vtkNew<vtkRenderWindow> window;
-
-  window->AddRenderer(renderer);
-  importer->SetRenderWindow(window);
-  renderer->SetImporter(importer);
-
-  // Check invalid bounding box code path
-  renderer->ShowGrid(true);
-  renderer->UpdateActors();
-
-  vtkNew<vtkXMLUnstructuredGridReader> readerVTU;
-  std::string filename = std::string(argv[1]) + "data/bluntfin_t.vtu";
-  readerVTU->SetFileName(filename.c_str());
-  vtkNew<vtkF3DGenericImporter> importerVTU;
-  importerVTU->SetInternalReader(readerVTU);
-
-  importer->AddImporter({ "foo", importerVTU });
-  importer->Update();
-
-  // Check invalid array code path
-  renderer->SetEnableColoring(true);
-  renderer->SetArrayNameForColoring("Invalid");
-  renderer->SetUseVolume(false);
-  renderer->UpdateActors();
-  renderer->CycleComponentForColoring();
-  renderer->SetUseVolume(true);
-  renderer->UpdateActors();
-
-  if (renderer->GetArrayNameForColoring() != "Invalid" || renderer->GetComponentForColoring() != -1)
+  // Test invalid data
   {
-    std::cerr << "Unexpected coloring information with invalid array\n";
-    return EXIT_FAILURE;
+    vtkNew<vtkF3DRenderer> renderer;
+    vtkNew<vtkF3DMetaImporter> importer;
+    vtkNew<vtkRenderWindow> window;
+
+    window->AddRenderer(renderer);
+    importer->SetRenderWindow(window);
+    renderer->SetImporter(importer);
+
+    // Check invalid bounding box code path
+    renderer->ShowGrid(true);
+    renderer->UpdateActors();
+
+    vtkNew<vtkXMLUnstructuredGridReader> readerVTU;
+    const std::string filename = std::format("{}data/bluntfin_t.vtu", argv[1]);
+    readerVTU->SetFileName(filename.c_str());
+    vtkNew<vtkF3DGenericImporter> importerVTU;
+    importerVTU->SetInternalReader(readerVTU);
+
+    importer->AddImporter({ "foo", importerVTU });
+    importer->Update();
+
+    // Check invalid array code path
+    renderer->SetEnableColoring(true);
+    renderer->SetArrayNameForColoring("Invalid");
+    renderer->SetUseVolume(false);
+    renderer->UpdateActors();
+    renderer->CycleComponentForColoring();
+    renderer->SetUseVolume(true);
+    renderer->UpdateActors();
+
+    if (renderer->GetArrayNameForColoring() != "Invalid" || renderer->GetComponentForColoring() != -1)
+    {
+      std::cerr << "Unexpected coloring information with invalid array\n";
+      return EXIT_FAILURE;
+    }
+
+    // Check invalid component code path
+    renderer->SetArrayNameForColoring("Momentum");
+    renderer->SetComponentForColoring(5);
+    renderer->UpdateActors();
+    renderer->SetUseVolume(true);
+    renderer->UpdateActors();
+
+    if (renderer->GetArrayNameForColoring() != "Momentum" || renderer->GetComponentForColoring() != 5)
+    {
+      std::cerr << "Unexpected coloring information with invalid component\n";
+      return EXIT_FAILURE;
+    }
+
+    renderer->CycleComponentForColoring();
+    if (renderer->GetArrayNameForColoring() != "Momentum" || renderer->GetComponentForColoring() != 1)
+    {
+      std::cerr << "Unexpected coloring information after cycling component\n";
+      return EXIT_FAILURE;
+    }
+
+    // Check invalid colormap code path
+    renderer->SetColormap({ 0, 0, 0 });
+    renderer->UpdateActors();
+
+    // Smoke test for deprecated HDRI collapse codepath
+    // F3D_DEPRECATED
+    renderer->SetHDRIFile("path/not/valid/../../to/file.ext");
+
+    // Check SetInteractionStyle without interactor (early return)
+    renderer->SetInteractionStyle("default");
+
+    // Check SetInteractionStyle with invalid style
+    vtkNew<vtkRenderWindowInteractor> interactor;
+    window->SetInteractor(interactor);
+    vtkNew<vtkF3DInteractorStyle> style;
+    interactor->SetInteractorStyle(style);
+    renderer->SetInteractionStyle("invalid");
   }
 
-  // Check invalid component code path
-  renderer->SetArrayNameForColoring("Momentum");
-  renderer->SetComponentForColoring(5);
-  renderer->UpdateActors();
-  renderer->SetUseVolume(true);
-  renderer->UpdateActors();
-
-  if (renderer->GetArrayNameForColoring() != "Momentum" || renderer->GetComponentForColoring() != 5)
+  // Test depth scalar coloring
   {
-    std::cerr << "Unexpected coloring information with invalid component\n";
-    return EXIT_FAILURE;
+    vtkNew<vtkRenderWindow> window;
+    vtkNew<vtkF3DRenderer> renderer;
+    vtkNew<vtkF3DMetaImporter> importer;
+
+    window->AddRenderer(renderer);
+    importer->SetRenderWindow(window);
+    renderer->SetImporter(importer);
+
+    vtkNew<vtkGLTFReader> gltfReader;
+    const std::string filename = std::format("{}data/WaterBottle.glb", argv[1]);
+    gltfReader->SetFileName(filename.c_str());
+    vtkNew<vtkF3DGenericImporter> gltfImporter;
+    gltfImporter->SetInternalReader(gltfReader);
+
+    importer->AddImporter({ "foo", gltfImporter });
+    importer->Update();
+
+    renderer->SetDisplayDepth(true);
+    renderer->SetEnableColoring(true);
+    renderer->SetArrayNameForColoring("NORMAL");
+    renderer->SetUseVolume(false);
+    renderer->ShowScalarBar(true);
+    renderer->UpdateActors();
+
+    F3DColoringInfoHandler& coloringHandler = importer->GetColoringInfoHandler();
+    auto coloringInfo = coloringHandler.GetCurrentColoringInfo();
+
+    if (!coloringInfo.has_value())
+    {
+      std::cerr << "Unexpected coloring information\n";
+      return EXIT_FAILURE;
+    }
+
+    if (coloringInfo.value().Name != "NORMAL")
+    {
+      std::cerr << "Unexpected coloring information name: " << coloringInfo.value().Name << "\n";
+      return EXIT_FAILURE;
+    }
+
+    // Component should not matter when display depth is set
+    if (renderer->ComponentToString(-1) != "Depth")
+    {
+      std::cerr << "Unexpected coloring component\n";
+      return EXIT_FAILURE;
+    }
   }
-
-  renderer->CycleComponentForColoring();
-  if (renderer->GetArrayNameForColoring() != "Momentum" || renderer->GetComponentForColoring() != 1)
-  {
-    std::cerr << "Unexpected coloring information after cycling component\n";
-    return EXIT_FAILURE;
-  }
-
-  // Check invalid colormap code path
-  renderer->SetColormap({ 0, 0, 0 });
-  renderer->UpdateActors();
-
-  // Smoke test for deprecated HDRI collapse codepath
-  // F3D_DEPRECATED
-  renderer->SetHDRIFile("path/not/valid/../../to/file.ext");
-
-  // Check SetInteractionStyle without interactor (early return)
-  renderer->SetInteractionStyle("default");
-
-  // Check SetInteractionStyle with invalid style
-  vtkNew<vtkRenderWindowInteractor> interactor;
-  window->SetInteractor(interactor);
-  vtkNew<vtkF3DInteractorStyle> style;
-  interactor->SetInteractorStyle(style);
-  renderer->SetInteractionStyle("invalid");
 
   return EXIT_SUCCESS;
 }

--- a/vtkext/private/module/Testing/TestF3DRendererWithColoring.cxx
+++ b/vtkext/private/module/Testing/TestF3DRendererWithColoring.cxx
@@ -1,4 +1,3 @@
-#include <vtkGLTFReader.h>
 #include <vtkNew.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
@@ -13,131 +12,79 @@
 
 int TestF3DRendererWithColoring(int argc, char* argv[])
 {
-  // Test invalid data
+  vtkNew<vtkF3DRenderer> renderer;
+  vtkNew<vtkF3DMetaImporter> importer;
+  vtkNew<vtkRenderWindow> window;
+
+  window->AddRenderer(renderer);
+  importer->SetRenderWindow(window);
+  renderer->SetImporter(importer);
+
+  // Check invalid bounding box code path
+  renderer->ShowGrid(true);
+  renderer->UpdateActors();
+
+  vtkNew<vtkXMLUnstructuredGridReader> readerVTU;
+  std::string filename = std::string(argv[1]) + "data/bluntfin_t.vtu";
+  readerVTU->SetFileName(filename.c_str());
+  vtkNew<vtkF3DGenericImporter> importerVTU;
+  importerVTU->SetInternalReader(readerVTU);
+
+  importer->AddImporter({ "foo", importerVTU });
+  importer->Update();
+
+  // Check invalid array code path
+  renderer->SetEnableColoring(true);
+  renderer->SetArrayNameForColoring("Invalid");
+  renderer->SetUseVolume(false);
+  renderer->UpdateActors();
+  renderer->CycleComponentForColoring();
+  renderer->SetUseVolume(true);
+  renderer->UpdateActors();
+
+  if (renderer->GetArrayNameForColoring() != "Invalid" || renderer->GetComponentForColoring() != -1)
   {
-    vtkNew<vtkF3DRenderer> renderer;
-    vtkNew<vtkF3DMetaImporter> importer;
-    vtkNew<vtkRenderWindow> window;
-
-    window->AddRenderer(renderer);
-    importer->SetRenderWindow(window);
-    renderer->SetImporter(importer);
-
-    // Check invalid bounding box code path
-    renderer->ShowGrid(true);
-    renderer->UpdateActors();
-
-    vtkNew<vtkXMLUnstructuredGridReader> readerVTU;
-    const std::string filename = std::format("{}data/bluntfin_t.vtu", argv[1]);
-    readerVTU->SetFileName(filename.c_str());
-    vtkNew<vtkF3DGenericImporter> importerVTU;
-    importerVTU->SetInternalReader(readerVTU);
-
-    importer->AddImporter({ "foo", importerVTU });
-    importer->Update();
-
-    // Check invalid array code path
-    renderer->SetEnableColoring(true);
-    renderer->SetArrayNameForColoring("Invalid");
-    renderer->SetUseVolume(false);
-    renderer->UpdateActors();
-    renderer->CycleComponentForColoring();
-    renderer->SetUseVolume(true);
-    renderer->UpdateActors();
-
-    if (renderer->GetArrayNameForColoring() != "Invalid" || renderer->GetComponentForColoring() != -1)
-    {
-      std::cerr << "Unexpected coloring information with invalid array\n";
-      return EXIT_FAILURE;
-    }
-
-    // Check invalid component code path
-    renderer->SetArrayNameForColoring("Momentum");
-    renderer->SetComponentForColoring(5);
-    renderer->UpdateActors();
-    renderer->SetUseVolume(true);
-    renderer->UpdateActors();
-
-    if (renderer->GetArrayNameForColoring() != "Momentum" || renderer->GetComponentForColoring() != 5)
-    {
-      std::cerr << "Unexpected coloring information with invalid component\n";
-      return EXIT_FAILURE;
-    }
-
-    renderer->CycleComponentForColoring();
-    if (renderer->GetArrayNameForColoring() != "Momentum" || renderer->GetComponentForColoring() != 1)
-    {
-      std::cerr << "Unexpected coloring information after cycling component\n";
-      return EXIT_FAILURE;
-    }
-
-    // Check invalid colormap code path
-    renderer->SetColormap({ 0, 0, 0 });
-    renderer->UpdateActors();
-
-    // Smoke test for deprecated HDRI collapse codepath
-    // F3D_DEPRECATED
-    renderer->SetHDRIFile("path/not/valid/../../to/file.ext");
-
-    // Check SetInteractionStyle without interactor (early return)
-    renderer->SetInteractionStyle("default");
-
-    // Check SetInteractionStyle with invalid style
-    vtkNew<vtkRenderWindowInteractor> interactor;
-    window->SetInteractor(interactor);
-    vtkNew<vtkF3DInteractorStyle> style;
-    interactor->SetInteractorStyle(style);
-    renderer->SetInteractionStyle("invalid");
+    std::cerr << "Unexpected coloring information with invalid array\n";
+    return EXIT_FAILURE;
   }
 
-  // Test depth scalar coloring
+  // Check invalid component code path
+  renderer->SetArrayNameForColoring("Momentum");
+  renderer->SetComponentForColoring(5);
+  renderer->UpdateActors();
+  renderer->SetUseVolume(true);
+  renderer->UpdateActors();
+
+  if (renderer->GetArrayNameForColoring() != "Momentum" || renderer->GetComponentForColoring() != 5)
   {
-    vtkNew<vtkRenderWindow> window;
-    vtkNew<vtkF3DRenderer> renderer;
-    vtkNew<vtkF3DMetaImporter> importer;
-
-    window->AddRenderer(renderer);
-    importer->SetRenderWindow(window);
-    renderer->SetImporter(importer);
-
-    vtkNew<vtkGLTFReader> gltfReader;
-    const std::string filename = std::format("{}data/WaterBottle.glb", argv[1]);
-    gltfReader->SetFileName(filename.c_str());
-    vtkNew<vtkF3DGenericImporter> gltfImporter;
-    gltfImporter->SetInternalReader(gltfReader);
-
-    importer->AddImporter({ "foo", gltfImporter });
-    importer->Update();
-
-    renderer->SetDisplayDepth(true);
-    renderer->SetEnableColoring(true);
-    renderer->SetArrayNameForColoring("NORMAL");
-    renderer->SetUseVolume(false);
-    renderer->ShowScalarBar(true);
-    renderer->UpdateActors();
-
-    const F3DColoringInfoHandler& coloringHandler = importer->GetColoringInfoHandler();
-    const auto coloringInfo = coloringHandler.GetCurrentColoringInfo();
-
-    if (!coloringInfo.has_value())
-    {
-      std::cerr << "Unexpected coloring information\n";
-      return EXIT_FAILURE;
-    }
-
-    if (coloringInfo.value().Name != "NORMAL")
-    {
-      std::cerr << "Unexpected coloring information name: " << coloringInfo.value().Name << "\n";
-      return EXIT_FAILURE;
-    }
-
-    // Component should not matter when display depth is set
-    if (renderer->ComponentToString(-1) != "Depth")
-    {
-      std::cerr << "Unexpected coloring component\n";
-      return EXIT_FAILURE;
-    }
+    std::cerr << "Unexpected coloring information with invalid component\n";
+    return EXIT_FAILURE;
   }
+
+  renderer->CycleComponentForColoring();
+  if (renderer->GetArrayNameForColoring() != "Momentum" || renderer->GetComponentForColoring() != 1)
+  {
+    std::cerr << "Unexpected coloring information after cycling component\n";
+    return EXIT_FAILURE;
+  }
+
+  // Check invalid colormap code path
+  renderer->SetColormap({ 0, 0, 0 });
+  renderer->UpdateActors();
+
+  // Smoke test for deprecated HDRI collapse codepath
+  // F3D_DEPRECATED
+  renderer->SetHDRIFile("path/not/valid/../../to/file.ext");
+
+  // Check SetInteractionStyle without interactor (early return)
+  renderer->SetInteractionStyle("default");
+
+  // Check SetInteractionStyle with invalid style
+  vtkNew<vtkRenderWindowInteractor> interactor;
+  window->SetInteractor(interactor);
+  vtkNew<vtkF3DInteractorStyle> style;
+  interactor->SetInteractorStyle(style);
+  renderer->SetInteractionStyle("invalid");
 
   return EXIT_SUCCESS;
 }

--- a/vtkext/private/module/Testing/TestF3DRendererWithColoring.cxx
+++ b/vtkext/private/module/Testing/TestF3DRendererWithColoring.cxx
@@ -116,8 +116,8 @@ int TestF3DRendererWithColoring(int argc, char* argv[])
     renderer->ShowScalarBar(true);
     renderer->UpdateActors();
 
-    F3DColoringInfoHandler& coloringHandler = importer->GetColoringInfoHandler();
-    auto coloringInfo = coloringHandler.GetCurrentColoringInfo();
+    const F3DColoringInfoHandler& coloringHandler = importer->GetColoringInfoHandler();
+    const auto coloringInfo = coloringHandler.GetCurrentColoringInfo();
 
     if (!coloringInfo.has_value())
     {

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -3394,8 +3394,12 @@ void vtkF3DRenderer::ConfigureOpacityTransferFunction(vtkPiecewiseFunction* otf,
 void vtkF3DRenderer::ConfigureScalarBarActorForColoring(
   vtkScalarBarActor* scalarBar, std::string arrayName, int component, vtkColorTransferFunction* ctf)
 {
+  const std::string componentName = (this->DisplayDepth && this->DisplayDepthScalarColoring)
+    ? "Depth"
+    : this->ComponentToString(component);
+
   arrayName += " (";
-  arrayName += this->ComponentToString(component);
+  arrayName += componentName;
   arrayName += ")";
 
   scalarBar->SetLookupTable(ctf);
@@ -3453,8 +3457,9 @@ void vtkF3DRenderer::ConfigureRangeAndCTFForColoring(
     }
     else
     {
-      minRange = info.MagnitudeRange[0];
-      maxRange = info.MagnitudeRange[1];
+      const bool depthEnabled = this->DisplayDepth && this->DisplayDepthScalarColoring;
+      minRange = depthEnabled ? 0.0 : info.MagnitudeRange[0];
+      maxRange = depthEnabled ? 1.0 : info.MagnitudeRange[1];
     }
     if (this->ExpandingRangeSet)
     {

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -3387,7 +3387,8 @@ void vtkF3DRenderer::ConfigureScalarBarActorForColoring(
   if (this->DisplayDepth)
   {
     arrayName = "DEPTH";
-  } else
+  }
+  else
   {
     arrayName += " (";
     arrayName += this->ComponentToString(component);

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -3094,8 +3094,7 @@ void vtkF3DRenderer::ConfigureColoringAndVisibilities()
   assert(this->Importer);
 
   // Recover coloring information and update handler
-  bool enableColoring = this->EnableColoring || (!this->UseRaytracing && this->UseVolume) ||
-    this->DisplayDepth;
+  bool enableColoring = this->EnableColoring || (!this->UseRaytracing && this->UseVolume);
   F3DColoringInfoHandler& coloringHandler = this->Importer->GetColoringInfoHandler();
   auto info = coloringHandler.SetCurrentColoring(
     enableColoring, this->UseCellColoring, this->ArrayNameForColoring, false);

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -3384,9 +3384,15 @@ void vtkF3DRenderer::ConfigureOpacityTransferFunction(vtkPiecewiseFunction* otf,
 void vtkF3DRenderer::ConfigureScalarBarActorForColoring(
   vtkScalarBarActor* scalarBar, std::string arrayName, int component, vtkColorTransferFunction* ctf)
 {
-  arrayName += " (";
-  arrayName += this->ComponentToString(component);
-  arrayName += ")";
+  if (this->DisplayDepth)
+  {
+    arrayName = "DEPTH";
+  } else
+  {
+    arrayName += " (";
+    arrayName += this->ComponentToString(component);
+    arrayName += ")";
+  }
 
   scalarBar->SetLookupTable(ctf);
   scalarBar->SetTitle(arrayName.c_str());
@@ -3609,11 +3615,7 @@ std::string vtkF3DRenderer::ComponentToString(int component)
 {
   assert(this->Importer);
 
-  if (this->DisplayDepth)
-  {
-    return "Depth";
-  }
-  else if (component == -2)
+  if (component == -2)
   {
     return "Direct Scalars";
   }

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -494,7 +494,7 @@ void vtkF3DRenderer::ConfigureRenderPasses()
     vtkNew<vtkF3DDisplayDepthRenderPass> depthP;
     camP->SetDelegatePass(opaqueP);
     depthP->SetDelegatePass(camP);
-    if (this->DisplayDepthScalarColoring)
+    if (this->EnableColoring)
     {
       this->ConfigureColoringAndVisibilities();
       depthP->SetColorMap(this->ColorTransferFunction);
@@ -1753,16 +1753,6 @@ void vtkF3DRenderer::SetDisplayDepth(bool use)
   if (this->DisplayDepth != use)
   {
     this->DisplayDepth = use;
-    this->RenderPassesConfigured = false;
-  }
-}
-
-//----------------------------------------------------------------------------
-void vtkF3DRenderer::SetDisplayDepthScalarColoring(bool use)
-{
-  if (this->DisplayDepthScalarColoring != use)
-  {
-    this->DisplayDepthScalarColoring = use;
     this->RenderPassesConfigured = false;
   }
 }
@@ -3035,6 +3025,7 @@ void vtkF3DRenderer::SetEnableColoring(bool enable)
     this->EnableColoring = enable;
     this->CheatSheetConfigured = false;
     this->ColoringConfigured = false;
+    this->RenderPassesConfigured = false;
   }
 }
 
@@ -3104,7 +3095,7 @@ void vtkF3DRenderer::ConfigureColoringAndVisibilities()
 
   // Recover coloring information and update handler
   bool enableColoring = this->EnableColoring || (!this->UseRaytracing && this->UseVolume) ||
-    (this->DisplayDepth && this->DisplayDepthScalarColoring);
+    this->DisplayDepth;
   F3DColoringInfoHandler& coloringHandler = this->Importer->GetColoringInfoHandler();
   auto info = coloringHandler.SetCurrentColoring(
     enableColoring, this->UseCellColoring, this->ArrayNameForColoring, false);
@@ -3394,12 +3385,8 @@ void vtkF3DRenderer::ConfigureOpacityTransferFunction(vtkPiecewiseFunction* otf,
 void vtkF3DRenderer::ConfigureScalarBarActorForColoring(
   vtkScalarBarActor* scalarBar, std::string arrayName, int component, vtkColorTransferFunction* ctf)
 {
-  const std::string componentName = (this->DisplayDepth && this->DisplayDepthScalarColoring)
-    ? "Depth"
-    : this->ComponentToString(component);
-
   arrayName += " (";
-  arrayName += componentName;
+  arrayName += this->ComponentToString(component);
   arrayName += ")";
 
   scalarBar->SetLookupTable(ctf);
@@ -3457,9 +3444,8 @@ void vtkF3DRenderer::ConfigureRangeAndCTFForColoring(
     }
     else
     {
-      const bool depthEnabled = this->DisplayDepth && this->DisplayDepthScalarColoring;
-      minRange = depthEnabled ? 0.0 : info.MagnitudeRange[0];
-      maxRange = depthEnabled ? 1.0 : info.MagnitudeRange[1];
+      minRange = this->DisplayDepth ? 0.0 : info.MagnitudeRange[0];
+      maxRange = this->DisplayDepth ? 1.0 : info.MagnitudeRange[1];
     }
     if (this->ExpandingRangeSet)
     {
@@ -3624,7 +3610,11 @@ std::string vtkF3DRenderer::ComponentToString(int component)
 {
   assert(this->Importer);
 
-  if (component == -2)
+  if (this->DisplayDepth)
+  {
+    return "Depth";
+  }
+  else if (component == -2)
   {
     return "Direct Scalars";
   }

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -3386,7 +3386,7 @@ void vtkF3DRenderer::ConfigureScalarBarActorForColoring(
 {
   if (this->DisplayDepth)
   {
-    arrayName = "DEPTH";
+    arrayName = "Depth";
   }
   else
   {

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -750,7 +750,6 @@ private:
   bool UseSSAOPass = false;
   bool UseToneMappingPass = false;
   bool DisplayDepth = false;
-  bool DisplayDepthScalarColoring = false;
   bool UseBlurBackground = false;
   std::optional<bool> UseOrthographicProjection = false;
   bool InvertZoom = false;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -153,7 +153,6 @@ public:
   AntiAliasingMode GetAntiAliasingMode() const;
   void SetUseToneMappingPass(bool use);
   void SetDisplayDepth(bool use);
-  void SetDisplayDepthScalarColoring(bool use);
   void SetUseBlurBackground(bool use);
   void SetBlurCircleOfConfusionRadius(double radius);
   void SetRaytracingSamples(int samples);


### PR DESCRIPTION
### Describe your changes
Fix for ISSUE-3009 where the depth scalar would show (1.0, 1.0] with Magnitude as the name. Here's a screenshot of the new behavior on a MacOS build:
<img width="1254" height="698" alt="Screenshot 2026-05-07 at 8 04 16 AM" src="https://github.com/user-attachments/assets/70100b3d-f076-47cf-b1f7-5b1b684bf5d5" />

### Issue ticket number and link if any
https://github.com/f3d-app/f3d/issues/3009

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
