### PR TITLE
Add interactive bind to cycle backface culling modes

### DIFF
--- a/library/options.json
+++ b/library/options.json
@@ -68,9 +68,10 @@
     },
     "backface_type": {
       "type": "string",
+      "default_value": "default",
       "domain": {
         "style": "enum",
-        "enum": ["visible", "hidden"]
+        "enum": ["default", "visible", "hidden"]
       }
     },
     "grid": {

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -1017,6 +1017,28 @@ interactor& interactor_impl::initCommands()
       "cycle_anti_aliasing", "cycle between the anti-aliasing method (none,fxaa,ssaa,taa)" });
 
   this->addCommand(
+    "cycle_backface_type",
+    [&](const std::vector<std::string>&)
+    {
+      auto& type = this->Internals->Options.render.backface_type;
+      if (!type.has_value())
+      {
+        type = "visible";
+      }
+      else if (*type == "visible")
+      {
+        type = "hidden";       
+      }
+      else if (*type == "hidden")
+      {
+        type = std::nullopt;
+      }
+      this->Internals->Window.render();
+    },
+    command_documentation_t{
+      "cycle_backface_type", "cycle between backface culling modes (default, visible, hidden)" });
+  
+  this->addCommand(
     "cycle_blending",
     [&](const std::vector<std::string>&)
     {
@@ -1580,6 +1602,22 @@ interactor& interactor_impl::initBindings()
     return std::pair("Anti-aliasing", std::move(desc));
   };
 
+  // "Cycle backface type" , "visible/hidden/default"
+  auto docBackface = [&]()
+  {
+    std::string desc;
+    const auto& type = this->Internals->Options.render.backface_type;
+    if (!type.has_value())
+    {
+      desc = "default"; 
+    }
+    else
+    {
+      desc = *type;
+    }
+    return std::pair("Backface type", std::move(desc));
+  };
+
   // "Cycle point sprites" , "none/sphere/gaussian"
   auto docPS = [&]()
   {
@@ -1696,6 +1734,7 @@ interactor& interactor_impl::initBindings()
   this->addBinding({mod_t::NONE, "P"}, "cycle_blending", "Scene", docBlend, f3d::interactor::BindingType::CYCLIC);
   this->addBinding({mod_t::NONE, "Q"}, "toggle render.effect.ambient_occlusion","Scene", std::bind(docTgl, "Ambient occlusion", std::cref(opts.render.effect.ambient_occlusion)), f3d::interactor::BindingType::TOGGLE);
   this->addBinding({mod_t::NONE, "A"}, "cycle_anti_aliasing","Scene", docAA, f3d::interactor::BindingType::CYCLIC);
+  this->addBinding({mod_t::CTRL, "B"},"cycle_backface_type","Scene",docBackface,f3d::interactor::BindingType::CYCLIC);
   this->addBinding({mod_t::NONE, "T"}, "toggle render.effect.tone_mapping","Scene", std::bind(docTgl, "Toggle tone mapping", std::cref(opts.render.effect.tone_mapping)), f3d::interactor::BindingType::TOGGLE);
   this->addBinding({mod_t::NONE, "E"}, "toggle render.show_edges","Scene", std::bind(docTglOpt, "Toggle edges display", std::cref(opts.render.show_edges)), f3d::interactor::BindingType::TOGGLE);
   this->addBinding({mod_t::NONE, "X"}, "toggle ui.axis","Scene", std::bind(docTgl, "Toggle axes display", std::cref(opts.ui.axis)), f3d::interactor::BindingType::TOGGLE);

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -992,6 +992,28 @@ interactor& interactor_impl::initCommands()
     command_documentation_t{
       "cycle_animation", "cycle scene.animation.index option using model information" });
 
+  this->addCommand(
+    "cycle_backface_type",
+    [&](const std::vector<std::string>&)
+    {
+      auto& type = this->Internals->Options.render.backface_type;
+      if (!type.has_value())
+      {
+        type = "visible";
+      }
+      else if (*type == "visible")
+      {
+        type = "hidden";       
+      }
+      else if (*type == "hidden")
+      {
+        type = std::nullopt;
+      }
+      this->Internals->Window.render();
+    },
+    command_documentation_t{
+      "cycle_backface_type", "cycle between backface culling modes (default, visible, hidden)" });
+  
   std::vector<std::string> cycleColoringValidArgs = { "field", "array", "component" };
   this->addCommand(
     "cycle_coloring",
@@ -1561,6 +1583,22 @@ interactor& interactor_impl::initBindings()
     }
   };
 
