### PR TITLE
Move user event loop callback to it's own API

### DIFF
--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -222,5 +222,5 @@ runs:
     # Qt6 tests only supported on windows for now https://github.com/f3d-app/f3d/issues/2670
     - name: Test wheel
       shell: bash
-      working-directory: ${{github.workspace}}/source/python/testing
+      working-directory: ${{github.workspace}}/source
       run: python -m pytest ${{ runner.os != 'Windows' && '-k "not test_minimal_qt6 and not test_minimal_qml"' || null }}

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -222,5 +222,5 @@ runs:
     # Qt6 tests only supported on windows for now https://github.com/f3d-app/f3d/issues/2670
     - name: Test wheel
       shell: bash
-      working-directory: ${{github.workspace}}/source
+      working-directory: ${{github.workspace}}/source/python/testing
       run: python -m pytest ${{ runner.os != 'Windows' && '-k "not test_minimal_qt6 and not test_minimal_qml"' || null }}

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -1485,7 +1485,7 @@ int F3DStarter::Start(int argc, char** argv)
         std::signal(SIGTERM, F3DInternals::SigCallback);
         std::signal(SIGINT, F3DInternals::SigCallback);
 
-        interactor.setEventLoopUserCallBack([this](f3d::interactor_state_t) { this->EventLoop(); });
+        interactor.setEventLoopUserCallback([this](f3d::interactor_state_t) { this->EventLoop(); });
         interactor.start(deltaTime);
       }
 #endif

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -1485,7 +1485,8 @@ int F3DStarter::Start(int argc, char** argv)
         std::signal(SIGTERM, F3DInternals::SigCallback);
         std::signal(SIGINT, F3DInternals::SigCallback);
 
-        interactor.start(deltaTime, [this]() { this->EventLoop(); });
+        interactor.setEventLoopUserCallBack([this](f3d::interactor_state_t) { this->EventLoop(); });
+        interactor.start(deltaTime);
       }
 #endif
     }

--- a/c/interactor_c_api.cxx
+++ b/c/interactor_c_api.cxx
@@ -288,8 +288,8 @@ int f3d_interactor_record_interaction(f3d_interactor_t* interactor, const char* 
 }
 
 //----------------------------------------------------------------------------
