### PR TITLE
OCCT: Rework CanReadFile to only exclude IFC instead of requiring AUTOMOTIVE_DESIGN

### DIFF
--- a/plugins/occt/module/Testing/TestF3DOCCTReaderStream.cxx
+++ b/plugins/occt/module/Testing/TestF3DOCCTReaderStream.cxx
@@ -33,6 +33,7 @@ int TestF3DOCCTReaderStream(int vtkNotUsed(argc), char* argv[])
   const std::string data = std::string(argv[1]) + "data";
   bool ret = true;
   ret &= testReaderStream(data + "/f3d.stp", vtkF3DOCCTReader::FILE_FORMAT::STEP);
+  ret &= !testReaderStream(data + "/IfcOpenHouse_IFC4.ifc", vtkF3DOCCTReader::FILE_FORMAT::STEP);
   // OCCT doesn't support reading IGES stream yet
   // https://dev.opencascade.org/content/reading-iges-stream-seems-broken-770
   //  ret &= testReaderStream(data + "/f3d.igs", vtkF3DOCCTReader::FILE_FORMAT::IGES);

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -946,8 +946,8 @@ bool vtkF3DOCCTReader::CanReadFile(vtkResourceStream* stream, vtkF3DOCCTReader::
         // Exclude IFC schema as this reader is not able to read it.
         // Other unsupported schema may need to be added if we stumble upon them.
         std::array unsupportedSchemas = std::to_array<std::string_view>({ "IFC" });
-        return std::ranges::none_of(unsupportedSchemas,
-          [line](const std::string_view& schema) { return line.find(schema) != std::string::npos; });
+        return std::ranges::none_of(unsupportedSchemas, [line](const std::string_view& schema)
+          { return line.find(schema) != std::string::npos; });
       }
 
       if (line.find("ENDSEC") != std::string::npos)

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -945,9 +945,9 @@ bool vtkF3DOCCTReader::CanReadFile(vtkResourceStream* stream, vtkF3DOCCTReader::
         format = vtkF3DOCCTReader::FILE_FORMAT::STEP;
         // Exclude IFC schema as this reader is not able to read it.
         // Other unsupported schema may need to be added if we stumble upon them.
-        std::vector<std::string> unsupportedSchemas{ "IFC" };
+        std::array unsupportedSchemas = std::to_array<std::string_view>({ "IFC" });
         return std::ranges::none_of(unsupportedSchemas,
-          [line](const std::string& schema) { return line.find(schema) != std::string::npos; });
+          [line](const std::string_view& schema) { return line.find(schema) != std::string::npos; });
       }
 
       if (line.find("ENDSEC") != std::string::npos)

--- a/plugins/occt/module/vtkF3DOCCTReader.cxx
+++ b/plugins/occt/module/vtkF3DOCCTReader.cxx
@@ -943,7 +943,11 @@ bool vtkF3DOCCTReader::CanReadFile(vtkResourceStream* stream, vtkF3DOCCTReader::
       if (line.find("FILE_SCHEMA") != std::string::npos)
       {
         format = vtkF3DOCCTReader::FILE_FORMAT::STEP;
-        return line.find("AUTOMOTIVE_DESIGN") != std::string::npos;
+        // Exclude IFC schema as this reader is not able to read it.
+        // Other unsupported schema may need to be added if we stumble upon them.
+        std::vector<std::string> unsupportedSchemas{ "IFC" };
+        return std::ranges::none_of(unsupportedSchemas,
+          [line](const std::string& schema) { return line.find(schema) != std::string::npos; });
       }
 
       if (line.find("ENDSEC") != std::string::npos)


### PR DESCRIPTION
### Describe your changes

Rework CanReadFile to only exclude IFC instead of requiring AUTOMOTIVE_DESIGN

### Issue ticket number and link if any

Fix: https://github.com/f3d-app/f3d/issues/3087

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