+  // "Cycle backface type" , "visible/hidden/default"
+  auto docBackface = [&]()
+  {
+    std::string desc;
+    const auto& type = this->Internals->Options.render.backface_type;
+    if (!type.has_value())
+    {
+      desc = "default"; 
+    }
+    else
+    {
+      desc = *type;
+    }
+    return std::pair("Backface type", std::move(desc));
+  };
+
   // "Cycle animation" , "animationName"
   auto docAnim = [&]()
   { return std::pair("Animation", this->Internals->AnimationManager->GetAnimationName()); };
@@ -1647,6 +1685,7 @@ interactor& interactor_impl::initBindings()
   this->addBinding({mod_t::NONE, "P"}, "cycle render.effect.blending.mode", "Scene", std::bind(docStr, "Blending", std::cref(opts.render.effect.blending.mode)), f3d::interactor::BindingType::CYCLIC);
   this->addBinding({mod_t::NONE, "Q"}, "toggle render.effect.ambient_occlusion","Scene", std::bind(docTgl, "Ambient occlusion", std::cref(opts.render.effect.ambient_occlusion)), f3d::interactor::BindingType::TOGGLE);
   this->addBinding({mod_t::NONE, "A"}, "cycle render.effect.antialiasing.mode","Scene", std::bind(docStr, "Anti-aliasing", std::cref(opts.render.effect.antialiasing.mode)), f3d::interactor::BindingType::CYCLIC);
+  this->addBinding({mod_t::CTRL, "B"},"cycle_backface_type","Scene",docBackface,f3d::interactor::BindingType::CYCLIC);
   this->addBinding({mod_t::NONE, "T"}, "toggle render.effect.tone_mapping","Scene", std::bind(docTgl, "Toggle tone mapping", std::cref(opts.render.effect.tone_mapping)), f3d::interactor::BindingType::TOGGLE);
   this->addBinding({mod_t::NONE, "E"}, "toggle render.show_edges","Scene", std::bind(docTglOpt, "Toggle edges display", std::cref(opts.render.show_edges)), f3d::interactor::BindingType::TOGGLE);
   this->addBinding({mod_t::NONE, "X"}, "toggle ui.axis","Scene", std::bind(docTgl, "Toggle axes display", std::cref(opts.ui.axis)), f3d::interactor::BindingType::TOGGLE);

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -991,28 +991,6 @@ interactor& interactor_impl::initCommands()
     [&](const std::vector<std::string>&) { this->Internals->AnimationManager->CycleAnimation(); },
     command_documentation_t{
       "cycle_animation", "cycle scene.animation.index option using model information" });
-
-  this->addCommand(
-    "cycle_backface_type",
-    [&](const std::vector<std::string>&)
-    {
-      auto& type = this->Internals->Options.render.backface_type;
-      if (!type.has_value())
-      {
-        type = "visible";
-      }
-      else if (*type == "visible")
-      {
-        type = "hidden";       
-      }
-      else if (*type == "hidden")
-      {
-        type = std::nullopt;
-      }
-      this->Internals->Window.render();
-    },
-    command_documentation_t{
-      "cycle_backface_type", "cycle between backface culling modes (default, visible, hidden)" });
   
   std::vector<std::string> cycleColoringValidArgs = { "field", "array", "component" };
   this->addCommand(
@@ -1583,22 +1561,6 @@ interactor& interactor_impl::initBindings()
     }
   };
 