-void f3d_interactor_start_with_callback(f3d_interactor_t* interactor, double delta_time,
-  f3d_interactor_callback_t callback, void* user_data)
+void f3d_interactor_set_event_loop_user_callback(
+  f3d_interactor_t* interactor, f3d_interactor_callback_t callback, void* user_data)
 {
   if (!interactor)
   {
@@ -297,21 +297,20 @@ void f3d_interactor_start_with_callback(f3d_interactor_t* interactor, double del
   }
 
   f3d::interactor* cpp_interactor = reinterpret_cast<f3d::interactor*>(interactor);
-
-  if (callback)
-  {
-    cpp_interactor->start(delta_time, [callback, user_data]() { callback(user_data); });
-  }
-  else
-  {
-    cpp_interactor->start(delta_time, nullptr);
-  }
+  cpp_interactor->setEventLoopUserCallBack(
+    [callback, user_data](f3d::interactor_state_t) { callback(user_data); });
 }
 
 //----------------------------------------------------------------------------
 void f3d_interactor_start(f3d_interactor_t* interactor, double delta_time)
 {
-  f3d_interactor_start_with_callback(interactor, delta_time, nullptr, nullptr);
+  if (!interactor)
+  {
+    return;
+  }
+
+  f3d::interactor* cpp_interactor = reinterpret_cast<f3d::interactor*>(interactor);
+  cpp_interactor->start(delta_time);
 }
 
 //----------------------------------------------------------------------------

--- a/c/interactor_c_api.cxx
+++ b/c/interactor_c_api.cxx
@@ -297,7 +297,7 @@ void f3d_interactor_set_event_loop_user_callback(
   }
 
   f3d::interactor* cpp_interactor = reinterpret_cast<f3d::interactor*>(interactor);
-  cpp_interactor->setEventLoopUserCallBack(
+  cpp_interactor->setEventLoopUserCallback(
     [callback, user_data](f3d::interactor_state_t) { callback(user_data); });
 }
 

--- a/c/interactor_c_api.h
+++ b/c/interactor_c_api.h
@@ -452,16 +452,15 @@ extern "C"
 
   typedef void (*f3d_interactor_callback_t)(void* user_data);
   /**
-   * @brief Start the interactor event loop.
+   * @brief Set the event loop user callback.
    *
    * @param interactor Interactor handle.
-   * @param delta_time Time step in seconds.
    * @param callback Optional user callback called at the start of each event-loop
-   *        iteration. May be NULL if no callback is desired.
+   *        iteration.
    * @param user_data Optional opaque pointer passed verbatim to callback.
    */
-  F3D_EXPORT void f3d_interactor_start_with_callback(f3d_interactor_t* interactor,
-    double delta_time, f3d_interactor_callback_t callback, void* user_data);
+  F3D_EXPORT void f3d_interactor_set_event_loop_user_callback(
+    f3d_interactor_t* interactor, f3d_interactor_callback_t callback, void* user_data);
 
   /**
    * @brief Stop the interactor.

--- a/c/testing/test_interactor.c
+++ b/c/testing/test_interactor.c
@@ -137,7 +137,8 @@ int test_interactor()
 
   f3d_interactor_remove_binding(interactor, &bind);
 
-  f3d_interactor_start_with_callback(interactor, 0.01, stop_callback, interactor);
+  f3d_interactor_set_event_loop_user_callback(interactor, stop_callback, interactor);
+  f3d_interactor_start(interactor, 0.01);
 
   f3d_engine_delete(engine);
   return 0;

--- a/doc/libf3d/01-OVERVIEW.md
+++ b/doc/libf3d/01-OVERVIEW.md
@@ -149,3 +149,7 @@ see the installed `f3dConfig.cmake` file for more info.
 
 In order to add new supported file format to libf3d, you can create a plugin using CMake macros. Please follow instructions in the [F3D plugin SDK guide](05-PLUGINS.md).
 Also make sure the `plugin_sdk` component have been installed as well as the `sdk` component.
+
+## Migrate from 3.x
+
+Non backward compatible changes have been introduced in 4.0, please take a look at [the migration guide](06-MIGRATION.md) if you are trying to migrate your libf3d 3.x code base.

--- a/doc/libf3d/01-OVERVIEW.md
+++ b/doc/libf3d/01-OVERVIEW.md
@@ -150,6 +150,6 @@ see the installed `f3dConfig.cmake` file for more info.
 In order to add new supported file format to libf3d, you can create a plugin using CMake macros. Please follow instructions in the [F3D plugin SDK guide](05-PLUGINS.md).
 Also make sure the `plugin_sdk` component have been installed as well as the `sdk` component.
 
-## Migrate from v3.x
+## Migrate from v3.5
 
-Non backward compatible changes have been introduced in v4.0, please take a look at [the migration guide](06-MIGRATION.md) if you are trying to migrate your libf3d v3.x code base.
+Non backward compatible changes have been introduced in v4.0, please take a look at [the migration guide](06-MIGRATION.md) if you are trying to migrate your libf3d v3.5 code base.

--- a/doc/libf3d/01-OVERVIEW.md
+++ b/doc/libf3d/01-OVERVIEW.md
@@ -150,6 +150,6 @@ see the installed `f3dConfig.cmake` file for more info.
 In order to add new supported file format to libf3d, you can create a plugin using CMake macros. Please follow instructions in the [F3D plugin SDK guide](05-PLUGINS.md).
 Also make sure the `plugin_sdk` component have been installed as well as the `sdk` component.
 
-## Migrate from 3.x
+## Migrate from v3.x
 
 Non backward compatible changes have been introduced in v4.0, please take a look at [the migration guide](06-MIGRATION.md) if you are trying to migrate your libf3d v3.x code base.

--- a/doc/libf3d/01-OVERVIEW.md
+++ b/doc/libf3d/01-OVERVIEW.md
@@ -152,4 +152,4 @@ Also make sure the `plugin_sdk` component have been installed as well as the `sd
 
 ## Migrate from 3.x
 
-Non backward compatible changes have been introduced in 4.0, please take a look at [the migration guide](06-MIGRATION.md) if you are trying to migrate your libf3d 3.x code base.
+Non backward compatible changes have been introduced in v4.0, please take a look at [the migration guide](06-MIGRATION.md) if you are trying to migrate your libf3d v3.x code base.

--- a/doc/libf3d/06-MIGRATION.md
+++ b/doc/libf3d/06-MIGRATION.md
@@ -3,5 +3,5 @@
 ## User callback
 
 When calling `f3d::interactor::start()` or `f3d::interactor::playInteraction()`, it was possible to set a user callback automatically called at each event loop.
-If you was setting such callback, please call `f3d::interactor::setEventLoopUserCallBack()` manually before calling `start()` or `playInteractor()`.
+If you was setting such callback, please call `f3d::interactor::setEventLoopUserCallback()` manually before calling `start()` or `playInteractor()`.
 The callback takes an argument of type `f3d::interactor::interactor_state_t` allowing you to retrieve useful information about the interactor state.

--- a/doc/libf3d/06-MIGRATION.md
+++ b/doc/libf3d/06-MIGRATION.md
@@ -3,5 +3,5 @@
 ## User callback
 
 When calling `f3d::interactor::start()` or `f3d::interactor::playInteraction()`, it was possible to set a user callback automatically called at each event loop.
-If you was setting such callback, please call `f3d::interactor::setEventLoopUserCallback()` manually before calling `start()` or `playInteractor()`.
+If you were setting such callback, please call `f3d::interactor::setEventLoopUserCallback()` manually before calling `start()` or `playInteractor()`.
 The callback takes an argument of type `f3d::interactor::interactor_state_t` allowing you to retrieve useful information about the interactor state.

--- a/doc/libf3d/06-MIGRATION.md
+++ b/doc/libf3d/06-MIGRATION.md
@@ -1,0 +1,7 @@
+# Migrate from 3.x
+
+## User callback
+
+When calling `f3d::interactor::start()` or `f3d::interactor::playInteraction()`, it was possible to set a user callback automatically called at each event loop.
+If you was setting such callback, please call `f3d::interactor::setEventLoopUserCallBack()` manually before calling `start()` or `playInteractor()`.
+The callback takes an argument of type `f3d::interactor::interactor_state_t` allowing you to retrieve useful information about the interactor state.

--- a/doc/libf3d/06-MIGRATION.md
+++ b/doc/libf3d/06-MIGRATION.md
@@ -1,4 +1,4 @@
-# Migrate from 3.x
+# Migrate from v3.x
 
 ## User callback
 

--- a/doc/libf3d/06-MIGRATION.md
+++ b/doc/libf3d/06-MIGRATION.md
@@ -1,4 +1,9 @@
-# Migrate from v3.x
+# Migrate from v3.5
+
+This guide explains how to migrate the libf3d code base from v3.5 to v4.0.
+
+> [!WARNING]
+> This guide assumes all deprecation warnings have been addressed, since the deprecated APIs have been removed.
 
 ## User callback
 

--- a/examples/libf3d/c/interactive-app/main.c
+++ b/examples/libf3d/c/interactive-app/main.c
@@ -84,7 +84,8 @@ int main(int argc, char** argv)
   {
     // For testing purposes only, shutdown the example after `timeout` seconds
     int timeout = atoi(argv[2]);
-    f3d_interactor_start_with_callback(interactor, timeout, timeout_callback, interactor);
+    f3d_interactor_set_event_loop_user_callback(interactor, timeout_callback, interactor);
+    f3d_interactor_start(interactor, timeout);
   }
   else
   {

--- a/examples/libf3d/cpp/interactive-app/main.cxx
+++ b/examples/libf3d/cpp/interactive-app/main.cxx
@@ -218,7 +218,8 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.start(timeout, [&inter]() { inter.stop(); });
+      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.start(timeout);
     }
     catch (const std::exception& e)
     {

--- a/examples/libf3d/cpp/interactive-app/main.cxx
+++ b/examples/libf3d/cpp/interactive-app/main.cxx
@@ -218,7 +218,7 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.setEventLoopUserCallback([&inter](f3d::interactor_state_t) { inter.stop(); });
       inter.start(timeout);
     }
     catch (const std::exception& e)

--- a/examples/libf3d/cpp/multi-files/main.cxx
+++ b/examples/libf3d/cpp/multi-files/main.cxx
@@ -42,7 +42,8 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.start(timeout, [&inter]() { inter.stop(); });
+      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.start(timeout);
     }
     catch (const std::exception& e)
     {

--- a/examples/libf3d/cpp/multi-files/main.cxx
+++ b/examples/libf3d/cpp/multi-files/main.cxx
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.setEventLoopUserCallback([&inter](f3d::interactor_state_t) { inter.stop(); });
       inter.start(timeout);
     }
     catch (const std::exception& e)

--- a/examples/libf3d/cpp/render-interact/main.cxx
+++ b/examples/libf3d/cpp/render-interact/main.cxx
@@ -35,7 +35,8 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.start(timeout, [&inter]() { inter.stop(); });
+      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.start(timeout);
     }
     catch (const std::exception& e)
     {

--- a/examples/libf3d/cpp/render-interact/main.cxx
+++ b/examples/libf3d/cpp/render-interact/main.cxx
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.setEventLoopUserCallback([&inter](f3d::interactor_state_t) { inter.stop(); });
       inter.start(timeout);
     }
     catch (const std::exception& e)

--- a/examples/libf3d/cpp/use-options-string/main.cxx
+++ b/examples/libf3d/cpp/use-options-string/main.cxx
@@ -42,7 +42,8 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.start(timeout, [&inter]() { inter.stop(); });
+      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.start(timeout);
     }
     catch (const std::exception& e)
     {

--- a/examples/libf3d/cpp/use-options-string/main.cxx
+++ b/examples/libf3d/cpp/use-options-string/main.cxx
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.setEventLoopUserCallback([&inter](f3d::interactor_state_t) { inter.stop(); });
       inter.start(timeout);
     }
     catch (const std::exception& e)

--- a/examples/libf3d/cpp/use-options-struct/main.cxx
+++ b/examples/libf3d/cpp/use-options-struct/main.cxx
@@ -42,7 +42,8 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.start(timeout, [&inter]() { inter.stop(); });
+      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.start(timeout);
     }
     catch (const std::exception& e)
     {

--- a/examples/libf3d/cpp/use-options-struct/main.cxx
+++ b/examples/libf3d/cpp/use-options-struct/main.cxx
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.setEventLoopUserCallback([&inter](f3d::interactor_state_t) { inter.stop(); });
       inter.start(timeout);
     }
     catch (const std::exception& e)

--- a/examples/libf3d/cpp/use-options-variant/main.cxx
+++ b/examples/libf3d/cpp/use-options-variant/main.cxx
@@ -39,7 +39,8 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.start(timeout, [&inter]() { inter.stop(); });
+      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.start(timeout);
     }
     catch (const std::exception& e)
     {

--- a/examples/libf3d/cpp/use-options-variant/main.cxx
+++ b/examples/libf3d/cpp/use-options-variant/main.cxx
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
     try
     {
       int timeout = std::stoi(argv[2]);
-      inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+      inter.setEventLoopUserCallback([&inter](f3d::interactor_state_t) { inter.stop(); });
       inter.start(timeout);
     }
     catch (const std::exception& e)

--- a/examples/libf3d/java/interactive-app/InteractiveApp.java
+++ b/examples/libf3d/java/interactive-app/InteractiveApp.java
@@ -53,7 +53,8 @@ public class InteractiveApp {
             if (args.length > 1) {
                 // For testing purposes, stop after timeout seconds
                 int timeout = Integer.parseInt(args[1]);
-                interactor.start(timeout, () -> interactor.stop());
+                interactor.setEventLoopUserCallBack(state -> interactor.stop());
+                interactor.start(timeout);
             } else {
                 interactor.start();
             }

--- a/examples/libf3d/java/interactive-app/InteractiveApp.java
+++ b/examples/libf3d/java/interactive-app/InteractiveApp.java
@@ -53,7 +53,7 @@ public class InteractiveApp {
             if (args.length > 1) {
                 // For testing purposes, stop after timeout seconds
                 int timeout = Integer.parseInt(args[1]);
-                interactor.setEventLoopUserCallBack(state -> interactor.stop());
+                interactor.setEventLoopUserCallback(state -> interactor.stop());
                 interactor.start(timeout);
             } else {
                 interactor.start();

--- a/examples/libf3d/python/interactive-app/interactive_app.py
+++ b/examples/libf3d/python/interactive-app/interactive_app.py
@@ -54,7 +54,10 @@ def main(argv: list[str] | None = None):
 
     if args.timeout:
         # For testing purposes only, exit after `timeout` seconds
-        eng.interactor.start(args.timeout, eng.interactor.stop)
+        eng.interactor.set_event_loop_user_callback(
+            lambda _state: eng.interactor.request_stop()
+        )
+        eng.interactor.start(args.timeout)
     else:
         eng.interactor.start()
 

--- a/examples/libf3d/python/render-interact/render_interact.py
+++ b/examples/libf3d/python/render-interact/render_interact.py
@@ -34,7 +34,10 @@ def main(argv: list[str] | None = None):
 
     if args.timeout:
         # For testing purposes only, exit after `timeout` seconds
-        eng.interactor.start(args.timeout, eng.interactor.stop)
+        eng.interactor.set_event_loop_user_callback(
+            lambda _state: eng.interactor.request_stop()
+        )
+        eng.interactor.start(args.timeout)
     else:
         eng.interactor.start()
 

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -604,7 +604,7 @@ extern "C"
     return self;
   }
 
-  JNIEXPORT jobject JAVA_BIND(Interactor, setEventLoopUserCallBack)(
+  JNIEXPORT jobject JAVA_BIND(Interactor, setEventLoopUserCallback)(
     JNIEnv* env, jobject self, jobject callback)
   {
     if (g_eventLoopCallback != nullptr)
@@ -615,13 +615,13 @@ extern "C"
 
     if (callback == nullptr)
     {
-      GetInteractor(env, self).setEventLoopUserCallBack(nullptr);
+      GetInteractor(env, self).setEventLoopUserCallback(nullptr);
       return self;
     }
 
     g_eventLoopCallback = env->NewGlobalRef(callback);
 
-    GetInteractor(env, self).setEventLoopUserCallBack(
+    GetInteractor(env, self).setEventLoopUserCallback(
       [](f3d::interactor_state_t state)
       {
         JNIEnv* env = nullptr;

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -9,6 +9,7 @@
 namespace
 {
 std::map<std::string, jobject> g_commandCallbacks;
+jobject g_eventLoopCallback = nullptr;
 JavaVM* g_jvm = nullptr;
 
 f3d::interactor& GetInteractor(JNIEnv* env, jobject self)
@@ -603,6 +604,54 @@ extern "C"
     return self;
   }
 
+  JNIEXPORT jobject JAVA_BIND(Interactor, setEventLoopUserCallBack)(
+    JNIEnv* env, jobject self, jobject callback)
+  {
+    if (g_eventLoopCallback != nullptr)
+    {
+      env->DeleteGlobalRef(g_eventLoopCallback);
+      g_eventLoopCallback = nullptr;
+    }
+
+    if (callback == nullptr)
+    {
+      GetInteractor(env, self).setEventLoopUserCallBack(nullptr);
+      return self;
+    }
+
+    g_eventLoopCallback = env->NewGlobalRef(callback);
+
+    GetInteractor(env, self).setEventLoopUserCallBack(
+      [](f3d::interactor_state_t state)
+      {
+        JNIEnv* env = nullptr;
+#ifdef __ANDROID__
+        if (g_jvm->AttachCurrentThread(&env, nullptr) != JNI_OK)
+#else
+        if (g_jvm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr) != JNI_OK)
+#endif
+        {
+          return;
+        }
+
+        jclass callbackClass = env->GetObjectClass(g_eventLoopCallback);
+        jmethodID executeMethod =
+          env->GetMethodID(callbackClass, "execute", "(Lapp/f3d/F3D/Interactor$InteractorState;)V");
+
+        jclass stateClass = env->FindClass("app/f3d/F3D/Interactor$InteractorState");
+        jmethodID stateConstructor = env->GetMethodID(stateClass, "<init>", "()V");
+        jobject stateObj = env->NewObject(stateClass, stateConstructor);
+        jfieldID animationTimeField = env->GetFieldID(stateClass, "animationTime", "D");
+        env->SetDoubleField(stateObj, animationTimeField, state.animationTime);
+
+        env->CallVoidMethod(g_eventLoopCallback, executeMethod, stateObj);
+
+        env->DeleteLocalRef(stateObj);
+        g_jvm->DetachCurrentThread();
+      });
+    return self;
+  }
+
   JNIEXPORT jboolean JAVA_BIND(Interactor, playInteraction)(
     JNIEnv* env, jobject self, jstring file, jdouble deltaTime)
   {
@@ -624,34 +673,6 @@ extern "C"
   JNIEXPORT jobject JAVA_BIND(Interactor, start)(JNIEnv* env, jobject self, jdouble deltaTime)
   {
     GetInteractor(env, self).start(deltaTime);
-    return self;
-  }
-
-  JNIEXPORT jobject JAVA_BIND(Interactor, startWithCallback)(
-    JNIEnv* env, jobject self, jdouble deltaTime, jobject callback)
-  {
-    jobject globalCallback = env->NewGlobalRef(callback);
-
-    GetInteractor(env, self).start(deltaTime,
-      [globalCallback]()
-      {
-        JNIEnv* env = nullptr;
-#ifdef __ANDROID__
-        if (g_jvm->AttachCurrentThread(&env, nullptr) != JNI_OK)
-#else
-        if (g_jvm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr) != JNI_OK)
-#endif
-        {
-          return;
-        }
-
-        jclass runnableClass = env->GetObjectClass(globalCallback);
-        jmethodID runMethod = env->GetMethodID(runnableClass, "run", "()V");
-        env->CallVoidMethod(globalCallback, runMethod);
-
-        env->DeleteGlobalRef(globalCallback);
-        g_jvm->DetachCurrentThread();
-      });
     return self;
   }
 

--- a/java/Interactor.java
+++ b/java/Interactor.java
@@ -476,7 +476,7 @@ public class Interactor {
      * @param callback callback to be called on each event loop iteration
      * @return this interactor for method chaining
      */
-    public native Interactor setEventLoopUserCallBack(EventLoopCallback callback);
+    public native Interactor setEventLoopUserCallback(EventLoopCallback callback);
 
     /**
      * Play a VTK interaction file.

--- a/java/Interactor.java
+++ b/java/Interactor.java
@@ -149,6 +149,14 @@ public class Interactor {
         }
     }
 
+    public static class InteractorState {
+        public double animationTime;
+    }
+
+    public interface EventLoopCallback {
+        void execute(InteractorState state);
+    }
+
     public interface CommandCallback {
         void execute(List<String> args);
     }
@@ -463,6 +471,14 @@ public class Interactor {
     public native Interactor triggerEventLoop(double deltaTime);
 
     /**
+     * Set the event loop user callback called automatically on each event loop iteration.
+     *
+     * @param callback callback to be called on each event loop iteration
+     * @return this interactor for method chaining
+     */
+    public native Interactor setEventLoopUserCallBack(EventLoopCallback callback);
+
+    /**
      * Play a VTK interaction file.
      *
      * @param file path to interaction file
@@ -504,28 +520,6 @@ public class Interactor {
      */
     public Interactor start() {
         return start(1.0 / 30);
-    }
-
-    /**
-     * Start the interactor event loop with a callback.
-     * The callback is called on each event loop iteration.
-     *
-     * @param deltaTime time delta in seconds (must be positive)
-     * @param callback callback to execute on each iteration
-     * @return this interactor for method chaining
-     */
-    private native Interactor startWithCallback(double deltaTime, Runnable callback);
-
-    /**
-     * Start the interactor event loop with a callback.
-     * The callback is called on each event loop iteration.
-     *
-     * @param deltaTime time delta in seconds (must be positive)
-     * @param callback callback to execute on each iteration
-     * @return this interactor for method chaining
-     */
-    public Interactor start(double deltaTime, Runnable callback) {
-        return startWithCallback(deltaTime, callback);
     }
 
     /**

--- a/library/private/animationManager.h
+++ b/library/private/animationManager.h
@@ -104,7 +104,7 @@ public:
    */
   int GetAnimationDirection() const
   {
-    return AnimationDirection;
+    return this->AnimationDirection;
   }
 
   /**
@@ -112,7 +112,15 @@ public:
    */
   bool IsPlaying() const
   {
-    return Playing;
+    return this->Playing;
+  }
+
+  /**
+   * Return the current animation time in seconds
+   */
+  double GetCurrentTime() const
+  {
+    return this->CurrentTime;
   }
 
   /**

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -77,8 +77,8 @@ public:
   interactor& enableCameraMovement() override;
   interactor& disableCameraMovement() override;
 
-  interactor& setEventLoopUserCallBack(
-    std::function<void(interactor_state_t)> userCallBack) override;
+  interactor& setEventLoopUserCallback(
+    std::function<void(interactor_state_t)> userCallback) override;
 
   bool playInteraction(const std::filesystem::path& file, double deltaTime) override;
   bool recordInteraction(const std::filesystem::path& file) override;
@@ -128,7 +128,7 @@ public:
 
   /**
    * Event loop being called automatically once the interactor is started
-   * First call the EventLoopUserCallBack, then call render if requested.
+   * First call the EventLoopUserCallback, then call render if requested.
    */
   void EventLoop();
 

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -77,14 +77,16 @@ public:
   interactor& enableCameraMovement() override;
   interactor& disableCameraMovement() override;
 
-  bool playInteraction(const std::filesystem::path& file, double deltaTime,
-    std::function<void()> userCallBack) override;
+  interactor& setEventLoopUserCallBack(
+    std::function<void(interactor_state_t)> userCallBack) override;
+
+  bool playInteraction(const std::filesystem::path& file, double deltaTime) override;
   bool recordInteraction(const std::filesystem::path& file) override;
 
   interactor& triggerNotification(
     std::string desc, std::string value = "", double duration = 3.f) override;
 
-  interactor& start(double deltaTime, std::function<void()> userCallBack) override;
+  interactor& start(double deltaTime) override;
   interactor& stop() override;
   interactor& requestRender() override;
   interactor& requestStop() override;

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -403,8 +403,8 @@ public:
   /**
    * Set the user callback of the event loop, which is called right after the rendering.
    */
-  virtual interactor& setEventLoopUserCallBack(
-    std::function<void(interactor_state_t)> userCallBack) = 0;
+  virtual interactor& setEventLoopUserCallback(
+    std::function<void(interactor_state_t)> userCallback) = 0;
 
   /**
    * Start the interactor event loop.

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -59,6 +59,14 @@ struct interaction_bind_t
 };
 
 /**
+ * State of the interactor that can be used in the user callback of playInteraction and start.
+ */
+struct interactor_state_t
+{
+  double animationTime = 0.0;
+};
+
+/**
  * @class   interactor
  * @brief   Class used to control interaction and animation
  *
@@ -382,11 +390,9 @@ public:
   /**
    * Play a VTK interaction file.
    * Provided file path is used as is and file existence will be checked.
-   * If the event loop is not already running, it will be triggered every deltaTime in seconds,
-   * and userCallBack will be called at the start of the event loop.
+   * If the event loop is not already running, it will be triggered every deltaTime in seconds.
    */
-  virtual bool playInteraction(const std::filesystem::path& file, double deltaTime = 1.0 / 30,
-    std::function<void()> userCallBack = nullptr) = 0;
+  virtual bool playInteraction(const std::filesystem::path& file, double deltaTime = 1.0 / 30) = 0;
 
   /**
    * Start interaction and record it all in a VTK interaction file.
@@ -395,13 +401,18 @@ public:
   virtual bool recordInteraction(const std::filesystem::path& file) = 0;
 
   /**
+   * Set the user callback of the event loop, which is called right after the rendering.
+   */
+  virtual interactor& setEventLoopUserCallBack(
+    std::function<void(interactor_state_t)> userCallBack) = 0;
+
+  /**
    * Start the interactor event loop.
-   * The event loop will be triggered every deltaTime in seconds, and userCallBack will be called at
-   * the start of the event loop, deltaTime should be strictly positive.
+   * The event loop will be triggered every deltaTime in seconds.
+   * deltaTime should be strictly positive.
    * Safe to call multiple times but will log an info in that case.
    */
-  virtual interactor& start(
-    double deltaTime = 1.0 / 30, std::function<void()> userCallBack = nullptr) = 0;
+  virtual interactor& start(double deltaTime = 1.0 / 30) = 0;
 
   /**
    * Stop the interactor.

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -600,6 +600,7 @@ public:
     }
     this->VTKInteractor->RemoveObserver(this->EventLoopObserverId);
     this->VTKInteractor->DestroyTimer(this->EventLoopTimerId);
+    this->EventLoopUserCallBack = nullptr;
     this->EventLoopObserverId = -1;
     this->EventLoopTimerId = 0;
     return true;

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -577,16 +577,16 @@ public:
     this->CallbackDeltaTime = deltaTime;
 
     // Create the callback and add an observer
-    vtkNew<vtkCallbackCommand> timerCallBack;
-    timerCallBack->SetCallback(
+    vtkNew<vtkCallbackCommand> timerCallback;
+    timerCallback->SetCallback(
       [](vtkObject*, unsigned long, void* clientData, void*)
       {
         internals* that = static_cast<internals*>(clientData);
         that->EventLoop(that->CallbackDeltaTime);
       });
     this->EventLoopObserverId =
-      this->VTKInteractor->AddObserver(vtkCommand::TimerEvent, timerCallBack);
-    timerCallBack->SetClientData(this);
+      this->VTKInteractor->AddObserver(vtkCommand::TimerEvent, timerCallback);
+    timerCallback->SetClientData(this);
     return true;
   }
 
@@ -600,7 +600,7 @@ public:
     }
     this->VTKInteractor->RemoveObserver(this->EventLoopObserverId);
     this->VTKInteractor->DestroyTimer(this->EventLoopTimerId);
-    this->EventLoopUserCallBack = nullptr;
+    this->EventLoopUserCallback = nullptr;
     this->EventLoopObserverId = -1;
     this->EventLoopTimerId = 0;
     return true;
@@ -619,9 +619,9 @@ public:
       this->Interactor.stop();
       return;
     }
-    if (this->EventLoopUserCallBack)
+    if (this->EventLoopUserCallback)
     {
-      this->EventLoopUserCallBack({ .animationTime = this->AnimationManager->GetCurrentTime() });
+      this->EventLoopUserCallback({ .animationTime = this->AnimationManager->GetCurrentTime() });
     }
 
     if (this->CommandBuffer.has_value())
@@ -693,7 +693,7 @@ public:
   int DragDistanceTol = 3;      /* px */
   int TransitionDuration = 100; /* ms */
 
-  std::function<void(interactor_state_t)> EventLoopUserCallBack = nullptr;
+  std::function<void(interactor_state_t)> EventLoopUserCallback = nullptr;
   unsigned long EventLoopTimerId = 0;
   int EventLoopObserverId = -1;
   std::atomic<bool> RenderRequested = false;
@@ -2036,8 +2036,8 @@ interactor& interactor_impl::disableCameraMovement()
 }
 
 //----------------------------------------------------------------------------
-interactor& interactor_impl::setEventLoopUserCallBack(
-  std::function<void(interactor_state_t)> userCallBack)
+interactor& interactor_impl::setEventLoopUserCallback(
+  std::function<void(interactor_state_t)> userCallback)
 {
   if (this->Internals->EventLoopObserverId != -1)
   {
@@ -2045,7 +2045,7 @@ interactor& interactor_impl::setEventLoopUserCallBack(
     return *this;
   }
 
-  this->Internals->EventLoopUserCallBack = std::move(userCallBack);
+  this->Internals->EventLoopUserCallback = std::move(userCallback);
   return *this;
 }
 

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -560,7 +560,7 @@ public:
   }
 
   //----------------------------------------------------------------------------
-  bool StartEventLoop(double deltaTime, std::function<void()> userCallBack)
+  bool StartEventLoop(double deltaTime)
   {
     if (this->EventLoopObserverId != -1)
     {
@@ -570,9 +570,6 @@ public:
 
     // Trigger a render to ensure Window is ready to be configured
     this->Window.render();
-
-    // Copy user callback
-    this->EventLoopUserCallBack = std::move(userCallBack);
 
     // Create the timer
     this->EventLoopTimerId = this->VTKInteractor->CreateRepeatingTimer(deltaTime * 1000);
@@ -623,7 +620,7 @@ public:
     }
     if (this->EventLoopUserCallBack)
     {
-      this->EventLoopUserCallBack();
+      this->EventLoopUserCallBack({ .animationTime = this->AnimationManager->GetCurrentTime() });
     }
 
     if (this->CommandBuffer.has_value())
@@ -695,7 +692,7 @@ public:
   int DragDistanceTol = 3;      /* px */
   int TransitionDuration = 100; /* ms */
 
-  std::function<void()> EventLoopUserCallBack = nullptr;
+  std::function<void(interactor_state_t)> EventLoopUserCallBack = nullptr;
   unsigned long EventLoopTimerId = 0;
   int EventLoopObserverId = -1;
   std::atomic<bool> RenderRequested = false;
@@ -2038,8 +2035,21 @@ interactor& interactor_impl::disableCameraMovement()
 }
 
 //----------------------------------------------------------------------------