-  // "Cycle backface type" , "visible/hidden/default"
-  auto docBackface = [&]()
-  {
-    std::string desc;
-    const auto& type = this->Internals->Options.render.backface_type;
-    if (!type.has_value())
-    {
-      desc = "default"; 
-    }
-    else
-    {
-      desc = *type;
-    }
-    return std::pair("Backface type", std::move(desc));
-  };
-
   // "Cycle animation" , "animationName"
   auto docAnim = [&]()
   { return std::pair("Animation", this->Internals->AnimationManager->GetAnimationName()); };
@@ -1685,7 +1647,7 @@ interactor& interactor_impl::initBindings()
   this->addBinding({mod_t::NONE, "P"}, "cycle render.effect.blending.mode", "Scene", std::bind(docStr, "Blending", std::cref(opts.render.effect.blending.mode)), f3d::interactor::BindingType::CYCLIC);
   this->addBinding({mod_t::NONE, "Q"}, "toggle render.effect.ambient_occlusion","Scene", std::bind(docTgl, "Ambient occlusion", std::cref(opts.render.effect.ambient_occlusion)), f3d::interactor::BindingType::TOGGLE);
   this->addBinding({mod_t::NONE, "A"}, "cycle render.effect.antialiasing.mode","Scene", std::bind(docStr, "Anti-aliasing", std::cref(opts.render.effect.antialiasing.mode)), f3d::interactor::BindingType::CYCLIC);
-  this->addBinding({mod_t::CTRL, "B"},"cycle_backface_type","Scene",docBackface,f3d::interactor::BindingType::CYCLIC);
+  this->addBinding({mod_t::CTRL, "B"}, "cycle render.backface_type", "Scene", std::bind(docStr, "Backface type", std::cref(opts.render.backface_type)), f3d::interactor::BindingType::CYCLIC);
   this->addBinding({mod_t::NONE, "T"}, "toggle render.effect.tone_mapping","Scene", std::bind(docTgl, "Toggle tone mapping", std::cref(opts.render.effect.tone_mapping)), f3d::interactor::BindingType::TOGGLE);
   this->addBinding({mod_t::NONE, "E"}, "toggle render.show_edges","Scene", std::bind(docTglOpt, "Toggle edges display", std::cref(opts.render.show_edges)), f3d::interactor::BindingType::TOGGLE);
   this->addBinding({mod_t::NONE, "X"}, "toggle ui.axis","Scene", std::bind(docTgl, "Toggle axes display", std::cref(opts.ui.axis)), f3d::interactor::BindingType::TOGGLE);

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -660,12 +660,27 @@ void window_impl::UpdateDynamicOptions()
       R"( is an invalid blending mode. Valid modes are: "none", "ddp", "sort", "sort_cpu", "stochastic")");
   }
 
+  vtkF3DRenderer::BackfaceCullingType backfaceType = vtkF3DRenderer::BackfaceCullingType::DEFAULT;
+  if (opt.render.backface_type == "visible")
+  {
+    backfaceType = vtkF3DRenderer::BackfaceCullingType::VISIBLE;
+  }
+  else if (opt.render.backface_type == "hidden")
+  {
+    backfaceType = vtkF3DRenderer::BackfaceCullingType::HIDDEN;
+  }
+  else if (opt.render.backface_type != "default")
+  {
+    log::warn(opt.render.backface_type,
+      R"( is an invalid backface type. Valid modes are: "default", "visible", "hidden")");
+  }
+
   renderer->SetUseSSAOPass(opt.render.effect.ambient_occlusion);
   renderer->SetAntiAliasingMode(aaMode);
   renderer->SetUseToneMappingPass(opt.render.effect.tone_mapping);
   renderer->SetDisplayDepth(opt.render.effect.display_depth);
   renderer->SetBlendingMode(blendMode);