-bool interactor_impl::playInteraction(
-  const fs::path& file, double loopTime, std::function<void()> userCallBack)
+interactor& interactor_impl::setEventLoopUserCallBack(
+  std::function<void(interactor_state_t)> userCallBack)
+{
+  if (this->Internals->EventLoopObserverId != -1)
+  {
+    log::info("Cannot set event loop user callback after the event loop has started");
+    return *this;
+  }
+
+  this->Internals->EventLoopUserCallBack = std::move(userCallBack);
+  return *this;
+}
+
+//----------------------------------------------------------------------------
+bool interactor_impl::playInteraction(const fs::path& file, double loopTime)
 {
   try
   {
@@ -2053,7 +2063,7 @@ bool interactor_impl::playInteraction(
     this->Internals->Recorder->Off();
     this->Internals->Recorder->Clear();
 
-    bool loop = this->Internals->StartEventLoop(loopTime, std::move(userCallBack));
+    bool loop = this->Internals->StartEventLoop(loopTime);
     this->Internals->Recorder->SetFileName(file.string().c_str());
     this->Internals->Recorder->Play();
 
@@ -2114,9 +2124,9 @@ bool interactor_impl::recordInteraction(const fs::path& file)
 }
 
 //----------------------------------------------------------------------------
-interactor& interactor_impl::start(double loopTime, std::function<void()> userCallBack)
+interactor& interactor_impl::start(double loopTime)
 {
-  if (this->Internals->StartEventLoop(loopTime, std::move(userCallBack)))
+  if (this->Internals->StartEventLoop(loopTime))
   {
     this->Internals->VTKInteractor->Start();
   }

--- a/library/testing/TestSDKRenderAndInteract.cxx
+++ b/library/testing/TestSDKRenderAndInteract.cxx
@@ -18,7 +18,7 @@ int TestSDKRenderAndInteract([[maybe_unused]] int argc, [[maybe_unused]] char* a
   win.render();
 
   f3d::interactor& inter = eng.getInteractor();
-  inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.requestStop(); });
+  inter.setEventLoopUserCallback([&inter](f3d::interactor_state_t) { inter.requestStop(); });
   inter.start(1);
 
   return EXIT_SUCCESS;

--- a/library/testing/TestSDKRenderAndInteract.cxx
+++ b/library/testing/TestSDKRenderAndInteract.cxx
@@ -18,7 +18,8 @@ int TestSDKRenderAndInteract([[maybe_unused]] int argc, [[maybe_unused]] char* a
   win.render();
 
   f3d::interactor& inter = eng.getInteractor();
-  inter.start(1, [&inter]() { inter.stop(); });
+  inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.requestStop(); });
+  inter.start(1);
 
   return EXIT_SUCCESS;
 }

--- a/library/testing/TestSDKSceneFromMemory.cxx
+++ b/library/testing/TestSDKSceneFromMemory.cxx
@@ -20,7 +20,11 @@ int TestSDKSceneFromMemory([[maybe_unused]] int argc, [[maybe_unused]] char* arg
 
   // Add mesh with invalid number of points
   test.expect<f3d::scene::load_failure_exception>("add mesh with invalid number of points", [&]() {
-    sce.add(f3d::mesh_t{ { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f }, {}, {}, { 3 }, { 0, 1, 2 } });
+    sce.add(f3d::mesh_t{ .points = { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f },
+      .normals = {},
+      .texture_coordinates = {},
+      .face_sides = { 3 },
+      .face_indices = { 0, 1, 2 } });
   });
 
   // Add mesh with empty points
@@ -30,34 +34,48 @@ int TestSDKSceneFromMemory([[maybe_unused]] int argc, [[maybe_unused]] char* arg
   // Add mesh with invalid number of cell indices
   test.expect<f3d::scene::load_failure_exception>(
     "add mesh with invalid number of cell indices", [&]() {
-      sce.add(f3d::mesh_t{
-        { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f }, {}, {}, { 3 }, { 0, 1, 2, 3 } });
+      sce.add(f3d::mesh_t{ .points = { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f },
+        .normals = {},
+        .texture_coordinates = {},
+        .face_sides = { 3 },
+        .face_indices = { 0, 1, 2, 3 } });
     });
 
   // Add mesh with invalid vertex index
   test.expect<f3d::scene::load_failure_exception>("add mesh with invalid vertex index", [&]() {
-    sce.add(
-      f3d::mesh_t{ { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f }, {}, {}, { 3 }, { 0, 1, 4 } });
+    sce.add(f3d::mesh_t{ .points = { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f },
+      .normals = {},
+      .texture_coordinates = {},
+      .face_sides = { 3 },
+      .face_indices = { 0, 1, 4 } });
   });
 
   // Add mesh with invalid normals
   test.expect<f3d::scene::load_failure_exception>("add mesh with invalid normals", [&]() {
-    sce.add(f3d::mesh_t{
-      { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f }, { 1.f }, {}, { 3 }, { 0, 1, 2, 4 } });
+    sce.add(f3d::mesh_t{ .points = { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f },
+      .normals = { 1.f },
+      .texture_coordinates = {},
+      .face_sides = { 3 },
+      .face_indices = { 0, 1, 2, 4 } });
   });
 
   // Add mesh with invalid texture coordinates
   test.expect<f3d::scene::load_failure_exception>(
     "add mesh with invalid texture coordinates", [&]() {
-      sce.add(f3d::mesh_t{
-        { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f }, {}, { 1.f }, { 3 }, { 0, 1, 2, 4 } });
+      sce.add(f3d::mesh_t{ .points = { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f },
+        .normals = {},
+        .texture_coordinates = { 1.f },
+        .face_sides = { 3 },
+        .face_indices = { 0, 1, 2, 4 } });
     });
 
   // Add mesh from memory and render it
   test("add mesh from memory", [&]() {
-    sce.add(f3d::mesh_t{ { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f, 1.f, 1.f, 0.f },
-      { 0.f, 0.f, -1.f, 0.f, 0.f, -1.f, 0.f, 0.f, -1.f, 0.f, 0.f, -1.f },
-      { 0.f, 0.f, 0.f, 1.f, 1.f, 0.f, 1.f, 1.f }, { 3, 3 }, { 0, 1, 2, 1, 3, 2 } });
+    sce.add(f3d::mesh_t{ .points = { 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f, 1.f, 1.f, 0.f },
+      .normals = { 0.f, 0.f, -1.f, 0.f, 0.f, -1.f, 0.f, 0.f, -1.f, 0.f, 0.f, -1.f },
+      .texture_coordinates = { 0.f, 0.f, 0.f, 1.f, 1.f, 0.f, 1.f, 1.f },
+      .face_sides = { 3, 3 },
+      .face_indices = { 0, 1, 2, 1, 3, 2 } });
   });
 
   // Render test

--- a/library/testing/TestSDKStartInteractor.cxx
+++ b/library/testing/TestSDKStartInteractor.cxx
@@ -14,6 +14,10 @@ int TestSDKStartInteractor([[maybe_unused]] int argc, [[maybe_unused]] char* arg
 
   // Call start multiple times
   inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) {
+
+    // Trying to set a callback when loop is already running. Should not do anything.
+    inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) {});
+
     inter.start();
     inter.stop();
   });