-  renderer->SetBackfaceType(opt.render.backface_type);
+  renderer->SetBackfaceType(backfaceType);
   renderer->SetFinalShader(opt.render.effect.final_shader);
 
   renderer->SetBackground(opt.render.background.color.data());

--- a/vtkext/private/module/vtkF3DMetaImporter.h
+++ b/vtkext/private/module/vtkF3DMetaImporter.h
@@ -90,9 +90,11 @@ public:
       this->Actor->vtkProp3D::ShallowCopy(originalActor);
       this->Actor->SetMapper(this->Mapper);
       this->Mapper->InterpolateScalarsBeforeMappingOn();
+      this->OriginalProperty->DeepCopy(originalActor->GetProperty());
     }
     vtkNew<vtkActor> Actor;
     vtkNew<vtkPolyDataMapper> Mapper;
+    vtkNew<vtkProperty> OriginalProperty;
     vtkActor* OriginalActor;
   };
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -285,6 +285,7 @@ void vtkF3DRenderer::ReleaseGraphicsResources(vtkWindow* w)
 void vtkF3DRenderer::Initialize()
 {
   this->OriginalLightIntensities.clear();
+  this->OriginalBackfaceCulling.clear();
   this->RemoveAllViewProps();
   this->RemoveAllLights();
 
@@ -2522,11 +2523,27 @@ void vtkF3DRenderer::ConfigureActorsProperties()
       coloring.Actor->GetProperty()->SetPointSize(this->PointSize.value());
       coloring.OriginalActor->GetProperty()->SetPointSize(this->PointSize.value());
     }
+    
+    vtkProperty* prop = coloring.Actor->GetProperty();
+    vtkProperty* origProp = coloring.OriginalActor->GetProperty();
+    if (this->OriginalBackfaceCulling.count(prop) == 0)
+    {
+      this->OriginalBackfaceCulling[prop] = (prop->GetBackfaceCulling() != 0);
+    }
+    if (this->OriginalBackfaceCulling.count(origProp) == 0)
+    {
+      this->OriginalBackfaceCulling[origProp] = (origProp->GetBackfaceCulling() != 0);
+    }
 
     if (setBackfaceCulling)
     {
-      coloring.Actor->GetProperty()->SetBackfaceCulling(backfaceCulling);
-      coloring.OriginalActor->GetProperty()->SetBackfaceCulling(backfaceCulling);
+      prop->SetBackfaceCulling(backfaceCulling);
+      origProp->SetBackfaceCulling(backfaceCulling);
+    }
+    else
+    {
+      prop->SetBackfaceCulling(this->OriginalBackfaceCulling[prop]);
+      origProp->SetBackfaceCulling(this->OriginalBackfaceCulling[origProp]);
     }
 
     if (surfaceColor)

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1680,6 +1680,8 @@ void vtkF3DRenderer::SetBackfaceType(const std::optional<std::string>& backfaceT
   {
     this->BackfaceType = backfaceType;
     this->RenderPassesConfigured = false;
+    this->CheatSheetConfigured = false;
+    this->ActorsPropertiesConfigured = false;
   }
 }
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2526,13 +2526,10 @@ void vtkF3DRenderer::ConfigureActorsProperties()
     
     vtkProperty* prop = coloring.Actor->GetProperty();
     vtkProperty* origProp = coloring.OriginalActor->GetProperty();
-    if (this->OriginalBackfaceCulling.count(prop) == 0)
+    auto it = this->OriginalBackfaceCulling.find(prop);
+    if (it == this->OriginalBackfaceCulling.end())
     {
       this->OriginalBackfaceCulling[prop] = (prop->GetBackfaceCulling() != 0);
-    }
-    if (this->OriginalBackfaceCulling.count(origProp) == 0)
-    {
-      this->OriginalBackfaceCulling[origProp] = (origProp->GetBackfaceCulling() != 0);
     }
 
     if (setBackfaceCulling)