--- a/library/testing/TestSDKStartInteractor.cxx
+++ b/library/testing/TestSDKStartInteractor.cxx
@@ -9,13 +9,13 @@ int TestSDKStartInteractor([[maybe_unused]] int argc, [[maybe_unused]] char* arg
   f3d::scene& sce = eng.getScene();
   sce.add(std::string(argv[1]) + "/data/cow.vtp");
   f3d::interactor& inter = eng.getInteractor();
-  inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+  inter.setEventLoopUserCallback([&inter](f3d::interactor_state_t) { inter.stop(); });
   inter.start(0.1);
 
   // Call start multiple times
-  inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) {
+  inter.setEventLoopUserCallback([&inter](f3d::interactor_state_t) {
     // Trying to set a callback when loop is already running. Should not do anything.
-    inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) {});
+    inter.setEventLoopUserCallback([](f3d::interactor_state_t) {});
 
     inter.start();
     inter.stop();

--- a/library/testing/TestSDKStartInteractor.cxx
+++ b/library/testing/TestSDKStartInteractor.cxx
@@ -9,13 +9,15 @@ int TestSDKStartInteractor([[maybe_unused]] int argc, [[maybe_unused]] char* arg
   f3d::scene& sce = eng.getScene();
   sce.add(std::string(argv[1]) + "/data/cow.vtp");
   f3d::interactor& inter = eng.getInteractor();
-  inter.start(0.1, [&inter]() { inter.stop(); });
+  inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) { inter.stop(); });
+  inter.start(0.1);
 
   // Call start multiple times
-  inter.start(0.1, [&inter]() {
-    inter.start(1, []() {});
+  inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) {
+    inter.start();
     inter.stop();
   });
+  inter.start(0.1);
 
   // Call stop without loop running
   inter.stop();

--- a/library/testing/TestSDKStartInteractor.cxx
+++ b/library/testing/TestSDKStartInteractor.cxx
@@ -14,7 +14,6 @@ int TestSDKStartInteractor([[maybe_unused]] int argc, [[maybe_unused]] char* arg
 
   // Call start multiple times
   inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) {
-
     // Trying to set a callback when loop is already running. Should not do anything.
     inter.setEventLoopUserCallBack([&inter](f3d::interactor_state_t) {});
 

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -320,7 +320,7 @@ PYBIND11_MODULE(pyf3d, module)
       "Enable the camera interaction")
     .def("disable_camera_movement", &f3d::interactor::disableCameraMovement,
       "Disable the camera interaction")
-    .def("set_event_loop_user_callback", &f3d::interactor::setEventLoopUserCallBack,
+    .def("set_event_loop_user_callback", &f3d::interactor::setEventLoopUserCallback,
       "Set the user callback of the event loop", py::arg("user_callback") = nullptr)
     .def("trigger_mod_update", &f3d::interactor::triggerModUpdate, "Trigger a key modifier update")
     .def("trigger_mouse_button", &f3d::interactor::triggerMouseButton, "Trigger a mouse button")

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -262,6 +262,11 @@ PYBIND11_MODULE(pyf3d, module)
     .def_readwrite("inter", &f3d::interaction_bind_t::inter)
     .def("format", &f3d::interaction_bind_t::format);
 
+  py::class_<f3d::interactor_state_t> interactor_state(module, "InteractorState");
+
+  interactor_state.def(py::init<>())
+    .def_readonly("animation_time", &f3d::interactor_state_t::animationTime);
+
   py::class_<f3d::interactor, std::unique_ptr<f3d::interactor, py::nodelete>> interactor(
     module, "Interactor");
 
@@ -315,6 +320,8 @@ PYBIND11_MODULE(pyf3d, module)
       "Enable the camera interaction")
     .def("disable_camera_movement", &f3d::interactor::disableCameraMovement,
       "Disable the camera interaction")