@@ -2543,7 +2540,7 @@ void vtkF3DRenderer::ConfigureActorsProperties()
     else
     {
       prop->SetBackfaceCulling(this->OriginalBackfaceCulling[prop]);
-      origProp->SetBackfaceCulling(this->OriginalBackfaceCulling[origProp]);
+      origProp->SetBackfaceCulling(this->OriginalBackfaceCulling[prop]);
     }
 
     if (surfaceColor)

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1774,6 +1774,8 @@ void vtkF3DRenderer::SetBackfaceType(const std::optional<std::string>& backfaceT
   {
     this->BackfaceType = backfaceType;
     this->RenderPassesConfigured = false;
+    this->CheatSheetConfigured = false;
+    this->ActorsPropertiesConfigured = false;
   }
 }
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -277,7 +277,6 @@ void vtkF3DRenderer::ReleaseGraphicsResources(vtkWindow* w)
 void vtkF3DRenderer::Initialize()
 {
   this->OriginalLightIntensities.clear();
-  this->OriginalBackfaceCulling.clear();
   this->RemoveAllViewProps();
   this->RemoveAllLights();
 
@@ -2623,6 +2622,20 @@ void vtkF3DRenderer::ConfigureActorsProperties()
 
   for (const auto& coloring : this->Importer->GetColoringActorsAndMappers())
   {
+    vtkProperty* prop = coloring.Actor->GetProperty();
+    vtkProperty* origProp = coloring.OriginalActor->GetProperty();
+
+    if (setBackfaceCulling)
+    {
+      prop->SetBackfaceCulling(backfaceCulling);
+      origProp->SetBackfaceCulling(backfaceCulling);
+    }
+    else
+    {
+      prop->SetBackfaceCulling(coloring.OriginalProperty->GetBackfaceCulling());
+      origProp->SetBackfaceCulling(coloring.OriginalProperty->GetBackfaceCulling());
+    }
+
     if (this->EdgeVisible.has_value())
     {
       coloring.Actor->GetProperty()->SetEdgeVisibility(this->EdgeVisible.value());
@@ -2639,25 +2652,6 @@ void vtkF3DRenderer::ConfigureActorsProperties()
     {
       coloring.Actor->GetProperty()->SetPointSize(this->PointSize.value());
       coloring.OriginalActor->GetProperty()->SetPointSize(this->PointSize.value());
-    }
-    
-    vtkProperty* prop = coloring.Actor->GetProperty();
-    vtkProperty* origProp = coloring.OriginalActor->GetProperty();
-    auto it = this->OriginalBackfaceCulling.find(prop);
-    if (it == this->OriginalBackfaceCulling.end())
-    {
-      this->OriginalBackfaceCulling[prop] = (prop->GetBackfaceCulling() != 0);
-    }
-
-    if (setBackfaceCulling)
-    {
-      prop->SetBackfaceCulling(backfaceCulling);
-      origProp->SetBackfaceCulling(backfaceCulling);
-    }
-    else
-    {
-      prop->SetBackfaceCulling(this->OriginalBackfaceCulling[prop]);
-      origProp->SetBackfaceCulling(this->OriginalBackfaceCulling[prop]);
     }
 
     if (surfaceColor)

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -277,6 +277,7 @@ void vtkF3DRenderer::ReleaseGraphicsResources(vtkWindow* w)
 void vtkF3DRenderer::Initialize()
 {
   this->OriginalLightIntensities.clear();
+  this->OriginalBackfaceCulling.clear();
   this->RemoveAllViewProps();
   this->RemoveAllLights();
 
@@ -2639,11 +2640,27 @@ void vtkF3DRenderer::ConfigureActorsProperties()
       coloring.Actor->GetProperty()->SetPointSize(this->PointSize.value());
       coloring.OriginalActor->GetProperty()->SetPointSize(this->PointSize.value());
     }
+    
+    vtkProperty* prop = coloring.Actor->GetProperty();
+    vtkProperty* origProp = coloring.OriginalActor->GetProperty();
+    if (this->OriginalBackfaceCulling.count(prop) == 0)
+    {
+      this->OriginalBackfaceCulling[prop] = (prop->GetBackfaceCulling() != 0);
+    }
+    if (this->OriginalBackfaceCulling.count(origProp) == 0)
+    {
+      this->OriginalBackfaceCulling[origProp] = (origProp->GetBackfaceCulling() != 0);
+    }
 
     if (setBackfaceCulling)
     {
-      coloring.Actor->GetProperty()->SetBackfaceCulling(backfaceCulling);
-      coloring.OriginalActor->GetProperty()->SetBackfaceCulling(backfaceCulling);
+      prop->SetBackfaceCulling(backfaceCulling);
+      origProp->SetBackfaceCulling(backfaceCulling);
+    }
+    else
+    {
+      prop->SetBackfaceCulling(this->OriginalBackfaceCulling[prop]);
+      origProp->SetBackfaceCulling(this->OriginalBackfaceCulling[origProp]);
     }
 
     if (surfaceColor)

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2643,13 +2643,10 @@ void vtkF3DRenderer::ConfigureActorsProperties()
     
     vtkProperty* prop = coloring.Actor->GetProperty();
     vtkProperty* origProp = coloring.OriginalActor->GetProperty();
-    if (this->OriginalBackfaceCulling.count(prop) == 0)
+    auto it = this->OriginalBackfaceCulling.find(prop);
+    if (it == this->OriginalBackfaceCulling.end())
     {
       this->OriginalBackfaceCulling[prop] = (prop->GetBackfaceCulling() != 0);
-    }
-    if (this->OriginalBackfaceCulling.count(origProp) == 0)
-    {
-      this->OriginalBackfaceCulling[origProp] = (origProp->GetBackfaceCulling() != 0);
     }
 
     if (setBackfaceCulling)
@@ -2660,7 +2657,7 @@ void vtkF3DRenderer::ConfigureActorsProperties()
     else
     {
       prop->SetBackfaceCulling(this->OriginalBackfaceCulling[prop]);
-      origProp->SetBackfaceCulling(this->OriginalBackfaceCulling[origProp]);
+      origProp->SetBackfaceCulling(this->OriginalBackfaceCulling[prop]);
     }
 
     if (surfaceColor)

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1768,7 +1768,7 @@ void vtkF3DRenderer::SetUseBlurBackground(bool use)
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRenderer::SetBackfaceType(const std::optional<std::string>& backfaceType)
+void vtkF3DRenderer::SetBackfaceType(const std::string& backfaceType)
 {
   if (this->BackfaceType != backfaceType)
   {
@@ -2601,14 +2601,14 @@ void vtkF3DRenderer::ConfigureActorsProperties()
 
   bool setBackfaceCulling = false;
   bool backfaceCulling = true;
-  if (this->BackfaceType.has_value())
+  if (this->BackfaceType != "default")
   {
     setBackfaceCulling = true;
-    if (this->BackfaceType.value() == "visible")
+    if (this->BackfaceType == "visible")
     {
       backfaceCulling = false;
     }
-    else if (this->BackfaceType.value() == "hidden")
+    else if (this->BackfaceType == "hidden")
     {
       backfaceCulling = true;
     }
@@ -2616,7 +2616,7 @@ void vtkF3DRenderer::ConfigureActorsProperties()
     {
       setBackfaceCulling = false;
       F3DLog::Print(F3DLog::Severity::Warning,
-        this->BackfaceType.value() + " is not a valid backface type, assuming it is not set");
+        this->BackfaceType + " is not a valid backface type, assuming it is not set");
     }
   }
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1768,11 +1768,11 @@ void vtkF3DRenderer::SetUseBlurBackground(bool use)
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRenderer::SetBackfaceType(const std::string& backfaceType)
+void vtkF3DRenderer::SetBackfaceType(BackfaceCullingType type)
 {
-  if (this->BackfaceType != backfaceType)
+  if (this->BackfaceType != type)
   {
-    this->BackfaceType = backfaceType;
+    this->BackfaceType = type;
     this->RenderPassesConfigured = false;
     this->CheatSheetConfigured = false;
     this->ActorsPropertiesConfigured = false;
@@ -2601,23 +2601,11 @@ void vtkF3DRenderer::ConfigureActorsProperties()
 
   bool setBackfaceCulling = false;
   bool backfaceCulling = true;
-  if (this->BackfaceType != "default")
+  
+  if (this->BackfaceType != BackfaceCullingType::DEFAULT)
   {
     setBackfaceCulling = true;
-    if (this->BackfaceType == "visible")
-    {
-      backfaceCulling = false;
-    }
-    else if (this->BackfaceType == "hidden")
-    {
-      backfaceCulling = true;
-    }
-    else
-    {
-      setBackfaceCulling = false;
-      F3DLog::Print(F3DLog::Severity::Warning,
-        this->BackfaceType + " is not a valid backface type, assuming it is not set");
-    }
+    backfaceCulling = (this->BackfaceType == BackfaceCullingType::HIDDEN);
   }
 
   for (const auto& coloring : this->Importer->GetColoringActorsAndMappers())

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -798,6 +798,8 @@ private:
   std::string CachePath;
 
   std::optional<std::string> BackfaceType;
+  std::map<vtkProperty*, bool> OriginalBackfaceCulling;
+
   std::optional<std::string> FinalShader;
 
   vtkF3DMetaImporter* Importer = nullptr;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -851,7 +851,6 @@ private:
   std::string CachePath;
 
   std::optional<std::string> BackfaceType;
-  std::map<vtkProperty*, bool> OriginalBackfaceCulling;
 
   std::optional<std::string> FinalShader;
 

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -851,6 +851,8 @@ private:
   std::string CachePath;
 
   std::optional<std::string> BackfaceType;
+  std::map<vtkProperty*, bool> OriginalBackfaceCulling;
+
   std::optional<std::string> FinalShader;
 
   vtkF3DMetaImporter* Importer = nullptr;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -84,6 +84,16 @@ public:
     CROSS
   };
 
+  /**
+   * Enum listing backface culling types.
+   */
+  enum class BackfaceCullingType : unsigned char
+  {
+    DEFAULT,
+    VISIBLE,
+    HIDDEN
+  };
+
   ///@{
   /**
    * Set visibility of different actors
@@ -162,7 +172,7 @@ public:
   void SetUseBlurBackground(bool use);
   void SetBlurCircleOfConfusionRadius(double radius);
   void SetRaytracingSamples(int samples);
-  void SetBackfaceType(const std::string& backfaceType);
+  void SetBackfaceType(BackfaceCullingType type);
   void SetFinalShader(const std::optional<std::string>& finalShader);
   ///@}
 
@@ -850,7 +860,7 @@ private:
 
   std::string CachePath;
 
-  std::string BackfaceType = "default";
+  BackfaceCullingType BackfaceType = BackfaceCullingType::DEFAULT;
   std::optional<std::string> FinalShader;
 
   vtkF3DMetaImporter* Importer = nullptr;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -162,7 +162,7 @@ public:
   void SetUseBlurBackground(bool use);
   void SetBlurCircleOfConfusionRadius(double radius);
   void SetRaytracingSamples(int samples);
-  void SetBackfaceType(const std::optional<std::string>& backfaceType);
+  void SetBackfaceType(const std::string& backfaceType);
   void SetFinalShader(const std::optional<std::string>& finalShader);
   ///@}
 
@@ -850,8 +850,7 @@ private:
 
   std::string CachePath;
 
-  std::optional<std::string> BackfaceType;
-
+  std::string BackfaceType = "default";
   std::optional<std::string> FinalShader;
 
   vtkF3DMetaImporter* Importer = nullptr;


### PR DESCRIPTION
### Describe your changes

This PR adds a command and a bind to control backface culling.

### Issue ticket number and link if any
#2697 

### Checklist for finalizing the PR

- [X] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [X] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [X] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