+    .def("set_event_loop_user_callback", &f3d::interactor::setEventLoopUserCallBack,
+      "Set the user callback of the event loop", py::arg("user_callback") = nullptr)
     .def("trigger_mod_update", &f3d::interactor::triggerModUpdate, "Trigger a key modifier update")
     .def("trigger_mouse_button", &f3d::interactor::triggerMouseButton, "Trigger a mouse button")
     .def(
@@ -328,7 +335,7 @@ PYBIND11_MODULE(pyf3d, module)
     .def("play_interaction", &f3d::interactor::playInteraction, "Play an interaction file")
     .def("record_interaction", &f3d::interactor::recordInteraction, "Record an interaction file")
     .def("start", &f3d::interactor::start, "Start the interactor and the event loop",
-      py::arg("delta_time") = 1.0 / 30, py::arg("user_callback") = nullptr)
+      py::arg("delta_time") = 1.0 / 30)
     .def("stop", &f3d::interactor::stop, "Stop the interactor and the event loop")
     .def(
       "request_render", &f3d::interactor::requestRender, "Request a render on the next event loop")

--- a/python/testing/test_interactor_start.py
+++ b/python/testing/test_interactor_start.py
@@ -3,27 +3,27 @@ from functools import partial
 import f3d
 
 
-def stop_fn(_state: f3d.InteractorState, inter: f3d.Interactor):
-    inter.stop()
-
-
-def test_start_stop():
-    engine = f3d.Engine.create(True)
-    inter = engine.interactor
-    inter.set_event_loop_user_callback(partial(stop_fn, inter=inter))
-    inter.start(1 / 30)
-
-
-def test_request_render():
-    engine = f3d.Engine.create(True)
-    inter = engine.interactor
-    inter.request_render()
-    inter.set_event_loop_user_callback(partial(stop_fn, inter=inter))
-    inter.start(1 / 30)
-
-
-def test_request_stop():
-    engine = f3d.Engine.create(True)
-    inter = engine.interactor
-    inter.set_event_loop_user_callback(lambda _state: inter.request_stop())
-    inter.start(1 / 30)
+# def stop_fn(_state: f3d.InteractorState, inter: f3d.Interactor):
+#     inter.stop()
+# 
+# 
+# def test_start_stop():
+#     engine = f3d.Engine.create(True)
+#     inter = engine.interactor
+#     inter.set_event_loop_user_callback(partial(stop_fn, inter=inter))
+#     inter.start(1 / 30)
+# 
+# 
+# def test_request_render():
+#     engine = f3d.Engine.create(True)
+#     inter = engine.interactor
+#     inter.request_render()
+#     inter.set_event_loop_user_callback(partial(stop_fn, inter=inter))
+#     inter.start(1 / 30)
+# 
+# 
+# def test_request_stop():
+#     engine = f3d.Engine.create(True)
+#     inter = engine.interactor
+#     inter.set_event_loop_user_callback(lambda _state: inter.request_stop())
+#     inter.start(1 / 30)

--- a/python/testing/test_interactor_start.py
+++ b/python/testing/test_interactor_start.py
@@ -3,27 +3,27 @@ from functools import partial
 import f3d
 
 
-# def stop_fn(_state: f3d.InteractorState, inter: f3d.Interactor):
-#     inter.stop()
-# 
-# 
-# def test_start_stop():
-#     engine = f3d.Engine.create(True)
-#     inter = engine.interactor
-#     inter.set_event_loop_user_callback(partial(stop_fn, inter=inter))
-#     inter.start(1 / 30)
-# 
-# 
-# def test_request_render():
-#     engine = f3d.Engine.create(True)
-#     inter = engine.interactor
-#     inter.request_render()
-#     inter.set_event_loop_user_callback(partial(stop_fn, inter=inter))
-#     inter.start(1 / 30)
-# 
-# 
-# def test_request_stop():
-#     engine = f3d.Engine.create(True)
-#     inter = engine.interactor
-#     inter.set_event_loop_user_callback(lambda _state: inter.request_stop())
-#     inter.start(1 / 30)
+def stop_fn(_state: f3d.InteractorState, inter: f3d.Interactor):
+    inter.stop()
+
+
+def test_start_stop():
+    engine = f3d.Engine.create(True)
+    inter = engine.interactor
+    inter.set_event_loop_user_callback(partial(stop_fn, inter=inter))
+    inter.start(1 / 30)
+
+
+def test_request_render():
+    engine = f3d.Engine.create(True)
+    inter = engine.interactor
+    inter.request_render()
+    inter.set_event_loop_user_callback(partial(stop_fn, inter=inter))
+    inter.start(1 / 30)
+
+
+def test_request_stop():
+    engine = f3d.Engine.create(True)
+    inter = engine.interactor
+    inter.set_event_loop_user_callback(lambda _state: inter.request_stop())
+    inter.start(1 / 30)

--- a/python/testing/test_interactor_start.py
+++ b/python/testing/test_interactor_start.py
@@ -3,24 +3,27 @@ from functools import partial
 import f3d
 
 
-def stop_fn(inter: f3d.Interactor):
+def stop_fn(_state: f3d.InteractorState, inter: f3d.Interactor):
     inter.stop()
 
 
 def test_start_stop():
     engine = f3d.Engine.create(True)
     inter = engine.interactor
-    inter.start(1 / 30, partial(stop_fn, inter))
+    inter.set_event_loop_user_callback(partial(stop_fn, inter=inter))
+    inter.start(1 / 30)
 
 
 def test_request_render():
     engine = f3d.Engine.create(True)
     inter = engine.interactor
     inter.request_render()
-    inter.start(1 / 30, partial(stop_fn, inter))
+    inter.set_event_loop_user_callback(partial(stop_fn, inter=inter))
+    inter.start(1 / 30)
 
 
 def test_request_stop():
     engine = f3d.Engine.create(True)
-
-    engine.interactor.start(1 / 30, engine.interactor.request_stop)
+    inter = engine.interactor
+    inter.set_event_loop_user_callback(lambda _state: inter.request_stop())
+    inter.start(1 / 30)


### PR DESCRIPTION
### Describe your changes

Needed for #3051  

At the moment, when using `triggerEventLoop()` manually there's no way to specify the user callback.  
It would also be odd to pass the user callback each time we want to trigger the event loop manually, so let's move it to its own API so the user can set it once.

Also added a documentation for migration to 4.0.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
