### PR TITLE
CI: Rework to support proper cache pre-heating

### DIFF
--- a/.github/actions/alembic-install-dep/action.yml
+++ b/.github/actions/alembic-install-dep/action.yml
@@ -61,7 +61,7 @@ runs:
 
     # https://github.com/alembic/alembic/issues/476
     - name: Patch Alembic rpath issue
-      if: steps.cache-alembic.outputs.cache-hit != 'true' && inputs.version == '1.8.9'
+      if: steps.cache-alembic.outputs.cache-hit != 'true' && steps.alembic_ver.outputs.extract == '1.8.9'
       working-directory: ${{github.workspace}}/dependencies/alembic
       shell: bash
       run: patch -p1 < $GITHUB_ACTION_PATH/fix_cmake_rpath.patch

--- a/.github/actions/alembic-install-dep/action.yml
+++ b/.github/actions/alembic-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: alembic
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract imath version
       id: imath_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: imath
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/alembic-install-dep/action.yml
+++ b/.github/actions/alembic-install-dep/action.yml
@@ -51,7 +51,7 @@ runs:
       with:
         repository: alembic/alembic
         path: "./dependencies/alembic"
-        ref: ${{inputs.version}}
+        ref: ${{steps.alembic_ver.outputs.extract}}
 
     # https://github.com/alembic/alembic/issues/476
     - name: Patch Alembic rpath issue

--- a/.github/actions/alembic-install-dep/action.yml
+++ b/.github/actions/alembic-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract alembic version
       id: alembic_ver

--- a/.github/actions/alembic-install-dep/action.yml
+++ b/.github/actions/alembic-install-dep/action.yml
@@ -1,36 +1,48 @@
 name: "Install Alembic Dependency"
 description: "Install Alembic Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of alembic to build"
-    required: true
-  imath_version:
-    description: "Version of imath to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.imath_version }}" ]] || { echo "imath_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Cache Alembic
+    - name: Extract alembic version
+      id: alembic_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: alembic
+
+    - name: Extract imath version
+      id: imath_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: imath
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
+
+    - name: Cache alembic
       id: cache-alembic
       uses: actions/cache/restore@v5
       with:
         path: dependencies/alembic_install
-        key: alembic-${{inputs.version}}-${{inputs.imath_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-4
+        key: alembic-${{steps.alembic_ver.outputs.extract}}-${{steps.imath_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-4
 
     - name: Checkout Alembic
       if: steps.cache-alembic.outputs.cache-hit != 'true'

--- a/.github/actions/assimp-install-dep/action.yml
+++ b/.github/actions/assimp-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract assimp version
       id: assimp_ver

--- a/.github/actions/assimp-install-dep/action.yml
+++ b/.github/actions/assimp-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: assimp
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/assimp-install-dep/action.yml
+++ b/.github/actions/assimp-install-dep/action.yml
@@ -1,32 +1,41 @@
 name: "Install Assimp Dependency"
 description: "Install Assimp Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of assimp to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Cache ASSIMP
+    - name: Extract assimp version
+      id: assimp_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: assimp
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
+
+    - name: Cache assimp
       id: cache-assimp
       uses: actions/cache/restore@v5
       with:
         path: dependencies/assimp_install
-        key: assimp-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-2
+        key: assimp-${{steps.assimp_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
 
     - name: Checkout ASSIMP
       if: steps.cache-assimp.outputs.cache-hit != 'true'

--- a/.github/actions/assimp-install-dep/action.yml
+++ b/.github/actions/assimp-install-dep/action.yml
@@ -44,7 +44,7 @@ runs:
       with:
         repository: assimp/assimp
         path: "./dependencies/assimp"
-        ref: ${{inputs.version}}
+        ref: ${{steps.assimp_ver.outputs.extract}}
 
     - name: Setup ASSIMP
       if: steps.cache-assimp.outputs.cache-hit != 'true'

--- a/.github/actions/blosc-install-dep/action.yml
+++ b/.github/actions/blosc-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: blosc
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract zlib version
       id: zlib_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: zlib
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/blosc-install-dep/action.yml
+++ b/.github/actions/blosc-install-dep/action.yml
@@ -1,19 +1,13 @@
 name: "Install blosc Dependency"
 description: "Install blosc Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of blosc to build"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -21,16 +15,35 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract blosc version
+      id: blosc_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: blosc
+
+    - name: Extract zlib version
+      id: zlib_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: zlib
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache blosc
       id: cache-blosc
       uses: actions/cache/restore@v5
       with:
         path: dependencies/blosc_install
-        key: blosc-${{inputs.version}}-${{inputs.zlib_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-2
+        key: blosc-${{steps.blosc_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
 
     # Dependents: openvdb vtk
     - name: Checkout blosc
@@ -39,7 +52,7 @@ runs:
       with:
         repository: Blosc/c-blosc
         path: "./dependencies/blosc"
-        ref: ${{inputs.version}}
+        ref: ${{steps.blosc_ver.outputs.extract}}
 
     - name: Setup blosc
       if: steps.cache-blosc.outputs.cache-hit != 'true'

--- a/.github/actions/coverage-ci/action.yml
+++ b/.github/actions/coverage-ci/action.yml
@@ -1,6 +1,9 @@
 name: "Coverage CI"
 description: "Coverage CI"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   lfs_sha:
     description: "Cache LFS sha"
     required: true
@@ -8,75 +11,6 @@ inputs:
     description: "Codecov token, needed for non-forked workflows"
     required: false
     default: ""
-  alembic_version:
-    description: "Version of alembic to build"
-    required: false
-  assimp_version:
-    description: "Version of assimp to build"
-    required: false
-  blosc_version:
-    description: "Version of blosc to build"
-    required: true
-  curl_version:
-    description: "Version of curl to build"
-    required: false
-  draco_version:
-    description: "Version of draco to build"
-    required: false
-  gdal_version:
-    description: "Version of gdal to build"
-    required: false
-  geotiff_version:
-    description: "Version of geotiff to build"
-    required: false
-  imath_version:
-    description: "Version of imath to build"
-    required: false
-  occt_version:
-    description: "Version of occt to build"
-    required: false
-  openexr_version:
-    description: "Version of openexr to build"
-    required: false
-  openvdb_version:
-    description: "Version of openvdb to build"
-    required: false
-  ospray_version:
-    description: "Version of ospray to build"
-    required: false
-  pdal_version:
-    description: "Version of pdal to build"
-    required: false
-  proj_version:
-    description: "Version of proj to build"
-    required: false
-  sqlite_csb_version:
-    description: "Version of csb providing sqlite to build against"
-    required: false
-  tbb_version:
-    description: "Version of tbb to build"
-    required: true
-  tiff_version:
-    description: "Version of tiff to build"
-    required: false
-  usd_version:
-    description: "Version of usd to build"
-    required: false
-  vtk_version:
-    description: "Version of vtk to build"
-    required: true
-  webp_version:
-    description: "Version of webp to build"
-    required: true
-  webifc_version:
-    description: "Version of webifc to build"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -84,8 +18,8 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
+        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
         [[ "${{ inputs.lfs_sha }}" ]] || { echo "lfs_sha input is empty" ; exit 1; }
-        [[ "${{ inputs.vtk_version }}" ]] || { echo "vtk_version input is empty" ; exit 1; }
 
     - name: Recover LFS Data
       uses: f3d-app/lfs-data-cache-action@v2
@@ -97,46 +31,12 @@ runs:
     - name: Install all F3D dependencies
       uses: ./source/.github/actions/generic-dependencies
       with:
-        alembic_version: ${{inputs.alembic_version}}
-        assimp_version: ${{inputs.assimp_version}}
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        draco_version: ${{inputs.draco_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        imath_version: ${{inputs.imath_version}}
-        occt_version: ${{inputs.occt_version}}
-        openexr_version: ${{inputs.openexr_version}}
-        openvdb_version: ${{inputs.openvdb_version}}
-        ospray_version: ${{inputs.ospray_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        usd_version: ${{inputs.usd_version}}
-        webifc_version: ${{inputs.webifc_version}}
-        webp_version: ${{inputs.webp_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        openvdb_version: ${{inputs.openvdb_version}}
-        ospray_version: ${{inputs.ospray_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        vtk_version: ${{inputs.vtk_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
 
     # coverage build is done in source as it seems to be required for codecov
     # CMAKE_MODULE_PATH is required because of

--- a/.github/actions/curl-install-dep/action.yml
+++ b/.github/actions/curl-install-dep/action.yml
@@ -1,19 +1,13 @@
 name: "Install curl Dependency"
 description: "Install curl Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of curl to build"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -21,16 +15,35 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract curl version
+      id: curl_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: curl
+
+    - name: Extract zlib version
+      id: zlib_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: zlib
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache curl
       id: cache-curl
       uses: actions/cache/restore@v5
       with:
         path: dependencies/curl_install
-        key: curl-${{inputs.version}}-${{ inputs.zlib_version }}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-2
+        key: curl-${{steps.curl_ver.outputs.extract}}-${{ steps.zlib_ver.outputs.extract }}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
 
     # Dependents: pdal vtk
     - name: Checkout curl
@@ -39,7 +52,7 @@ runs:
       with:
         repository: curl/curl
         path: "./dependencies/curl"
-        ref: ${{inputs.version}}
+        ref: ${{steps.curl_ver.outputs.extract}}
 
     - name: Setup curl
       if: steps.cache-curl.outputs.cache-hit != 'true'

--- a/.github/actions/curl-install-dep/action.yml
+++ b/.github/actions/curl-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: curl
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract zlib version
       id: zlib_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: zlib
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/draco-install-dep/action.yml
+++ b/.github/actions/draco-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: draco
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/draco-install-dep/action.yml
+++ b/.github/actions/draco-install-dep/action.yml
@@ -44,7 +44,7 @@ runs:
       with:
         repository: google/draco
         path: "./dependencies/draco"
-        ref: ${{inputs.version}}
+        ref: ${{steps.draco_ver.outputs.extract}}
 
     - name: Setup Draco
       if: steps.cache-draco.outputs.cache-hit != 'true'

--- a/.github/actions/draco-install-dep/action.yml
+++ b/.github/actions/draco-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract draco version
       id: draco_ver

--- a/.github/actions/draco-install-dep/action.yml
+++ b/.github/actions/draco-install-dep/action.yml
@@ -1,32 +1,41 @@
 name: "Install Draco Dependency"
 description: "Install Draco Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of draco to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Cache Draco
+    - name: Extract draco version
+      id: draco_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: draco
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
+
+    - name: Cache draco
       id: cache-draco
       uses: actions/cache/restore@v5
       with:
         path: dependencies/draco_install
-        key: draco-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
+        key: draco-${{steps.draco_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-1
 
     - name: Checkout Draco
       if: steps.cache-draco.outputs.cache-hit != 'true'

--- a/.github/actions/external-build-ci/action.yml
+++ b/.github/actions/external-build-ci/action.yml
@@ -1,20 +1,8 @@
 name: "External build CI"
 description: "External build CI"
 inputs:
-  blosc_version:
-    description: "Version of blosc to build"
-    required: true
-  tbb_version:
-    description: "Version of tbb to build"
-    required: true
-  vtk_version:
-    description: "Version of vtk to build"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
+  versions_file:
+    description: "File to recover versions from"
     required: true
 
 runs:
@@ -23,7 +11,7 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.vtk_version }}" ]] || { echo "vtk_version input is empty" ; exit 1; }
+        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Create top level CMakeLists.txt
       shell: bash
@@ -38,23 +26,18 @@ runs:
         cd dependencies
         mkdir install
 
-    - name: Install VTK dependencies TODO
+    - name: Install VTK dependencies
       uses: ./source/f3d/.github/actions/vtk-dependencies
       with:
         source_dir: ./source/f3d
-        blosc_version: ${{inputs.blosc_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
+        optdeps_label: no-optdeps
 
     - name: Install VTK dependency
       uses: ./source/f3d/.github/actions/vtk-install-dep
       with:
-        blosc_version: ${{inputs.blosc_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        vtk_version: ${{inputs.vtk_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
+        optdeps_label: no-optdeps
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/external-build-ci/action.yml
+++ b/.github/actions/external-build-ci/action.yml
@@ -18,14 +18,6 @@ runs:
       working-directory: ${{github.workspace}}
       run: echo -e "cmake_minimum_required(VERSION 3.21)\nproject(toplevel)\nadd_subdirectory(f3d)" > source/CMakeLists.txt
 
-    - name: Dependencies Dir
-      shell: bash
-      working-directory: ${{github.workspace}}
-      run: |
-        mkdir dependencies
-        cd dependencies
-        mkdir install
-
     - name: Install VTK dependencies
       uses: ./source/f3d/.github/actions/vtk-dependencies
       with:

--- a/.github/actions/external-build-ci/action.yml
+++ b/.github/actions/external-build-ci/action.yml
@@ -38,7 +38,7 @@ runs:
         cd dependencies
         mkdir install
 
-    - name: Install VTK dependencies
+    - name: Install VTK dependencies TODO
       uses: ./source/f3d/.github/actions/vtk-dependencies
       with:
         source_dir: ./source/f3d

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -7,7 +7,7 @@ inputs:
   mindeps_label:
     description: "Label to check for minimal version dependencies"
     required: false
-    default: "mindeps"
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -56,7 +56,7 @@ runs:
       uses: ./source/.github/actions/pybind11-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        cpu: ${{inputs.cpu}}
 
     - name: Install USD dependency
       uses: ./source/.github/actions/usd-install-dep

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -1,129 +1,77 @@
 name: "Install F3D Dependencies"
 description: "Install multiple F3D Dependencies"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
+  mindeps_label:
+    description: "Label to check for minimal version dependencies"
+    required: false
+    default: "mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  alembic_version:
-    description: "Version of alembic to build"
-    required: false
-  assimp_version:
-    description: "Version of assimp to build"
-    required: false
-  draco_version:
-    description: "Version of draco to build"
-    required: false
-  imath_version:
-    description: "Version of imath to build"
-    required: false
-  occt_version:
-    description: "Version of occt to build"
-    required: false
-  openexr_version:
-    description: "Version of openexr to build"
-    required: false
-  pybind11_version:
-    description: "Version of pybind11 to build"
-    required: false
-  tbb_version:
-    description: "Version of tbb to build"
-    required: true
-  usd_version:
-    description: "Version of usd to build"
-    required: false
-  webp_version:
-    description: "Version of webp to build"
-    required: false
-  webifc_version:
-    description: "Version of webifc to build"
-    required: false
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Install OCCT dependency
-      if: inputs.occt_version != ''
       uses: ./source/.github/actions/occt-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.occt_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install Assimp dependency
-      if: inputs.assimp_version != ''
       uses: ./source/.github/actions/assimp-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.assimp_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install Draco dependency
-      if: inputs.draco_version != ''
       uses: ./source/.github/actions/draco-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.draco_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install Imath dependency
-      if: inputs.imath_version != ''
       uses: ./source/.github/actions/imath-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.imath_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install OpenEXR dependency
-      if: inputs.openexr_version != ''
       uses: ./source/.github/actions/openexr-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.openexr_version}}
-        imath_version: ${{inputs.imath_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install Alembic dependency
-      if: inputs.alembic_version != ''
       uses: ./source/.github/actions/alembic-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.alembic_version}}
-        imath_version: ${{inputs.imath_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install pybind11 dependency
-      if: inputs.pybind11_version != ''
       uses: ./source/.github/actions/pybind11-install-dep
       with:
         version: ${{inputs.pybind11_version}}
         global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install USD dependency
-      if: inputs.usd_version != ''
       uses: ./source/.github/actions/usd-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.usd_version}}
-        openexr_version: ${{inputs.openexr_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install webp dependency
-      if: inputs.webp_version != ''
       uses: ./source/.github/actions/webp-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.webp_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install webifc dependency
-      if: inputs.webifc_version != ''
       uses: ./source/.github/actions/webifc-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.webifc_version}}
-        global_cache_index: ${{inputs.global_cache_index}}

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -20,58 +20,68 @@ runs:
       uses: ./source/.github/actions/occt-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install Assimp dependency
       uses: ./source/.github/actions/assimp-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install Draco dependency
       uses: ./source/.github/actions/draco-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install Imath dependency
       uses: ./source/.github/actions/imath-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install OpenEXR dependency
       uses: ./source/.github/actions/openexr-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install Alembic dependency
       uses: ./source/.github/actions/alembic-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install pybind11 dependency
       uses: ./source/.github/actions/pybind11-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install USD dependency
       uses: ./source/.github/actions/usd-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install webp dependency
       uses: ./source/.github/actions/webp-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install webifc dependency
       uses: ./source/.github/actions/webifc-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}

--- a/.github/actions/f3d-dependencies/action.yml
+++ b/.github/actions/f3d-dependencies/action.yml
@@ -55,7 +55,7 @@ runs:
     - name: Install pybind11 dependency
       uses: ./source/.github/actions/pybind11-install-dep
       with:
-        version: ${{inputs.pybind11_version}}
+        versions_file: ${{inputs.versions_file}}
         global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install USD dependency

--- a/.github/actions/gdal-install-dep/action.yml
+++ b/.github/actions/gdal-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: gdal
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract geotiff version
       id: geotiff_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: geotiff
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract proj version
       id: proj_ver
@@ -37,6 +43,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: proj
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract sqlite_csb version
       id: sqlite_csb_ver
@@ -44,6 +51,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: sqlite_csb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract tiff version
       id: tiff_ver
@@ -51,6 +59,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: tiff
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract zlib version
       id: zlib_ver
@@ -58,6 +67,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: zlib
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/gdal-install-dep/action.yml
+++ b/.github/actions/gdal-install-dep/action.yml
@@ -57,13 +57,21 @@ runs:
       uses: f3d-app/extract-version-action@main
       with:
         file: ${{inputs.versions_file}}
+        name: zlib
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache gdal
       id: cache-gdal
       uses: actions/cache/restore@v5
       with:
         path: dependencies/gdal_install
-        key: gdal-${{steps.gdal_ver.outputs.extract}}-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-5
+        key: gdal-${{steps.gdal_ver.outputs.extract}}-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_csb_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-5
 
     # Dependents: pdal vtk
     - name: Checkout gdal

--- a/.github/actions/gdal-install-dep/action.yml
+++ b/.github/actions/gdal-install-dep/action.yml
@@ -1,31 +1,13 @@
 name: "Install gdal Dependency"
 description: "Install gdal Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of gdal to build"
-    required: true
-  geotiff_version:
-    description: "Version of geotiff to build against"
-    required: true
-  proj_version:
-    description: "Version of proj to build against"
-    required: true
-  sqlite_csb_version:
-    description: "Version of csb providing sqlite to build against"
-    required: true
-  tiff_version:
-    description: "Version of tiff to build against"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -33,20 +15,55 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.geotiff_version }}" ]] || { echo "geotiff_version input is empty" ; exit 1; }
-        [[ "${{ inputs.proj_version }}" ]] || { echo "proj_version input is empty" ; exit 1; }
-        [[ "${{ inputs.sqlite_csb_version }}" ]] || { echo "sqlite_csb_version input is empty" ; exit 1; }
-        [[ "${{ inputs.tiff_version }}" ]] || { echo "tiff_version input is empty" ; exit 1; }
-        [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract gdal version
+      id: gdal_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: gdal
+
+    - name: Extract geotiff version
+      id: geotiff_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: geotiff
+
+    - name: Extract proj version
+      id: proj_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: proj
+
+    - name: Extract sqlite_csb version
+      id: sqlite_csb_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: sqlite_csb
+
+    - name: Extract tiff version
+      id: tiff_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: tiff
+
+    - name: Extract zlib version
+      id: zlib_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
 
     - name: Cache gdal
       id: cache-gdal
       uses: actions/cache/restore@v5
       with:
         path: dependencies/gdal_install
-        key: gdal-${{inputs.version}}-${{ inputs.geotiff_version }}-${{inputs.proj_version}}-${{ inputs.sqlite_csb_version }}-${{inputs.tiff_version}}-${{inputs.zlib_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-5
+        key: gdal-${{steps.gdal_ver.outputs.extract}}-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-5
 
     # Dependents: pdal vtk
     - name: Checkout gdal
@@ -55,7 +72,7 @@ runs:
       with:
         repository: OSGeo/gdal
         path: "./dependencies/gdal"
-        ref: ${{inputs.version}}
+        ref: ${{steps.gdal_ver.outputs.extract}}
 
     # https://github.com/OSGeo/gdal/issues/14015
     - name: Patch GDAL rpath issue

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -5,10 +5,20 @@ inputs:
     description: "Name of the build"
     required: false
     default: "standard"
-  optional_deps_label:
-    description: "Label to optional dependencies"
+  versions_file:
+    description: "File to recover versions from"
+    required: true
+  vtk_version:
+    description: "Descriptive VTK version to build against"
+    required: true
+  optdeps_label:
+    description: "Label to flag for optional dependencies"
     required: false
-    default: "optional-deps"
+    default: "optdeps"
+  mindeps_label:
+    description: "Label to flag for minimal version dependencies"
+    required: false
+    default: "mindeps"
   exclude_deprecated_label:
     description: "Label to control deprecated exclusion"
     required: false
@@ -32,84 +42,6 @@ inputs:
   lfs_sha:
     description: "Cache LFS sha"
     required: true
-  alembic_version:
-    description: "Version of alembic to build"
-    required: false
-  assimp_version:
-    description: "Version of assimp to build"
-    required: false
-  blosc_version:
-    description: "Version of blosc to build"
-    required: true
-  curl_version:
-    description: "Version of gdal to build"
-    required: false
-  draco_version:
-    description: "Version of draco to build"
-    required: false
-  gdal_version:
-    description: "Version of gdal to build"
-    required: false
-  geotiff_version:
-    description: "Version of geotiff to build"
-    required: false
-  imath_version:
-    description: "Version of imath to build"
-    required: false
-  java_version:
-    description: "Version of java to install"
-    required: false
-  occt_version:
-    description: "Version of occt to build"
-    required: false
-  openexr_version:
-    description: "Version of openexr to build"
-    required: false
-  openvdb_version:
-    description: "Version of openvdb to build"
-    required: false
-  ospray_version:
-    description: "Version of ospray to build"
-    required: false
-  pdal_version:
-    description: "Version of pdal to build"
-    required: false
-  proj_version:
-    description: "Version of proj to build"
-    required: false
-  pybind11_version:
-    description: "Version of pybind11 to build"
-    required: false
-  python_version:
-    description: "Version of python to install"
-    required: false
-  sqlite_csb_version:
-    description: "Version of csb providing sqlite to build against"
-    required: false
-  tiff_version:
-    description: "Version of tiff to build"
-    required: false
-  tbb_version:
-    description: "Version of tbb to build"
-    required: true
-  usd_version:
-    description: "Version of usd to build"
-    required: false
-  vtk_version:
-    description: "VTK version"
-    required: true
-  webp_version:
-    description: "Version of webp to build"
-    required: true
-  webifc_version:
-    description: "Version of webifc to build"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -117,6 +49,7 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
+        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
         [[ "${{ inputs.lfs_sha }}" ]] || { echo "lfs_sha input is empty" ; exit 1; }
         [[ "${{ inputs.vtk_version }}" ]] || { echo "vtk_version input is empty" ; exit 1; }
 
@@ -130,76 +63,56 @@ runs:
     - name: Install all F3D dependencies
       uses: ./source/.github/actions/generic-dependencies
       with:
-        cpu: ${{inputs.cpu}}
-        alembic_version: ${{inputs.alembic_version}}
-        assimp_version: ${{inputs.assimp_version}}
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        draco_version: ${{inputs.draco_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        imath_version: ${{inputs.imath_version}}
-        occt_version: ${{inputs.occt_version}}
-        openexr_version: ${{inputs.openexr_version}}
-        openvdb_version: ${{inputs.openvdb_version}}
-        ospray_version: ${{inputs.ospray_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        pybind11_version: ${{inputs.pybind11_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        usd_version: ${{inputs.usd_version}}
-        webifc_version: ${{inputs.webifc_version}}
-        webp_version: ${{inputs.webp_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
+        optdeps_label: ${{matrix.optdeps_label}}
+        mindeps_label: ${{matrix.mindeps_label}}
+        cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
-        cpu: ${{inputs.cpu}}
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        openvdb_version: ${{inputs.openvdb_version}}
-        ospray_version: ${{inputs.ospray_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
+        versions_file: ${{inputs.versions_file}}
+        optdeps_label: ${{matrix.optdeps_label}}
+        mindeps_label: ${{matrix.mindeps_label}}
+        cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
         vtk_version: ${{inputs.vtk_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+
+    - name: Extract python version
+      id: python_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: python
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Set up Python
-      if: |
-        inputs.optional_deps_label == 'optional-deps' &&
-        inputs.python_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: actions/setup-python@v6
       with:
-        python-version: ${{inputs.python_version}}
+        python-version: ${{steps.python_ver.outputs.extract}}
 
     - name: Install Python dependencies
-      if: |
-        inputs.optional_deps_label == 'optional-deps' &&
-        inputs.python_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       shell: bash
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest==8.0.0
         python -m pip install pybind11_stubgen
 
+    - name: Extract java version
+      id: java_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: java
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
     - name: Setup JDK
-      if: |
-        inputs.optional_deps_label == 'optional-deps' &&
-        inputs.java_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: actions/setup-java@v5
       with:
         distribution: "temurin"
-        java-version: ${{inputs.java_version}}
+        java-version: ${{steps.java_ver.outputs.extract}}
 
     - name: Setup Directories
       shell: bash
@@ -218,7 +131,7 @@ runs:
     - name: Set DYLD_LIBRARY_PATH on macOS for OSPRay dynamic loading
       if: |
         runner.os == 'macOS' &&
-        inputs.ospray_version != ''
+        inputs.optdeps_label == 'optdeps'
       shell: bash
       run: echo "DYLD_LIBRARY_PATH=$(pwd)/dependencies/install/lib" >> $GITHUB_ENV
 
@@ -252,33 +165,33 @@ runs:
         -DCMAKE_INSTALL_PREFIX:PATH=../install
         -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
         -DCMAKE_POLICY_DEFAULT_CMP0091=NEW
-        -DCMAKE_MODULE_PATH=${{ inputs.optional_deps_label == 'optional-deps' && '$(pwd)/../dependencies/install/lib/cmake/OpenVDB/' || '' }}
+        -DCMAKE_MODULE_PATH=${{ inputs.optdeps_label == 'optdeps' && '$(pwd)/../dependencies/install/lib/cmake/OpenVDB/' || '' }}
         -DCMAKE_PREFIX_PATH:PATH=$(pwd)/../dependencies/install/
         -DF3D_BINDINGS_C=ON
-        -DF3D_BINDINGS_JAVA=${{ (runner.os != 'macOS' || inputs.cpu == 'arm64') && inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_BINDINGS_PYTHON=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_BINDINGS_PYTHON_GENERATE_STUBS=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
+        -DF3D_BINDINGS_JAVA=${{ (runner.os != 'macOS' || inputs.cpu == 'arm64') && inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_BINDINGS_PYTHON=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_BINDINGS_PYTHON_GENERATE_STUBS=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
         -DF3D_EXCLUDE_DEPRECATED=${{ inputs.exclude_deprecated_label == 'exclude-deprecated' && 'ON' || 'OFF' }}
         -DF3D_LINUX_GENERATE_MAN=ON
         -DF3D_LINUX_INSTALL_DEFAULT_CONFIGURATION_FILE_IN_PREFIX=ON
         -DF3D_MACOS_BUNDLE=${{ inputs.bundle_label == 'bundle' && 'ON' || 'OFF' }}
-        -DF3D_MODULE_EXR=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_MODULE_WEBP=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_MODULE_RAYTRACING=${{ inputs.ospray_version != '' && 'ON' || 'OFF' }}
-        -DF3D_MODULE_UI=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_MODULE_DMON=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_MODULE_TINYFILEDIALOGS=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
+        -DF3D_MODULE_EXR=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_MODULE_WEBP=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_MODULE_RAYTRACING=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_MODULE_UI=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_MODULE_DMON=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_MODULE_TINYFILEDIALOGS=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
         -DF3D_PLUGINS_STATIC_BUILD=${{ inputs.bundle_label == 'bundle' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_BUILD_ALEMBIC=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_BUILD_ASSIMP=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_BUILD_DRACO=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_BUILD_HDF=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_BUILD_WEBIFC=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_BUILD_OCCT=${{ inputs.optional_deps_label == 'optional-deps' && inputs.static_label == 'no-static' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_BUILD_PDAL=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_BUILD_USD=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_BUILD_VDB=${{ inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
-        -DF3D_PLUGIN_OCCT_COLORING_SUPPORT=${{ inputs.occt_version != 'V7_6_3' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_BUILD_ALEMBIC=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_BUILD_ASSIMP=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_BUILD_DRACO=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_BUILD_HDF=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_BUILD_WEBIFC=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_BUILD_OCCT=${{ inputs.optdeps_label == 'optdeps' && inputs.static_label == 'no-static' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_BUILD_PDAL=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_BUILD_USD=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_BUILD_VDB=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
+        -DF3D_PLUGIN_OCCT_COLORING_SUPPORT=${{ inputs.mindeps_label != 'mindeps' && 'ON' || 'OFF' }}
         -DF3D_STRICT_BUILD=ON
         -DF3D_TESTING_ENABLE_EGL_TESTS=${{ runner.os == 'Linux' && 'ON' || 'OFF' }}
         -DF3D_TESTING_ENABLE_EXTERNAL_GLFW=${{ (runner.os == 'Linux' && inputs.rendering_backend == 'auto') && 'ON' || 'OFF' }}
@@ -386,7 +299,7 @@ runs:
 
     - name: Build and configure python externally
       if: |
-        inputs.optional_deps_label == 'optional-deps' &&
+        inputs.optdeps_label == 'optdeps' &&
         inputs.static_label == 'no-static'
       shell: bash
       working-directory: ${{github.workspace}}
@@ -404,7 +317,7 @@ runs:
         -Df3d_DIR:PATH=$(pwd)/install/lib/cmake/f3d
         -DBUILD_TESTING=ON
         -DF3D_ENABLE_C_EXAMPLES=ON
-        -DF3D_ENABLE_JAVA_EXAMPLES=${{ (runner.os != 'macOS' || inputs.cpu == 'arm64') && inputs.optional_deps_label == 'optional-deps' && 'ON' || 'OFF' }}
+        -DF3D_ENABLE_JAVA_EXAMPLES=${{ (runner.os != 'macOS' || inputs.cpu == 'arm64') && inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
         -DF3D_EXAMPLES_EXTERNAL_GLFW=${{ (runner.os == 'Linux' && inputs.rendering_backend == 'auto') && 'ON' || 'OFF' }}
         -DF3D_EXAMPLES_EXTERNAL_QT=${{ (runner.os == 'Linux' && inputs.rendering_backend == 'auto') && 'ON' || 'OFF' }}
         -DF3D_EXAMPLES_EXTERNAL_FLTK=${{ (runner.os == 'Linux' && inputs.rendering_backend == 'auto') && 'ON' || 'OFF' }}
@@ -482,7 +395,7 @@ runs:
     - name: Check F3D_PLUGINS_PATH using plugin example
       if: |
         inputs.vtk_version != 'v9.4.2' && inputs.vtk_version != 'v9.5.2' &&
-        inputs.cpu != 'arm64' && inputs.static_label == 'no-static' && inputs.optional_deps_label == 'optional-deps'
+        inputs.cpu != 'arm64' && inputs.static_label == 'no-static' && inputs.optdeps_label == 'optdeps'
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: F3D_PLUGINS_PATH=$(pwd)/../build_plugins/example-plugin${{ runner.os == 'Windows' && '/Release' || null }} ${{ env.F3D_BIN_PATH }} ../source/examples/plugins/example-plugin/data.expl --load-plugins=example --output=output/install_example_plugin_output.png --reference=../source/.github/baselines/install_example_plugin_output.png --resolution=300,300 --rendering-backend=${{ inputs.rendering_backend }} --verbose
@@ -500,7 +413,7 @@ runs:
     - name: Check Install
       if: |
         inputs.vtk_version != 'v9.4.2' && inputs.vtk_version != 'v9.5.2'
-        && inputs.cpu != 'arm64' && inputs.optional_deps_label == 'optional-deps'
+        && inputs.cpu != 'arm64' && inputs.optdeps_label == 'optdeps'
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: |
@@ -509,7 +422,7 @@ runs:
     - name: Check Install plugins
       if: |
         inputs.vtk_version != 'v9.4.2' && inputs.vtk_version != 'v9.5.2' && inputs.cpu != 'arm64'
-        && inputs.static_label == 'no-static' && inputs.optional_deps_label == 'optional-deps'
+        && inputs.static_label == 'no-static' && inputs.optdeps_label == 'optdeps'
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: |

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -18,7 +18,7 @@ inputs:
   mindeps_label:
     description: "Label to flag for minimal version dependencies"
     required: false
-    default: "mindeps"
+    default: "no-mindeps"
   exclude_deprecated_label:
     description: "Label to control deprecated exclusion"
     required: false

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -66,7 +66,7 @@ runs:
         versions_file: ${{inputs.versions_file}}
         optdeps_label: ${{inputs.optdeps_label}}
         mindeps_label: ${{inputs.mindeps_label}}
-        cpu: ${{ runner.os == 'macos-15' && 'arm64' || 'x86_64' }}
+        cpu: ${{inputs.cpu}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
@@ -74,7 +74,7 @@ runs:
         versions_file: ${{inputs.versions_file}}
         optdeps_label: ${{inputs.optdeps_label}}
         mindeps_label: ${{inputs.mindeps_label}}
-        cpu: ${{ runner.os == 'macos-15' && 'arm64' || 'x86_64' }}
+        cpu: ${{inputs.cpu}}
         vtk_version: ${{inputs.vtk_version}}
 
     - name: Extract python version

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -64,17 +64,17 @@ runs:
       uses: ./source/.github/actions/generic-dependencies
       with:
         versions_file: ${{inputs.versions_file}}
-        optdeps_label: ${{matrix.optdeps_label}}
-        mindeps_label: ${{matrix.mindeps_label}}
-        cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
+        optdeps_label: ${{inputs.optdeps_label}}
+        mindeps_label: ${{inputs.mindeps_label}}
+        cpu: ${{ runner.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
-        optdeps_label: ${{matrix.optdeps_label}}
-        mindeps_label: ${{matrix.mindeps_label}}
-        cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
+        optdeps_label: ${{inputs.optdeps_label}}
+        mindeps_label: ${{inputs.mindeps_label}}
+        cpu: ${{ runner.os == 'macos-15' && 'arm64' || 'x86_64' }}
         vtk_version: ${{inputs.vtk_version}}
 
     - name: Extract python version

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -1,6 +1,9 @@
 name: "Install F3D dependencies"
 description: "Install all F3D Dependencies but VTK"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   optional_deps_label:
     description: "Label to optional dependencies"
     required: false
@@ -9,79 +12,15 @@ inputs:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  alembic_version:
-    description: "Version of alembic to build"
-    required: false
-  assimp_version:
-    description: "Version of assimp to build"
-    required: false
-  blosc_version:
-    description: "Version of blosc to build"
-    required: true
-  curl_version:
-    description: "Version of curl to build"
-    required: false
-  draco_version:
-    description: "Version of draco to build"
-    required: false
-  gdal_version:
-    description: "Version of gdal to build"
-    required: false
-  geotiff_version:
-    description: "Version of geotiff to build"
-    required: false
-  imath_version:
-    description: "Version of imath to build"
-    required: false
-  occt_version:
-    description: "Version of occt to build"
-    required: false
-  openexr_version:
-    description: "Version of openexr to build"
-    required: false
-  openvdb_version:
-    description: "Version of openvdb to build"
-    required: false
-  ospray_version:
-    description: "Version of ospray to build"
-    required: false
-  pdal_version:
-    description: "Version of pdal to build"
-    required: false
-  proj_version:
-    description: "Version of proj to build"
-    required: false
-  pybind11_version:
-    description: "Version of pybind11 to build"
-    required: false
-  sqlite_csb_version:
-    description: "Version of sqlite common superbuild to build"
-    required: false
-  tbb_version:
-    description: "Version of tbb to build"
-    required: true
-  tiff_version:
-    description: "Version of tiff to build"
-    required: false
-  usd_version:
-    description: "Version of usd to build"
-    required: false
-  webp_version:
-    description: "Version of webp to build"
-    required: false
-  webifc_version:
-    description: "Version of webifc to build"
-    required: false
-  zlib_version:
-    description: "Version of zlib to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
+
     - name: Dependencies Dir
       shell: bash
       working-directory: ${{github.workspace}}
@@ -93,42 +32,19 @@ runs:
     - name: Install VTK dependencies
       uses: ./source/.github/actions/vtk-dependencies
       with:
+        versions_file: .github/workflows/versions.json
         cpu: ${{inputs.cpu}}
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        openvdb_version: ${{inputs.openvdb_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install Raytracing Dependencies
       if: inputs.ospray_version != ''
       uses: ./source/.github/actions/ospray-sb-install-dep
       with:
-        version: ${{inputs.ospray_version}}
+        versions_file: .github/workflows/versions.json
         cpu: ${{inputs.cpu}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install F3D dependencies
       if: inputs.optional_deps_label == 'optional-deps'
       uses: ./source/.github/actions/f3d-dependencies
       with:
+        versions_file: .github/workflows/versions.json
         cpu: ${{inputs.cpu}}
-        alembic_version: ${{inputs.alembic_version}}
-        assimp_version: ${{inputs.assimp_version}}
-        draco_version: ${{inputs.draco_version}}
-        imath_version: ${{inputs.imath_version}}
-        occt_version: ${{inputs.occt_version}}
-        openexr_version: ${{inputs.openexr_version}}
-        pybind11_version: ${{inputs.pybind11_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        usd_version: ${{inputs.usd_version}}
-        webp_version: ${{inputs.webp_version}}
-        webifc_version: ${{inputs.webifc_version}}
-        global_cache_index: ${{inputs.global_cache_index}}

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -28,16 +28,8 @@ runs:
     - name: Install VTK dependencies
       uses: ./source/.github/actions/vtk-dependencies
       with:
-        versions_file: ./source/.github/workflows/versions.json
+        versions_file: ${{inputs.versions_file}}
         optdeps_label: ${{inputs.optdeps_label}}
-        mindeps_label: ${{inputs.mindeps_label}}
-        cpu: ${{inputs.cpu}}
-
-    - name: Install Raytracing Dependencies
-      if: inputs.optdeps_label == 'optdeps'
-      uses: ./source/.github/actions/ospray-sb-install-dep
-      with:
-        versions_file: ./source/.github/workflows/versions.json
         mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
@@ -45,6 +37,6 @@ runs:
       if: inputs.optdeps_label == 'optdeps'
       uses: ./source/.github/actions/f3d-dependencies
       with:
-        versions_file: ./source/.github/workflows/versions.json
+        versions_file: ${{inputs.versions_file}}
         mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -4,10 +4,14 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
-  optional_deps_label:
-    description: "Label to optional dependencies"
+  optdeps_label:
+    description: "Label to flag for optional dependencies"
     required: false
-    default: "optional-deps"
+    default: "optdeps"
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -33,18 +37,22 @@ runs:
       uses: ./source/.github/actions/vtk-dependencies
       with:
         versions_file: .github/workflows/versions.json
+        optdeps_label: ${{inputs.optdeps_label}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install Raytracing Dependencies
-      if: inputs.ospray_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: ./source/.github/actions/ospray-sb-install-dep
       with:
         versions_file: .github/workflows/versions.json
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install F3D dependencies
-      if: inputs.optional_deps_label == 'optional-deps'
+      if: inputs.optdeps_label == 'optdeps'
       uses: ./source/.github/actions/f3d-dependencies
       with:
         versions_file: .github/workflows/versions.json
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -25,14 +25,6 @@ runs:
       run: |
         [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Dependencies Dir
-      shell: bash
-      working-directory: ${{github.workspace}}
-      run: |
-        mkdir dependencies
-        cd dependencies
-        mkdir install
-
     - name: Install VTK dependencies
       uses: ./source/.github/actions/vtk-dependencies
       with:

--- a/.github/actions/generic-dependencies/action.yml
+++ b/.github/actions/generic-dependencies/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Install VTK dependencies
       uses: ./source/.github/actions/vtk-dependencies
       with:
-        versions_file: .github/workflows/versions.json
+        versions_file: ./source/.github/workflows/versions.json
         optdeps_label: ${{inputs.optdeps_label}}
         mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
@@ -45,7 +45,7 @@ runs:
       if: inputs.optdeps_label == 'optdeps'
       uses: ./source/.github/actions/ospray-sb-install-dep
       with:
-        versions_file: .github/workflows/versions.json
+        versions_file: ./source/.github/workflows/versions.json
         mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
@@ -53,6 +53,6 @@ runs:
       if: inputs.optdeps_label == 'optdeps'
       uses: ./source/.github/actions/f3d-dependencies
       with:
-        versions_file: .github/workflows/versions.json
+        versions_file: ./source/.github/workflows/versions.json
         mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}

--- a/.github/actions/geotiff-install-dep/action.yml
+++ b/.github/actions/geotiff-install-dep/action.yml
@@ -64,7 +64,7 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: dependencies/geotiff_install
-        key: geotiff-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
+        key: geotiff-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_csb_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
 
     # Dependents: gdal pdal vtk
     - name: Checkout geotiff

--- a/.github/actions/geotiff-install-dep/action.yml
+++ b/.github/actions/geotiff-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: geotiff
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract proj version
       id: proj_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: proj
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract sqlite_csb version
       id: sqlite_csb_ver
@@ -37,6 +43,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: sqlite_csb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract tiff version
       id: tiff_ver
@@ -44,6 +51,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: tiff
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract zlib version
       id: zlib_ver
@@ -51,6 +59,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: zlib
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/geotiff-install-dep/action.yml
+++ b/.github/actions/geotiff-install-dep/action.yml
@@ -1,28 +1,13 @@
 name: "Install geotiff Dependency"
 description: "Install geotiff Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of geotiff to build"
-    required: true
-  proj_version:
-    description: "Version of proj to build against"
-    required: true
-  sqlite_csb_version:
-    description: "Version of csb providing sqlite to build against"
-    required: true
-  tiff_version:
-    description: "Version of tiff to build against"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -30,19 +15,56 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.proj_version }}" ]] || { echo "proj_version input is empty" ; exit 1; }
-        [[ "${{ inputs.sqlite_csb_version }}" ]] || { echo "sqlite_csb_version input is empty" ; exit 1; }
-        [[ "${{ inputs.tiff_version }}" ]] || { echo "tiff_version input is empty" ; exit 1; }
-        [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract geotiff version
+      id: geotiff_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: geotiff
+
+    - name: Extract proj version
+      id: proj_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: proj
+
+    - name: Extract sqlite_csb version
+      id: sqlite_csb_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: sqlite_csb
+
+    - name: Extract tiff version
+      id: tiff_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: tiff
+
+    - name: Extract zlib version
+      id: zlib_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: zlib
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache geotiff
       id: cache-geotiff
       uses: actions/cache/restore@v5
       with:
         path: dependencies/geotiff_install
-        key: geotiff-${{inputs.version}}-${{inputs.proj_version}}-${{ inputs.sqlite_csb_version }}-${{inputs.tiff_version}}-${{inputs.zlib_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-2
+        key: geotiff-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
 
     # Dependents: gdal pdal vtk
     - name: Checkout geotiff
@@ -51,7 +73,7 @@ runs:
       with:
         repository: OSGeo/libgeotiff
         path: "./dependencies/geotiff"
-        ref: ${{inputs.version}}
+        ref: ${{steps.geotiff_ver.outputs.extract}}
 
     - name: Setup geotiff
       if: steps.cache-geotiff.outputs.cache-hit != 'true'

--- a/.github/actions/imath-install-dep/action.yml
+++ b/.github/actions/imath-install-dep/action.yml
@@ -1,32 +1,41 @@
 name: "Install Imath Dependency"
 description: "Install Imath Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of imath to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Cache Imath
+    - name: Extract imath version
+      id: imath_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: imath
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
+
+    - name: Cache imath
       id: cache-imath
       uses: actions/cache/restore@v5
       with:
         path: dependencies/imath_install
-        key: imath-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
+        key: imath-${{steps.imath_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-1
 
     # Dependents: alembic openexr
     - name: Checkout Imath

--- a/.github/actions/imath-install-dep/action.yml
+++ b/.github/actions/imath-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract imath version
       id: imath_ver

--- a/.github/actions/imath-install-dep/action.yml
+++ b/.github/actions/imath-install-dep/action.yml
@@ -45,7 +45,7 @@ runs:
       with:
         repository: AcademySoftwareFoundation/Imath
         path: "./dependencies/imath"
-        ref: ${{inputs.version}}
+        ref: ${{steps.imath_ver.outputs.extract}}
 
     - name: Setup Imath
       if: steps.cache-imath.outputs.cache-hit != 'true'

--- a/.github/actions/imath-install-dep/action.yml
+++ b/.github/actions/imath-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: imath
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: occt
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -45,7 +45,7 @@ runs:
         repository: Open-Cascade-SAS/OCCT
         submodules: true
         path: "./dependencies/occt"
-        ref: ${{inputs.version}}
+        ref: ${{steps.occt_ver.outputs.extract}}
 
     - name: Patch OCCT all versions
       if: steps.cache-occt.outputs.cache-hit != 'true'

--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -1,32 +1,41 @@
 name: "Install OCCT Dependency"
 description: "Install OCCT Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of occt to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Cache OCCT
+    - name: Extract occt version
+      id: occt_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: occt
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
+
+    - name: Cache occt
       id: cache-occt
       uses: actions/cache/restore@v5
       with:
         path: dependencies/occt_install
-        key: occt-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-2
+        key: occt-${{steps.occt_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
 
     - name: Checkout OCCT
       if: steps.cache-occt.outputs.cache-hit != 'true'

--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract occt version
       id: occt_ver

--- a/.github/actions/occt-install-dep/action.yml
+++ b/.github/actions/occt-install-dep/action.yml
@@ -69,7 +69,7 @@ runs:
     - name: Configure OCCT current version
       if: |
         steps.cache-occt.outputs.cache-hit != 'true' &&
-        inputs.version != 'V7_6_3'
+        steps.occt_ver.outputs.extract != 'V7_6_3'
       working-directory: ${{github.workspace}}/dependencies/occt_build
       shell: bash
       run: >
@@ -98,7 +98,7 @@ runs:
     - name: Configure OCCT min version
       if: |
         steps.cache-occt.outputs.cache-hit != 'true' &&
-        inputs.version == 'V7_6_3'
+        steps.occt_ver.outputs.extract == 'V7_6_3'
       working-directory: ${{github.workspace}}/dependencies/occt_build
       shell: bash
       run: >

--- a/.github/actions/openexr-install-dep/action.yml
+++ b/.github/actions/openexr-install-dep/action.yml
@@ -52,7 +52,7 @@ runs:
       with:
         repository: AcademySoftwareFoundation/openexr
         path: "./dependencies/openexr"
-        ref: ${{inputs.version}}
+        ref: ${{steps.openexr_ver.outputs.extract}}
 
     - name: Setup OpenEXR
       if: steps.cache-openexr.outputs.cache-hit != 'true'

--- a/.github/actions/openexr-install-dep/action.yml
+++ b/.github/actions/openexr-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: openexr
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract imath version
       id: imath_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: imath
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/openexr-install-dep/action.yml
+++ b/.github/actions/openexr-install-dep/action.yml
@@ -70,7 +70,7 @@ runs:
 
     # OpenEXR 3.0.1 needs patching with recent libstd
     - name: Patch OpenEXR v3.0.1
-      if: steps.cache-openexr.outputs.cache-hit != 'true' && inputs.version == 'v3.0.1'
+      if: steps.cache-openexr.outputs.cache-hit != 'true' && steps.openexr_ver.outputs.extract == 'v3.0.1'
       working-directory: ${{github.workspace}}/dependencies/openexr
       shell: bash
       run: patch -p1 < $GITHUB_ACTION_PATH/include_cstdint.patch

--- a/.github/actions/openexr-install-dep/action.yml
+++ b/.github/actions/openexr-install-dep/action.yml
@@ -1,35 +1,48 @@
 name: "Install OpenEXR Dependency"
 description: "Install OpenEXR Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of openexr to build"
-    required: true
-  imath_version:
-    description: "Version of imath to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Cache OpenEXR
+    - name: Extract openexr version
+      id: openexr_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: openexr
+
+    - name: Extract imath version
+      id: imath_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: imath
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
+
+    - name: Cache openexr
       id: cache-openexr
       uses: actions/cache/restore@v5
       with:
         path: dependencies/openexr_install
-        key: openexr-${{inputs.version}}-${{inputs.imath_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-2
+        key: openexr-${{steps.openexr_ver.outputs.extract}}-${{steps.imath_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
 
     # Dependents: usd
     - name: Checkout OpenEXR

--- a/.github/actions/openexr-install-dep/action.yml
+++ b/.github/actions/openexr-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract openexr version
       id: openexr_ver

--- a/.github/actions/openvdb-install-dep/action.yml
+++ b/.github/actions/openvdb-install-dep/action.yml
@@ -29,18 +29,21 @@ runs:
       uses: f3d-app/extract-version-action@main
       with:
         file: ${{inputs.versions_file}}
+        name: zlib
 
     - name: Extract blosc version
       id: blosc_ver
       uses: f3d-app/extract-version-action@main
       with:
         file: ${{inputs.versions_file}}
+        name: blosc
 
     - name: Extract tbb version
       id: tbb_ver
       uses: f3d-app/extract-version-action@main
       with:
         file: ${{inputs.versions_file}}
+        name: tbb
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/openvdb-install-dep/action.yml
+++ b/.github/actions/openvdb-install-dep/action.yml
@@ -1,25 +1,13 @@
 name: "Install OpenVDB Dependency"
 description: "Install OpenVDB Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of openvdb to build"
-    required: true
-  blosc_version:
-    description: "Version of blosc to build against"
-    required: true
-  tbb_version:
-    description: "Version of tbb to build against"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -27,18 +15,46 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.blosc_version }}" ]] || { echo "blosc_version input is empty" ; exit 1; }
-        [[ "${{ inputs.tbb_version }}" ]] || { echo "tbb_version input is empty" ; exit 1; }
-        [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract openvdb version
+      id: openvdb_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: openvdb
+
+    - name: Extract zlib version
+      id: zlib_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+
+    - name: Extract blosc version
+      id: blosc_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+
+    - name: Extract tbb version
+      id: tbb_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache OpenVDB
       id: cache-openvdb
       uses: actions/cache/restore@v5
       with:
         path: dependencies/openvdb_install
-        key: openvdb-${{inputs.version}}-${{inputs.zlib_version}}-${{inputs.blosc_version}}-${{inputs.tbb_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
+        key: openvdb-${{steps.openvdb_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{steps.blosc_ver.outputs.extract}}-${{steps.tbb_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-1
 
     # Dependents: vtk
     - name: Checkout OpenVDB
@@ -47,7 +63,7 @@ runs:
       with:
         repository: AcademySoftwareFoundation/openvdb
         path: "./dependencies/openvdb"
-        ref: ${{inputs.version}}
+        ref: ${{steps.openvdb_ver.outputs.extract}}
 
     - name: Setup OpenVDB
       if: steps.cache-openvdb.outputs.cache-hit != 'true'

--- a/.github/actions/openvdb-install-dep/action.yml
+++ b/.github/actions/openvdb-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: openvdb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract zlib version
       id: zlib_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: zlib
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract blosc version
       id: blosc_ver
@@ -37,6 +43,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: blosc
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract tbb version
       id: tbb_ver
@@ -44,6 +51,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: tbb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -7,7 +7,7 @@ inputs:
   mindeps_label:
     description: "Label to check for minimal version dependencies"
     required: false
-    default: "mindeps"
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false

--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -1,32 +1,45 @@
 name: "Install ospray sb Dependency"
 description: "Install ospray sb Dependency using cache when possible"
 inputs:
-  version:
-    description: "Version of ospray to build"
+  versions_file:
+    description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to check for minimal version dependencies"
+    required: false
+    default: "mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract ospray version
+      id: ospray_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: ospray
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache ospray
       id: cache-ospray
       uses: actions/cache/restore@v5
       with:
         path: dependencies/ospray_install
-        key: ospray-sb-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
+        key: ospray-sb-${{steps.ospray_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-1
 
     # Dependents: vtk
     - name: Checkout ospray

--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -27,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: ospray
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -18,7 +18,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract ospray version
       id: ospray_ver

--- a/.github/actions/ospray-sb-install-dep/action.yml
+++ b/.github/actions/ospray-sb-install-dep/action.yml
@@ -49,7 +49,7 @@ runs:
       with:
         repository: RenderKit/ospray
         path: "./dependencies/ospray"
-        ref: ${{inputs.version}}
+        ref: ${{steps.ospray_ver.outputs.extract}}
 
     # https://github.com/ospray/ospray/pull/550
     - name: Patch ospray rkcommon superbuild

--- a/.github/actions/pdal-install-dep/action.yml
+++ b/.github/actions/pdal-install-dep/action.yml
@@ -63,7 +63,7 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: dependencies/pdal_install
-        key: pdal-${{steps.pdal_ver.outputs.extract}-${{steps.gdal_ver.outputs.extract}}-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-7
+        key: pdal-${{steps.pdal_ver.outputs.extract}}-${{steps.gdal_ver.outputs.extract}}-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-7
 
     # Dependents: vtk
     - name: Checkout pdal

--- a/.github/actions/pdal-install-dep/action.yml
+++ b/.github/actions/pdal-install-dep/action.yml
@@ -57,6 +57,21 @@ runs:
       uses: f3d-app/extract-version-action@main
       with:
         file: ${{inputs.versions_file}}
+        name: tiff
+
+    - name: Extract zlib version
+      id: zlib_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: zlib
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache pdal
       id: cache-pdal

--- a/.github/actions/pdal-install-dep/action.yml
+++ b/.github/actions/pdal-install-dep/action.yml
@@ -78,7 +78,7 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: dependencies/pdal_install
-        key: pdal-${{steps.pdal_ver.outputs.extract}}-${{steps.gdal_ver.outputs.extract}}-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-7
+        key: pdal-${{steps.pdal_ver.outputs.extract}}-${{steps.gdal_ver.outputs.extract}}-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_csb_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-7
 
     # Dependents: vtk
     - name: Checkout pdal

--- a/.github/actions/pdal-install-dep/action.yml
+++ b/.github/actions/pdal-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: pdal
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract gdal version
       id: gdal_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: gdal
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract geotiff version
       id: geotiff_ver
@@ -37,6 +43,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: geotiff
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract proj version
       id: proj_ver
@@ -44,6 +51,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: proj
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract sqlite_csb version
       id: sqlite_csb_ver
@@ -51,6 +59,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: sqlite_csb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract tiff version
       id: tiff_ver
@@ -58,6 +67,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: tiff
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract zlib version
       id: zlib_ver
@@ -65,6 +75,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: zlib
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/pdal-install-dep/action.yml
+++ b/.github/actions/pdal-install-dep/action.yml
@@ -1,37 +1,13 @@
 name: "Install pdal Dependency"
 description: "Install pdal Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of pdal to build"
-    required: true
-  curl_version:
-    description: "Version of gdal to build against"
-    required: true
-  gdal_version:
-    description: "Version of gdal to build against"
-    required: true
-  geotiff_version:
-    description: "Version of geotiff to build against"
-    required: true
-  proj_version:
-    description: "Version of proj to build against"
-    required: true
-  sqlite_csb_version:
-    description: "Version of csb providing sqlite to build against"
-    required: true
-  tiff_version:
-    description: "Version of tiff to build against"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -39,22 +15,55 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.curl_version }}" ]] || { echo "curl_version input is empty" ; exit 1; }
-        [[ "${{ inputs.gdal_version }}" ]] || { echo "gdal_version input is empty" ; exit 1; }
-        [[ "${{ inputs.geotiff_version }}" ]] || { echo "geotiff_version input is empty" ; exit 1; }
-        [[ "${{ inputs.proj_version }}" ]] || { echo "proj_version input is empty" ; exit 1; }
-        [[ "${{ inputs.sqlite_csb_version }}" ]] || { echo "sqlite_csb_version input is empty" ; exit 1; }
-        [[ "${{ inputs.tiff_version }}" ]] || { echo "tiff_version input is empty" ; exit 1; }
-        [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract pdal version
+      id: pdal_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: pdal
+
+    - name: Extract gdal version
+      id: gdal_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: gdal
+
+    - name: Extract geotiff version
+      id: geotiff_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: geotiff
+
+    - name: Extract proj version
+      id: proj_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: proj
+
+    - name: Extract sqlite_csb version
+      id: sqlite_csb_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: sqlite_csb
+
+    - name: Extract tiff version
+      id: tiff_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
 
     - name: Cache pdal
       id: cache-pdal
       uses: actions/cache/restore@v5
       with:
         path: dependencies/pdal_install
-        key: pdal-${{inputs.version}}-${{ inputs.curl_version }}-${{ inputs.gdal_version }}-${{ inputs.geotiff_version }}-${{inputs.proj_version}}-${{ inputs.sqlite_csb_version }}-${{inputs.tiff_version}}-${{inputs.zlib_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-7
+        key: pdal-${{steps.pdal_ver.outputs.extract}-${{steps.gdal_ver.outputs.extract}}-${{steps.geotiff_ver.outputs.extract}}-${{steps.proj_ver.outputs.extract}}-${{steps.sqlite_ver.outputs.extract}}-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-7
 
     # Dependents: vtk
     - name: Checkout pdal
@@ -63,10 +72,10 @@ runs:
       with:
         repository: PDAL/PDAL
         path: "./dependencies/pdal"
-        ref: ${{inputs.version}}
+        ref: ${{steps.pdal_ver.outputs.extract}}
 
     - name: Patch pdal
-      if: steps.cache-pdal.outputs.cache-hit != 'true' && inputs.version != '2.9.0'
+      if: steps.cache-pdal.outputs.cache-hit != 'true' && steps.pdal_ver.outputs.extract != '2.9.0'
       working-directory: ${{github.workspace}}/dependencies/pdal
       shell: bash
       run: |
@@ -74,7 +83,7 @@ runs:
         patch -p1 < $GITHUB_ACTION_PATH/remove_apps_tools.patch
 
     - name: Patch pdal minver
-      if: steps.cache-pdal.outputs.cache-hit != 'true' && inputs.version == '2.9.0'
+      if: steps.cache-pdal.outputs.cache-hit != 'true' && steps.pdal_ver.outputs.extract == '2.9.0'
       working-directory: ${{github.workspace}}/dependencies/pdal
       shell: bash
       run: |

--- a/.github/actions/proj-install-dep/action.yml
+++ b/.github/actions/proj-install-dep/action.yml
@@ -1,19 +1,13 @@
 name: "Install proj Dependency"
 description: "Install proj Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of proj to build"
-    required: true
-  sqlite_csb_version:
-    description: "Version of csb providing sqlite to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -21,16 +15,35 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.sqlite_csb_version }}" ]] || { echo "sqlite_csb_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract proj version
+      id: proj_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: proj
+
+    - name: Extract sqlite version
+      id: sqlite_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: sqlite_csb
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache proj
       id: cache-proj
       uses: actions/cache/restore@v5
       with:
         path: dependencies/proj_install
-        key: proj-${{inputs.version}}-${{ inputs.sqlite_csb_version }}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-2
+        key: proj-${{steps.proj_ver.outputs.extract}}-${{ steps.sqlite_ver.outputs.extract }}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
 
     # Dependents: gdal geotiff
     - name: Checkout proj
@@ -39,11 +52,11 @@ runs:
       with:
         repository: OSGeo/PROJ
         path: "./dependencies/proj"
-        ref: ${{inputs.version}}
+        ref: ${{steps.proj_ver.outputs.extract}}
 
     # Patch for compilation of minver
     - name: Patch proj include
-      if: steps.cache-proj.outputs.cache-hit != 'true' && inputs.version == '9.0.0'
+      if: steps.cache-proj.outputs.cache-hit != 'true' && steps.proj_ver.outputs.extract == '9.0.0'
       working-directory: ${{github.workspace}}/dependencies/proj
       shell: bash
       run: patch -p1 < $GITHUB_ACTION_PATH/add-missing-cstdint-includes.patch

--- a/.github/actions/proj-install-dep/action.yml
+++ b/.github/actions/proj-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: proj
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract sqlite version
       id: sqlite_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: sqlite_csb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/pybind11-install-dep/action.yml
+++ b/.github/actions/pybind11-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract pybind11 version
       id: pybind11_ver

--- a/.github/actions/pybind11-install-dep/action.yml
+++ b/.github/actions/pybind11-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: pybind11
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/pybind11-install-dep/action.yml
+++ b/.github/actions/pybind11-install-dep/action.yml
@@ -1,28 +1,41 @@
 name: "Install pybind11 Dependency"
 description: "Install pybind11 Dependency using cache when possible"
 inputs:
-  version:
-    description: "Version of pybind11 to build"
+  versions_file:
+    description: "File to recover versions from"
     required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
+  cpu:
+    description: "CPU architecture to build for"
+    required: false
+    default: "x86_64"
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract pybind11 version
+      id: pybind11_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: pybind11
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache pybind11
       id: cache-pybind11
       uses: actions/cache/restore@v5
       with:
         path: dependencies/pybind11_install
-        key: pybind11-${{inputs.version}}-${{runner.os}}-${{inputs.global_cache_index}}-1
+        key: pybind11-${{steps.pybind11_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-1
 
     - name: Checkout pybind11
       if: steps.cache-pybind11.outputs.cache-hit != 'true'

--- a/.github/actions/pybind11-install-dep/action.yml
+++ b/.github/actions/pybind11-install-dep/action.yml
@@ -45,7 +45,7 @@ runs:
         repository: pybind/pybind11
         submodules: true
         path: "./dependencies/pybind11"
-        ref: ${{inputs.version}}
+        ref: ${{steps.pybind11_ver.outputs.extract}}
 
     - name: Setup pybind11
       if: steps.cache-pybind11.outputs.cache-hit != 'true'

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -36,13 +36,13 @@ runs:
       uses: ./source/.github/actions/generic-dependencies
       with:
         versions_file: ${{inputs.versions_file}}
-        cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
+        cpu: ${{ runner.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
-        cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
+        cpu: ${{ runner.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -36,13 +36,13 @@ runs:
       uses: ./source/.github/actions/generic-dependencies
       with:
         versions_file: ${{inputs.versions_file}}
-        cpu: ${{ runner.os == 'macos-15' && 'arm64' || 'x86_64' }}
+        cpu: ${{inputs.cpu}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
-        cpu: ${{ runner.os == 'macos-15' && 'arm64' || 'x86_64' }}
+        cpu: ${{inputs.cpu}}
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -1,6 +1,12 @@
 name: "Python specific CI"
 description: "Python specific CI"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
+  python_version:
+    description: "Python version"
+    required: true
   lfs_sha:
     description: "Cache LFS sha"
     required: true
@@ -8,78 +14,6 @@ inputs:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  alembic_version:
-    description: "Version of alembic to build"
-    required: false
-  assimp_version:
-    description: "Version of assimp to build"
-    required: false
-  blosc_version:
-    description: "Version of blosc to build"
-    required: true
-  curl_version:
-    description: "Version of curl to build"
-    required: false
-  draco_version:
-    description: "Version of draco to build"
-    required: false
-  gdal_version:
-    description: "Version of gdal to build"
-    required: false
-  geotiff_version:
-    description: "Version of geotiff to build"
-    required: false
-  imath_version:
-    description: "Version of imath to build"
-    required: false
-  occt_version:
-    description: "Version of occt to build"
-    required: false
-  openexr_version:
-    description: "Version of openexr to build"
-    required: false
-  openvdb_version:
-    description: "Version of openvdb to build"
-    required: false
-  pdal_version:
-    description: "Version of pdal to build"
-    required: false
-  proj_version:
-    description: "Version of proj to build"
-    required: false
-  pybind11_version:
-    description: "Version of pybind11 to build"
-    required: false
-  python_version:
-    description: "Python version"
-    required: true
-  sqlite_csb_version:
-    description: "Version of csb providing sqlite to build against"
-    required: false
-  tiff_version:
-    description: "Version of tiff to build"
-    required: false
-  tbb_version:
-    description: "Version of tbb to build"
-    required: true
-  usd_version:
-    description: "Version of usd to build"
-    required: false
-  vtk_version:
-    description: "Version of vtk to build"
-    required: true
-  webp_version:
-    description: "Version of webp to build"
-    required: true
-  webifc_version:
-    description: "Version of webifc to build"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -87,9 +21,9 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
+        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
         [[ "${{ inputs.lfs_sha }}" ]] || { echo "lfs_sha input is empty" ; exit 1; }
         [[ "${{ inputs.python_version }}" ]] || { echo "python input is empty" ; exit 1; }
-        [[ "${{ inputs.vtk_version }}" ]] || { echo "vtk_version input is empty" ; exit 1; }
 
     - name: Recover LFS Data
       uses: f3d-app/lfs-data-cache-action@v2
@@ -101,47 +35,14 @@ runs:
     - name: Install all F3D dependencies
       uses: ./source/.github/actions/generic-dependencies
       with:
-        cpu: ${{inputs.cpu}}
-        alembic_version: ${{inputs.alembic_version}}
-        assimp_version: ${{inputs.assimp_version}}
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        draco_version: ${{inputs.draco_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        imath_version: ${{inputs.imath_version}}
-        occt_version: ${{inputs.occt_version}}
-        openexr_version: ${{inputs.openexr_version}}
-        openvdb_version: ${{inputs.openvdb_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        pybind11_version: ${{inputs.pybind11_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        usd_version: ${{inputs.usd_version}}
-        webifc_version: ${{inputs.webifc_version}}
-        webp_version: ${{inputs.webp_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
+        cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
-        cpu: ${{inputs.cpu}}
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        openvdb_version: ${{inputs.openvdb_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        vtk_version: ${{inputs.vtk_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
+        cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  vtk_version:
+    description: "Descriptive VTK version to build against"
+    required: false
+    default: "commit"
   sanitizer_type:
     description: "Type of sanitizer"
     required: true
@@ -37,6 +41,7 @@ runs:
       uses: ./source/.github/actions/vtk-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        vtk_version: ${{inputs.vtk_version}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -1,71 +1,14 @@
 name: "Sanitizer CI"
 description: "Sanitizer CI"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   sanitizer_type:
     description: "Type of sanitizer"
     required: true
   lfs_sha:
     description: "Cache LFS sha"
-    required: true
-  alembic_version:
-    description: "Version of alembic to build"
-    required: false
-  assimp_version:
-    description: "Version of assimp to build"
-    required: false
-  blosc_version:
-    description: "Version of blosc to build"
-    required: true
-  curl_version:
-    description: "Version of curl to build"
-    required: false
-  draco_version:
-    description: "Version of draco to build"
-    required: false
-  gdal_version:
-    description: "Version of gdal to build"
-    required: false
-  geotiff_version:
-    description: "Version of geotiff to build"
-    required: false
-  imath_version:
-    description: "Version of imath to build"
-    required: false
-  occt_version:
-    description: "Version of occt to build"
-    required: false
-  openexr_version:
-    description: "Version of openexr to build"
-    required: false
-  pdal_version:
-    description: "Version of pdal to build"
-    required: false
-  proj_version:
-    description: "Version of proj to build"
-    required: false
-  sqlite_csb_version:
-    description: "Version of csb providing sqlite to build against"
-    required: false
-  tbb_version:
-    description: "Version of tbb to build"
-    required: true
-  tiff_version:
-    description: "Version of tiff to build"
-    required: false
-  vtk_version:
-    description: "VTK version"
-    required: true
-  webp_version:
-    description: "webP version"
-    required: true
-  webifc_version:
-    description: "Version of webifc to build"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
     required: true
 
 runs:
@@ -74,9 +17,9 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
+        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
         [[ "${{ inputs.sanitizer_type }}" ]] || { echo "sanitizer_type input is empty" ; exit 1; }
         [[ "${{ inputs.lfs_sha }}" ]] || { echo "lfs_sha input is empty" ; exit 1; }
-        [[ "${{ inputs.vtk_version }}" ]] || { echo "vtk_version input is empty" ; exit 1; }
 
     - name: Recover LFS Data
       uses: f3d-app/lfs-data-cache-action@v2
@@ -88,41 +31,12 @@ runs:
     - name: Install all F3D dependencies
       uses: ./source/.github/actions/generic-dependencies
       with:
-        alembic_version: ${{inputs.alembic_version}}
-        assimp_version: ${{inputs.assimp_version}}
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        draco_version: ${{inputs.draco_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        imath_version: ${{inputs.imath_version}}
-        occt_version: ${{inputs.occt_version}}
-        openexr_version: ${{inputs.openexr_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        webifc_version: ${{inputs.webifc_version}}
-        webp_version: ${{inputs.webp_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        vtk_version: ${{inputs.vtk_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/sanitizer-ci/action.yml
+++ b/.github/actions/sanitizer-ci/action.yml
@@ -104,4 +104,4 @@ runs:
       uses: actions/upload-artifact@v7
       with:
         path: ./build/Testing/Temporary
-        name: f3d-tests-artifact-sanitizer-${{matrix.sanitizer_type}}
+        name: f3d-tests-artifact-sanitizer-${{inputs.sanitizer_type}}

--- a/.github/actions/sqlite-install-dep/action.yml
+++ b/.github/actions/sqlite-install-dep/action.yml
@@ -5,7 +5,8 @@ inputs:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  versions_file: "File to recover versions from"
+  versions_file:
+    description: "File to recover versions from"
     required: true
 
 runs:

--- a/.github/actions/sqlite-install-dep/action.yml
+++ b/.github/actions/sqlite-install-dep/action.yml
@@ -1,34 +1,33 @@
 name: "Install sqlite Dependency"
 description: "Install sqlite Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  versions_file:
-    description: "File to recover versions from"
-    required: true
-
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract sqlite version
       id: sqlite_ver
       uses: f3d-app/extract-version-action@main
       with:
-        file: ${{ inputs.versions_file }}
+        file: ${{inputs.versions_file}}
         name: sqlite_csb
 
     - name: Extract global cache index
       id: global_idx
       uses: f3d-app/extract-version-action@main
       with:
-        file: ${{ inputs.versions_file }}
+        file: ${{inputs.versions_file}}
         special_name: global_cache_index
 
     - name: Cache sqlite

--- a/.github/actions/sqlite-install-dep/action.yml
+++ b/.github/actions/sqlite-install-dep/action.yml
@@ -5,11 +5,7 @@ inputs:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  csb_version:
-    description: "Version of common-superbuild to build sqlite with"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
+  versions_file: "File to recover versions from"
     required: true
 
 runs:
@@ -18,18 +14,31 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.csb_version }}" ]] || { echo "csb_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract sqlite version
+      id: sqlite_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{ inputs.versions_file }}
+        name: sqlite_csb
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{ inputs.versions_file }}
+        special_name: global_cache_index
 
     - name: Cache sqlite
       id: cache-sqlite
       uses: actions/cache/restore@v5
       with:
         path: dependencies/sqlite_build/install
-        key: sqlite-${{ inputs.csb_version }}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-2
+        key: sqlite-${{steps.sqlite_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
 
     # Dependents: proj
-    # use --depth=1 --revision=${{ inputs.csb_version }}
+    # use --depth=1 --revision=${{steps.sqlite_ver.outputs.extract}}
     # when git supports it
     - name: Checkout common-superbuild and set everything up
       if: steps.cache-sqlite.outputs.cache-hit != 'true'
@@ -39,7 +48,7 @@ runs:
         mkdir sqlite_build
         git clone https://gitlab.kitware.com/paraview/common-superbuild.git sqlite_csb
         cd sqlite_csb
-        git checkout ${{ inputs.csb_version }}
+        git checkout ${{steps.sqlite_ver.outputs.extract}}
 
     - name: Setup msvc Windows
       if: |

--- a/.github/actions/sqlite-install-dep/action.yml
+++ b/.github/actions/sqlite-install-dep/action.yml
@@ -17,7 +17,7 @@ runs:
         [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract sqlite version
-      id: sqlite_ver
+      id: sqlite_csb_ver
       uses: f3d-app/extract-version-action@main
       with:
         file: ${{inputs.versions_file}}
@@ -35,7 +35,7 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: dependencies/sqlite_build/install
-        key: sqlite-${{steps.sqlite_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
+        key: sqlite-${{steps.sqlite_csb_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-2
 
     # Dependents: proj
     # use --depth=1 --revision=${{steps.sqlite_ver.outputs.extract}}

--- a/.github/actions/sqlite-install-dep/action.yml
+++ b/.github/actions/sqlite-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -22,6 +26,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: sqlite_csb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/static-analysis-ci/action.yml
+++ b/.github/actions/static-analysis-ci/action.yml
@@ -1,74 +1,11 @@
 name: "Static analysis CI"
 description: "Static analysis CI"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   lfs_sha:
     description: "Cache LFS sha"
-    required: true
-  alembic_version:
-    description: "Version of alembic to build"
-    required: true
-  assimp_version:
-    description: "Version of assimp to build"
-    required: true
-  blosc_version:
-    description: "Version of blosc to build"
-    required: true
-  curl_version:
-    description: "Version of curl to build"
-    required: false
-  draco_version:
-    description: "Version of draco to build"
-    required: true
-  gdal_version:
-    description: "Version of gdal to build"
-    required: false
-  geotiff_version:
-    description: "Version of geotiff to build"
-    required: false
-  imath_version:
-    description: "Version of imath to build"
-    required: true
-  occt_version:
-    description: "Version of occt to build"
-    required: true
-  openexr_version:
-    description: "Version of openexr to build"
-    required: true
-  openvdb_version:
-    description: "Version of openvdb to build"
-    required: true
-  pdal_version:
-    description: "Version of pdal to build"
-    required: false
-  proj_version:
-    description: "Version of proj to build"
-    required: false
-  sqlite_csb_version:
-    description: "Version of csb providing sqlite to build against"
-    required: false
-  tbb_version:
-    description: "Version of tbb to build"
-    required: true
-  tiff_version:
-    description: "Version of tiff to build"
-    required: false
-  usd_version:
-    description: "Version of usd to build"
-    required: true
-  vtk_version:
-    description: "Version of vtk to build"
-    required: true
-  webp_version:
-    description: "Version of webp to build"
-    required: true
-  webifc_version:
-    description: "Version of webifc to build"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
     required: true
 
 runs:
@@ -77,8 +14,8 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
+        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
         [[ "${{ inputs.lfs_sha }}" ]] || { echo "lfs_sha input is empty" ; exit 1; }
-        [[ "${{ inputs.vtk_version }}" ]] || { echo "vtk_version input is empty" ; exit 1; }
 
     # Needed for BUILD_TESTING
     - name: Recover LFS Data
@@ -91,44 +28,12 @@ runs:
     - name: Install all F3D dependencies
       uses: ./source/.github/actions/generic-dependencies
       with:
-        alembic_version: ${{inputs.alembic_version}}
-        assimp_version: ${{inputs.assimp_version}}
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        draco_version: ${{inputs.draco_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        imath_version: ${{inputs.imath_version}}
-        occt_version: ${{inputs.occt_version}}
-        openexr_version: ${{inputs.openexr_version}}
-        openvdb_version: ${{inputs.openvdb_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        usd_version: ${{inputs.usd_version}}
-        webifc_version: ${{inputs.webifc_version}}
-        webp_version: ${{inputs.webp_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
 
     - name: Install VTK dependency
       uses: ./source/.github/actions/vtk-install-dep
       with:
-        blosc_version: ${{inputs.blosc_version}}
-        curl_version: ${{inputs.curl_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        openvdb_version: ${{inputs.openvdb_version}}
-        pdal_version: ${{inputs.pdal_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        vtk_version: ${{inputs.vtk_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
+        versions_file: ${{inputs.versions_file}}
 
     - name: Setup Build Directory
       shell: bash

--- a/.github/actions/tbb-install-dep/action.yml
+++ b/.github/actions/tbb-install-dep/action.yml
@@ -1,16 +1,13 @@
 name: "Install TBB Dependency"
 description: "Install TBB Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of tbb to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -18,15 +15,28 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract tbb version
+      id: tbb_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: tbb
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache TBB
       id: cache-tbb
       uses: actions/cache/restore@v5
       with:
         path: dependencies/tbb_install
-        key: tbb-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
+        key: tbb-${{steps.tbb_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-1
 
     # Dependents: usd openvdb vtk
     # v2021.13.0 somehow cause memory issue in draco and alembic
@@ -37,7 +47,7 @@ runs:
       with:
         repository: oneapi-src/oneTBB
         path: "./dependencies/tbb"
-        ref: ${{inputs.version}}
+        ref: ${{steps.tbb_ver.outputs.extract}}
 
     - name: Setup TBB
       if: steps.cache-tbb.outputs.cache-hit != 'true'

--- a/.github/actions/tbb-install-dep/action.yml
+++ b/.github/actions/tbb-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: tbb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/tiff-install-dep/action.yml
+++ b/.github/actions/tiff-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: tiff
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract zlib version
       id: zlib_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: zlib
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/tiff-install-dep/action.yml
+++ b/.github/actions/tiff-install-dep/action.yml
@@ -1,19 +1,13 @@
 name: "Install tiff Dependency"
 description: "Install tiff Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of tiff to build"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -21,16 +15,35 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract tiff version
+      id: tiff_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: tiff
+
+    - name: Extract zlib version
+      id: zlib_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: zlib
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache tiff
       id: cache-tiff
       uses: actions/cache/restore@v5
       with:
         path: dependencies/tiff_install
-        key: tiff-${{inputs.version}}-${{inputs.zlib_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-4
+        key: tiff-${{steps.tiff_ver.outputs.extract}}-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-4
 
     # Dependents: gdal pdal vtk geotiff
     - name: Checkout tiff
@@ -39,7 +52,7 @@ runs:
       with:
         repository: libsdl-org/libtiff
         path: "./dependencies/tiff"
-        ref: ${{inputs.version}}
+        ref: ${{steps.tiff_ver.outputs.extract}}
 
     - name: Setup tiff
       if: steps.cache-tiff.outputs.cache-hit != 'true'

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -77,14 +77,14 @@ runs:
 
     # Upstream issue: https://github.com/PixarAnimationStudios/OpenUSD/issues/2490
     - name: Patch USD
-      if: steps.cache-usd.outputs.cache-hit != 'true' && inputs.version == 'v24.08'
+      if: steps.cache-usd.outputs.cache-hit != 'true' && steps.usd_ver.outputs.extract == 'v24.08'
       working-directory: ${{github.workspace}}/dependencies/usd
       shell: bash
       run: patch -p1 < $GITHUB_ACTION_PATH/usd-install-bin-mindep.patch
 
     # Upstream issue: https://github.com/PixarAnimationStudios/OpenUSD/issues/2490
     - name: Patch USD
-      if: steps.cache-usd.outputs.cache-hit != 'true' && inputs.version != 'v24.08'
+      if: steps.cache-usd.outputs.cache-hit != 'true' && steps.usd_ver.outputs.extract != 'v24.08'
       working-directory: ${{github.workspace}}/dependencies/usd
       shell: bash
       run: patch -p1 < $GITHUB_ACTION_PATH/usd-install-bin.patch

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: usd
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract openexr version
       id: openexr_ver
@@ -30,6 +35,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: openexr
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract imath version
       id: imath_ver
@@ -37,6 +43,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: imath
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract tbb version
       id: tbb_ver
@@ -44,6 +51,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: tbb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -65,7 +65,7 @@ runs:
       with:
         repository: PixarAnimationStudios/USD
         path: "./dependencies/usd"
-        ref: ${{inputs.version}}
+        ref: ${{steps.usd_ver.outputs.extract}}
 
     # Upstream issue: https://github.com/PixarAnimationStudios/OpenUSD/issues/2490
     - name: Patch USD

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -1,40 +1,62 @@
 name: "Install USD Dependency"
 description: "Install USD Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of usd to build"
-    required: true
-  openexr_version:
-    description: "Version of openexr to build against"
-    required: true
-  tbb_version:
-    description: "Version of tbb to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.openexr_version }}" ]] || { echo "openexr_version input is empty" ; exit 1; }
-        [[ "${{ inputs.tbb_version }}" ]] || { echo "tbb_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Cache USD
-      id: cache-usd
+    - name: Extract usd version
+      id: usd_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: usd
+
+    - name: Extract openexr version
+      id: openexr_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: openexr
+
+    - name: Extract imath version
+      id: imath_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: imath
+
+    - name: Extract tbb version
+      id: tbb_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: tbb
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
+
+    - name: Cache openexr
+      id: cache-openexr
       uses: actions/cache/restore@v5
       with:
-        path: dependencies/usd_install
-        key: usd-${{inputs.version}}-${{inputs.openexr_version}}-${{inputs.tbb_version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-0
+        path: dependencies/openexr_install
+        key: usd-${{steps.usd_ver.outputs.extract}}-${{steps.openexr_ver.outputs.extract}}-${{steps.imath_ver.outputs.extract}}-${{steps.tbb_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-0
 
     - name: Checkout USD
       if: steps.cache-usd.outputs.cache-hit != 'true'

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract usd version
       id: usd_ver

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -61,7 +61,7 @@ runs:
         special_name: global_cache_index
 
     - name: Cache openexr
-      id: cache-openexr
+      id: cache-usd
       uses: actions/cache/restore@v5
       with:
         path: dependencies/openexr_install

--- a/.github/actions/usd-install-dep/action.yml
+++ b/.github/actions/usd-install-dep/action.yml
@@ -60,11 +60,11 @@ runs:
         file: ${{inputs.versions_file}}
         special_name: global_cache_index
 
-    - name: Cache openexr
+    - name: Cache usd
       id: cache-usd
       uses: actions/cache/restore@v5
       with:
-        path: dependencies/openexr_install
+        path: dependencies/usd_install
         key: usd-${{steps.usd_ver.outputs.extract}}-${{steps.openexr_ver.outputs.extract}}-${{steps.imath_ver.outputs.extract}}-${{steps.tbb_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-0
 
     - name: Checkout USD

--- a/.github/actions/vtk-dependencies/action.yml
+++ b/.github/actions/vtk-dependencies/action.yml
@@ -1,6 +1,17 @@
 name: "Install VTK Dependencies"
 description: "Install multiple VTK Dependencies"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
+  optdeps_label:
+    description: "Label to check for optional dependencies"
+    required: false
+    default: "optdeps"
+  mindeps_label:
+    description: "Label to check for minimal version dependencies"
+    required: false
+    default: "mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -9,47 +20,16 @@ inputs:
     description: "Source directory for actions"
     required: false
     default: "./source"
-  blosc_version:
-    description: "Version of blosc to build"
-    required: true
-  curl_version:
-    description: "Version of curl to build"
-    required: false
-  gdal_version:
-    description: "Version of gdal to build"
-    required: false
-  geotiff_version:
-    description: "Version of geotiff to build"
-    required: false
-  openvdb_version:
-    description: "Version of openvdb to build"
-    required: false
-  pdal_version:
-    description: "Version of pdal to build"
-    required: false
-  proj_version:
-    description: "Version of proj to build"
-    required: false
-  sqlite_csb_version:
-    description: "Version of sqlite common superbuild to build"
-    required: false
-  tbb_version:
-    description: "Version of tbb to build"
-    required: true
-  tiff_version:
-    description: "Version of tiff to build"
-    required: false
-  zlib_version:
-    description: "Version of zlib to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
-    - name: Copy actions to a common directory TODO move to another step ?
+    - name: Check required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Copy actions to a common directory, means this step must be the first one, TODO?
       shell: bash
       working-directory: ${{github.workspace}}
       run: |
@@ -57,109 +37,75 @@ runs:
         cp -r ${{inputs.source_dir}}/.github/actions/* .actions/
 
     - name: Install sqlite
-      if: inputs.sqlite_csb_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: ./.actions/sqlite-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        csb_version: ${{inputs.sqlite_csb_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install proj
-      if: inputs.proj_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: ./.actions/proj-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        version: ${{inputs.proj_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install TBB
       uses: ./.actions/tbb-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.tbb_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install zlib
       uses: ./.actions/zlib-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install curl
-      if: inputs.curl_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: ./.actions/curl-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.curl_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install blosc
       uses: ./.actions/blosc-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.blosc_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install tiff
-      if: inputs.tiff_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: ./.actions/tiff-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.tiff_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install geotiff
-      if: inputs.geotiff_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: ./.actions/geotiff-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.geotiff_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install gdal
-      if: inputs.gdal_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: ./.actions/gdal-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install pdal
-      if: inputs.pdal_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: ./.actions/pdal-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.pdal_version}}
-        curl_version: ${{inputs.curl_version}}
-        gdal_version: ${{inputs.gdal_version}}
-        geotiff_version: ${{inputs.geotiff_version}}
-        proj_version: ${{inputs.proj_version}}
-        sqlite_csb_version: ${{inputs.sqlite_csb_version}}
-        tiff_version: ${{inputs.tiff_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}
 
     - name: Install OpenVDB
-      if: inputs.openvdb_version != ''
+      if: inputs.optdeps_label == 'optdeps'
       uses: ./.actions/openvdb-install-dep
       with:
+        versions_file: ${{inputs.versions_file}}
         cpu: ${{inputs.cpu}}
-        version: ${{inputs.openvdb_version}}
-        blosc_version: ${{inputs.blosc_version}}
-        tbb_version: ${{inputs.tbb_version}}
-        zlib_version: ${{inputs.zlib_version}}
-        global_cache_index: ${{inputs.global_cache_index}}

--- a/.github/actions/vtk-dependencies/action.yml
+++ b/.github/actions/vtk-dependencies/action.yml
@@ -29,7 +29,17 @@ runs:
       run: |
         [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Copy actions to a common directory, specific to external-build CI
+    # This implies this action must be done before other dependencies actions
+    - name: Create dependencies dir
+      shell: bash
+      working-directory: ${{github.workspace}}
+      run: |
+        mkdir dependencies
+        cd dependencies
+        mkdir install
+
+    # Specific to external build CI
+    - name: Copy actions to a common directory
       shell: bash
       working-directory: ${{github.workspace}}
       run: |

--- a/.github/actions/vtk-dependencies/action.yml
+++ b/.github/actions/vtk-dependencies/action.yml
@@ -130,3 +130,11 @@ runs:
         versions_file: ${{inputs.versions_file}}
         mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
+
+    - name: Install Raytracing Dependencies
+      if: inputs.optdeps_label == 'optdeps'
+      uses: ./source/.github/actions/ospray-sb-install-dep
+      with:
+        versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
+        cpu: ${{inputs.cpu}}

--- a/.github/actions/vtk-dependencies/action.yml
+++ b/.github/actions/vtk-dependencies/action.yml
@@ -11,7 +11,7 @@ inputs:
   mindeps_label:
     description: "Label to check for minimal version dependencies"
     required: false
-    default: "mindeps"
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -41,6 +41,7 @@ runs:
       uses: ./.actions/sqlite-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install proj
@@ -48,18 +49,21 @@ runs:
       uses: ./.actions/proj-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install TBB
       uses: ./.actions/tbb-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install zlib
       uses: ./.actions/zlib-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install curl
@@ -67,12 +71,14 @@ runs:
       uses: ./.actions/curl-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install blosc
       uses: ./.actions/blosc-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install tiff
@@ -80,6 +86,7 @@ runs:
       uses: ./.actions/tiff-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install geotiff
@@ -87,6 +94,7 @@ runs:
       uses: ./.actions/geotiff-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install gdal
@@ -94,6 +102,7 @@ runs:
       uses: ./.actions/gdal-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install pdal
@@ -101,6 +110,7 @@ runs:
       uses: ./.actions/pdal-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}
 
     - name: Install OpenVDB
@@ -108,4 +118,5 @@ runs:
       uses: ./.actions/openvdb-install-dep
       with:
         versions_file: ${{inputs.versions_file}}
+        mindeps_label: ${{inputs.mindeps_label}}
         cpu: ${{inputs.cpu}}

--- a/.github/actions/vtk-dependencies/action.yml
+++ b/.github/actions/vtk-dependencies/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         [[ "${{ inputs.versions_file }}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Copy actions to a common directory, means this step must be the first one, TODO?
+    - name: Copy actions to a common directory, specific to external-build CI
       shell: bash
       working-directory: ${{github.workspace}}
       run: |

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -164,7 +164,7 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: dependencies/vtk_install
-        key: vtk-${{env.VTK_VERSION}}-${{steps.zlib_ver.outputs.extract}}-${{steps.blosc_ver.outputs.extract}}-${{steps.tbb_ver.outputs.extract}}${{ steps.openvdb_ver.outputs.extract != '' && format('-openvdb-{0}', steps.openvdb_ver.outputs.extract) || '' }}${{ steps.ospray_ver.outputs.extract != '' && format('-ospray-{0}', steps.ospray_ver.outputs.extract) || '' }}${{ steps.curl_ver.outputs.extract != '' && format('-curl-{0}', steps.curl_ver.outputs.extract) || '' }}${{ steps.gdal_ver.outputs.extract != '' && format('-gdal-{0}', steps.gdal_ver.outputs.extract) || '' }}${{ steps.geotiff_ver.outputs.extract != '' && format('-geotiff-{0}', steps.geotiff_ver.outputs.extract) || '' }}${{ steps.pdal_ver.outputs.extract != '' && format('-pdal-{0}', steps.pdal_ver.outputs.extract) || '' }}${{ steps.proj_ver.outputs.extract != '' && format('-proj-{0}', steps.proj_ver.outputs.extract) || '' }}${{ steps.sqlite_csb_ver.outputs.extract != '' && format('-sqlite-{0}', steps.sqlite_csb_ver.outputs.extract) || '' }}${{ steps.tiff_ver.outputs.extract != '' && format('-tiff-{0}', steps.tiff_ver.outputs.extract) || '' }}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-4
+        key: vtk-${{env.VTK_VERSION}}-${{steps.zlib_ver.outputs.extract}}-${{steps.blosc_ver.outputs.extract}}-${{steps.tbb_ver.outputs.extract}}${{ steps.openvdb_ver.outputs.extract != '' && format('-openvdb-{0}', steps.openvdb_ver.outputs.extract) || '' }}${{ steps.ospray_ver.outputs.extract != '' && format('-ospray-{0}', steps.ospray_ver.outputs.extract) || '' }}${{ steps.curl_ver.outputs.extract != '' && format('-curl-{0}', steps.curl_ver.outputs.extract) || '' }}${{ steps.gdal_ver.outputs.extract != '' && format('-gdal-{0}', steps.gdal_ver.outputs.extract) || '' }}${{ steps.geotiff_ver.outputs.extract != '' && format('-geotiff-{0}', steps.geotiff_ver.outputs.extract) || '' }}${{ steps.pdal_ver.outputs.extract != '' && format('-pdal-{0}', steps.pdal_ver.outputs.extract) || '' }}${{ steps.proj_ver.outputs.extract != '' && format('-proj-{0}', steps.proj_ver.outputs.extract) || '' }}${{ steps.sqlite_csb_ver.outputs.extract != '' && format('-sqlite-{0}', steps.sqlite_csb_ver.outputs.extract) || '' }}${{ steps.tiff_ver.outputs.extract != '' && format('-tiff-{0}', steps.tiff_ver.outputs.extract) || '' }}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-5
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'
@@ -209,7 +209,7 @@ runs:
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX:PATH=../vtk_install
         -DCMAKE_PREFIX_PATH:PATH=$(pwd)/../install/
-        -DOpenVDB_CMAKE_PATH=${{ inputs.optdeps == 'optdeps' && '$(pwd)/../install/lib/cmake/OpenVDB/' || '' }}
+        -DOpenVDB_CMAKE_PATH=${{ inputs.optdeps_label == 'optdeps' && '$(pwd)/../install/lib/cmake/OpenVDB/' || '' }}
         -DVTKOSPRAY_ENABLE_DENOISER=ON
         -DVTK_BUILD_TESTING=OFF
         -DVTK_DEBUG_LEAKS=ON
@@ -231,8 +231,8 @@ runs:
         -DVTK_MODULE_ENABLE_VTK_IOImport=YES
         -DVTK_MODULE_ENABLE_VTK_IOLegacy=YES
         -DVTK_MODULE_ENABLE_VTK_IONetCDF=YES
-        -DVTK_MODULE_ENABLE_VTK_IOOpenVDB=${{ inputs.optdeps == 'optdeps' && 'YES' || 'DEFAULT' }}
-        -DVTK_MODULE_ENABLE_VTK_IOPDAL=${{ inputs.optdeps == 'optdeps' && 'YES' || 'DEFAULT' }}
+        -DVTK_MODULE_ENABLE_VTK_IOOpenVDB=${{ inputs.optdeps_label == 'optdeps' && 'YES' || 'DEFAULT' }}
+        -DVTK_MODULE_ENABLE_VTK_IOPDAL=${{ inputs.optdeps_label == 'optdeps' && 'YES' || 'DEFAULT' }}
         -DVTK_MODULE_ENABLE_VTK_IOPLY=YES
         -DVTK_MODULE_ENABLE_VTK_IOXML=YES
         -DVTK_MODULE_ENABLE_VTK_ImagingCore=YES
@@ -243,7 +243,7 @@ runs:
         -DVTK_MODULE_ENABLE_VTK_RenderingCore=YES
         -DVTK_MODULE_ENABLE_VTK_RenderingGridAxes=YES
         -DVTK_MODULE_ENABLE_VTK_RenderingOpenGL2=YES
-        -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing=${{ inputs.optdeps == 'optdeps' && 'YES' || 'DEFAULT' }}
+        -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing=${{ inputs.optdeps_label == 'optdeps' && 'YES' || 'DEFAULT' }}
         -DVTK_MODULE_ENABLE_VTK_RenderingVolumeOpenGL2=YES
         -DVTK_MODULE_ENABLE_VTK_TestingCore=YES
         -DVTK_OPENGL_HAS_EGL=${{ runner.os != 'macOS' && 'ON' || 'OFF' }}

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: "no-mindeps"
   vtk_version:
-    description: "VTK version"
+    description: "VTK version, either a hash/tag, or 'commit', which means recover from versions.json"
     required: false
     default: "commit"
   cpu:
@@ -42,7 +42,7 @@ runs:
       shell: bash
       run: echo "VTK_VERSION=${{steps.vtk_ver.outputs.extract}}" >> $GITHUB_ENV
 
-    - name: Store input vtk version directitly
+    - name: Store VTK version in env from the input directly
       if: inputs.vtk_version != 'commit'
       shell: bash
       run: echo "VTK_VERSION=${{inputs.vtk_version}}" >> $GITHUB_ENV

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -1,6 +1,17 @@
 name: "Install VTK Dependency"
 description: "Install VTK Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
+  optdeps_label:
+    description: "Label to flag for optional dependencies"
+    required: false
+    default: "optdeps"
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   vtk_version:
     description: "VTK version"
     required: true
@@ -8,45 +19,6 @@ inputs:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  blosc_version:
-    description: "Version of blosc to build against"
-    required: true
-  curl_version:
-    description: "Version of gdal to build against"
-    required: false
-  gdal_version:
-    description: "Version of gdal to build against"
-    required: false
-  geotiff_version:
-    description: "Version of geotiff to build against"
-    required: false
-  openvdb_version:
-    description: "Version of openvdb to build against"
-    required: false
-  ospray_version:
-    description: "Version of ospray to build against"
-    required: false
-  pdal_version:
-    description: "Version of pdal to build against"
-    required: false
-  proj_version:
-    description: "Version of proj to build against"
-    required: false
-  sqlite_csb_version:
-    description: "Version of csb providing sqlite to build against"
-    required: false
-  tiff_version:
-    description: "Version of tiff to build against"
-    required: false
-  tbb_version:
-    description: "Version of tbb to build against"
-    required: true
-  zlib_version:
-    description: "Version of zlib to build against"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -54,18 +26,145 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.vtk_version }}" ]] || { echo "vtk_version input is empty" ; exit 1; }
-        [[ "${{ inputs.blosc_version }}" ]] || { echo "blosc_version input is empty" ; exit 1; }
-        [[ "${{ inputs.tbb_version }}" ]] || { echo "tbb_version input is empty" ; exit 1; }
-        [[ "${{ inputs.zlib_version }}" ]] || { echo "zlib_version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+        [[ "${{inputs.vtk_versions}}" ]] || { echo "vtk_version is empty" ; exit 1; }
+
+    - name: Recover VTK version if needed
+      if: inputs.vtk_version == 'commit'
+      id: vtk_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: vtk_commit_sha
+
+    - name: Store VTK version in env
+      if: inputs.vtk_version == 'commit'
+      shell: bash
+      run: echo "VTK_VERSION=${{steps.vtk_ver.outputs.extract}}" >> $GITHUB_ENV
+
+    - name: Name to extract is special name
+      if: inputs.special_name != 'commit'
+      shell: bash
+      run: echo "VTK_VERSION=${{inputs.vtk_version}}" >> $GITHUB_ENV
+
+    - name: Extract zlib version
+      id: zlib_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: zlib
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract blosc version
+      id: blosc_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: blosc
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract tbb version
+      id: tbb_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: tbb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract openvdb version
+      if: inputs.optdeps_label == 'optdeps'
+      id: openvdb_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: openvdb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract ospray version
+      if: inputs.optdeps_label == 'optdeps'
+      id: ospray_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: ospray
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract curl version
+      if: inputs.optdeps_label == 'optdeps'
+      id: curl_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: curl
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract gdal version
+      if: inputs.optdeps_label == 'optdeps'
+      id: gdal_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: gdal
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract geotiff version
+      if: inputs.optdeps_label == 'optdeps'
+      id: geotiff_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: geotiff
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract pdal version
+      if: inputs.optdeps_label == 'optdeps'
+      id: pdal_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: pdal
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract proj version
+      if: inputs.optdeps_label == 'optdeps'
+      id: proj_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: proj
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract sqlite_csb version
+      if: inputs.optdeps_label == 'optdeps'
+      id: sqlite_csb_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: sqlite_csb
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract tiff version
+      if: inputs.optdeps_label == 'optdeps'
+      id: tiff_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: tiff
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache VTK
       id: cache-vtk
       uses: actions/cache/restore@v5
       with:
         path: dependencies/vtk_install
-        key: vtk-${{ inputs.vtk_version }}-${{inputs.zlib_version}}-${{inputs.blosc_version}}-${{inputs.tbb_version}}${{ inputs.openvdb_version != '' && format('-openvdb-{0}', inputs.openvdb_version) || '' }}${{ inputs.ospray_version != '' && format('-ospray-{0}', inputs.ospray_version) || '' }}${{ inputs.curl_version != '' && format('-curl-{0}', inputs.curl_version) || '' }}${{ inputs.gdal_version != '' && format('-gdal-{0}', inputs.gdal_version) || '' }}${{ inputs.geotiff_version != '' && format('-geotiff-{0}', inputs.geotiff_version) || '' }}${{ inputs.pdal_version != '' && format('-pdal-{0}', inputs.pdal_version) || '' }}${{ inputs.proj_version != '' && format('-proj-{0}', inputs.proj_version) || '' }}${{ inputs.sqlite_csb_version != '' && format('-sqlite-{0}', inputs.sqlite_csb_version) || '' }}${{ inputs.tiff_version != '' && format('-tiff-{0}', inputs.tiff_version) || '' }}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-3
+        key: vtk-${{env.VTK_VERSION}}-${{steps.zlib_ver.outputs.extract}}-${{steps.blosc_ver.outputs.extract}}-${{steps.tbb_ver.outputs.extract}}${{ steps.openvdb_ver.outputs.extract != '' && format('-openvdb-{0}', steps.openvdb_ver.outputs.extract) || '' }}${{ steps.ospray_ver.outputs.extract != '' && format('-ospray-{0}', steps.ospray_ver.outputs.extract) || '' }}${{ steps.curl_ver.outputs.extract != '' && format('-curl-{0}', steps.curl_ver.outputs.extract) || '' }}${{ steps.gdal_ver.outputs.extract != '' && format('-gdal-{0}', steps.gdal_ver.outputs.extract) || '' }}${{ steps.geotiff_ver.outputs.extract != '' && format('-geotiff-{0}', steps.geotiff_ver.outputs.extract) || '' }}${{ steps.pdal_ver.outputs.extract != '' && format('-pdal-{0}', steps.pdal_ver.outputs.extract) || '' }}${{ steps.proj_ver.outputs.extract != '' && format('-proj-{0}', steps.proj_ver.outputs.extract) || '' }}${{ inputs.sqlite_csb_version != '' && format('-sqlite-{0}', inputs.sqlite_csb_version) || '' }}${{ steps.tiff_ver.outputs.extract != '' && format('-tiff-{0}', steps.tiff_ver.outputs.extract) || '' }}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-3
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'
@@ -84,7 +183,7 @@ runs:
         submodules: true
         fetch-depth: 0
         path: "./dependencies/vtk"
-        ref: ${{ inputs.vtk_version }}
+        ref: ${{env.VTK_VERSION}}
 
     # CMake 3.31 introduced a new policy producing a warning when using vtkModule.cmake
     # See https://gitlab.kitware.com/vtk/vtk/-/issues/19526

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -21,10 +21,6 @@ inputs:
     required: false
     default: "x86_64"
 
-outputs:
-  vtk_commitish:
-    value: "${{steps.extract_vtk_commit-ish.outputs.vtk_commitish}}"
-
 runs:
   using: "composite"
   steps:
@@ -50,11 +46,6 @@ runs:
       if: inputs.vtk_version != 'commit'
       shell: bash
       run: echo "VTK_VERSION=${{inputs.vtk_version}}" >> $GITHUB_ENV
-
-    - name: Output VTK commitish
-      id: extract_vtk_commitish
-      shell: bash
-      run: echo "vtk_commitish=${{env.VTK_VERSION}} >> $GITHUB_OUTPUT
 
     - name: Extract zlib version
       id: zlib_ver

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -164,7 +164,7 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: dependencies/vtk_install
-        key: vtk-${{env.VTK_VERSION}}-${{steps.zlib_ver.outputs.extract}}-${{steps.blosc_ver.outputs.extract}}-${{steps.tbb_ver.outputs.extract}}${{ steps.openvdb_ver.outputs.extract != '' && format('-openvdb-{0}', steps.openvdb_ver.outputs.extract) || '' }}${{ steps.ospray_ver.outputs.extract != '' && format('-ospray-{0}', steps.ospray_ver.outputs.extract) || '' }}${{ steps.curl_ver.outputs.extract != '' && format('-curl-{0}', steps.curl_ver.outputs.extract) || '' }}${{ steps.gdal_ver.outputs.extract != '' && format('-gdal-{0}', steps.gdal_ver.outputs.extract) || '' }}${{ steps.geotiff_ver.outputs.extract != '' && format('-geotiff-{0}', steps.geotiff_ver.outputs.extract) || '' }}${{ steps.pdal_ver.outputs.extract != '' && format('-pdal-{0}', steps.pdal_ver.outputs.extract) || '' }}${{ steps.proj_ver.outputs.extract != '' && format('-proj-{0}', steps.proj_ver.outputs.extract) || '' }}${{ inputs.sqlite_csb_version != '' && format('-sqlite-{0}', inputs.sqlite_csb_version) || '' }}${{ steps.tiff_ver.outputs.extract != '' && format('-tiff-{0}', steps.tiff_ver.outputs.extract) || '' }}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-3
+        key: vtk-${{env.VTK_VERSION}}-${{steps.zlib_ver.outputs.extract}}-${{steps.blosc_ver.outputs.extract}}-${{steps.tbb_ver.outputs.extract}}${{ steps.openvdb_ver.outputs.extract != '' && format('-openvdb-{0}', steps.openvdb_ver.outputs.extract) || '' }}${{ steps.ospray_ver.outputs.extract != '' && format('-ospray-{0}', steps.ospray_ver.outputs.extract) || '' }}${{ steps.curl_ver.outputs.extract != '' && format('-curl-{0}', steps.curl_ver.outputs.extract) || '' }}${{ steps.gdal_ver.outputs.extract != '' && format('-gdal-{0}', steps.gdal_ver.outputs.extract) || '' }}${{ steps.geotiff_ver.outputs.extract != '' && format('-geotiff-{0}', steps.geotiff_ver.outputs.extract) || '' }}${{ steps.pdal_ver.outputs.extract != '' && format('-pdal-{0}', steps.pdal_ver.outputs.extract) || '' }}${{ steps.proj_ver.outputs.extract != '' && format('-proj-{0}', steps.proj_ver.outputs.extract) || '' }}${{ steps.sqlite_csb_ver.outputs.extract != '' && format('-sqlite-{0}', steps.sqlite_csb_ver.outputs.extract) || '' }}${{ steps.tiff_ver.outputs.extract != '' && format('-tiff-{0}', steps.tiff_ver.outputs.extract) || '' }}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-4
 
     - name: Setup VTK
       if: steps.cache-vtk.outputs.cache-hit != 'true'
@@ -209,7 +209,7 @@ runs:
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX:PATH=../vtk_install
         -DCMAKE_PREFIX_PATH:PATH=$(pwd)/../install/
-        -DOpenVDB_CMAKE_PATH=${{ inputs.openvdb_version != '' && '$(pwd)/../install/lib/cmake/OpenVDB/' || '' }}
+        -DOpenVDB_CMAKE_PATH=${{ inputs.optdeps == 'optdeps' && '$(pwd)/../install/lib/cmake/OpenVDB/' || '' }}
         -DVTKOSPRAY_ENABLE_DENOISER=ON
         -DVTK_BUILD_TESTING=OFF
         -DVTK_DEBUG_LEAKS=ON
@@ -231,8 +231,8 @@ runs:
         -DVTK_MODULE_ENABLE_VTK_IOImport=YES
         -DVTK_MODULE_ENABLE_VTK_IOLegacy=YES
         -DVTK_MODULE_ENABLE_VTK_IONetCDF=YES
-        -DVTK_MODULE_ENABLE_VTK_IOOpenVDB=${{ inputs.openvdb_version != '' && 'YES' || 'DEFAULT' }}
-        -DVTK_MODULE_ENABLE_VTK_IOPDAL=${{ inputs.pdal_version != '' && 'YES' || 'DEFAULT' }}
+        -DVTK_MODULE_ENABLE_VTK_IOOpenVDB=${{ inputs.optdeps == 'optdeps' && 'YES' || 'DEFAULT' }}
+        -DVTK_MODULE_ENABLE_VTK_IOPDAL=${{ inputs.optdeps == 'optdeps' && 'YES' || 'DEFAULT' }}
         -DVTK_MODULE_ENABLE_VTK_IOPLY=YES
         -DVTK_MODULE_ENABLE_VTK_IOXML=YES
         -DVTK_MODULE_ENABLE_VTK_ImagingCore=YES
@@ -243,7 +243,7 @@ runs:
         -DVTK_MODULE_ENABLE_VTK_RenderingCore=YES
         -DVTK_MODULE_ENABLE_VTK_RenderingGridAxes=YES
         -DVTK_MODULE_ENABLE_VTK_RenderingOpenGL2=YES
-        -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing=${{ inputs.ospray_version != '' && 'YES' || 'DEFAULT' }}
+        -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing=${{ inputs.optdeps == 'optdeps' && 'YES' || 'DEFAULT' }}
         -DVTK_MODULE_ENABLE_VTK_RenderingVolumeOpenGL2=YES
         -DVTK_MODULE_ENABLE_VTK_TestingCore=YES
         -DVTK_OPENGL_HAS_EGL=${{ runner.os != 'macOS' && 'ON' || 'OFF' }}

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -14,11 +14,16 @@ inputs:
     default: "no-mindeps"
   vtk_version:
     description: "VTK version"
-    required: true
+    required: false
+    default: "commit"
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
+
+outputs:
+  vtk_commitish:
+    value: "${{steps.extract_vtk_commit-ish.outputs.vtk_commitish}}"
 
 runs:
   using: "composite"
@@ -27,7 +32,6 @@ runs:
       shell: bash
       run: |
         [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
-        [[ "${{inputs.vtk_version}}" ]] || { echo "vtk_version is empty" ; exit 1; }
 
     - name: Recover VTK version if needed
       if: inputs.vtk_version == 'commit'
@@ -42,10 +46,15 @@ runs:
       shell: bash
       run: echo "VTK_VERSION=${{steps.vtk_ver.outputs.extract}}" >> $GITHUB_ENV
 
-    - name: Name to extract is special name
+    - name: Store input vtk version directitly
       if: inputs.vtk_version != 'commit'
       shell: bash
       run: echo "VTK_VERSION=${{inputs.vtk_version}}" >> $GITHUB_ENV
+
+    - name: Output VTK commitish
+      id: extract_vtk_commitish
+      shell: bash
+      run: echo "vtk_commitish=${{env.VTK_VERSION}} >> $GITHUB_OUTPUT
 
     - name: Extract zlib version
       id: zlib_ver

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
       run: |
         [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
-        [[ "${{inputs.vtk_versions}}" ]] || { echo "vtk_version is empty" ; exit 1; }
+        [[ "${{inputs.vtk_version}}" ]] || { echo "vtk_version is empty" ; exit 1; }
 
     - name: Recover VTK version if needed
       if: inputs.vtk_version == 'commit'

--- a/.github/actions/vtk-install-dep/action.yml
+++ b/.github/actions/vtk-install-dep/action.yml
@@ -43,7 +43,7 @@ runs:
       run: echo "VTK_VERSION=${{steps.vtk_ver.outputs.extract}}" >> $GITHUB_ENV
 
     - name: Name to extract is special name
-      if: inputs.special_name != 'commit'
+      if: inputs.vtk_version != 'commit'
       shell: bash
       run: echo "VTK_VERSION=${{inputs.vtk_version}}" >> $GITHUB_ENV
 

--- a/.github/actions/webifc-install-dep/action.yml
+++ b/.github/actions/webifc-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false

--- a/.github/actions/webifc-install-dep/action.yml
+++ b/.github/actions/webifc-install-dep/action.yml
@@ -44,7 +44,7 @@ runs:
       with:
         repository: ThatOpen/engine_web-ifc
         path: "./dependencies/webifc"
-        ref: ${{inputs.version}}
+        ref: ${{steps.webifc_ver.outputs.extract}}
 
     - name: Setup webifc
       if: steps.cache-webifc.outputs.cache-hit != 'true'

--- a/.github/actions/webifc-install-dep/action.yml
+++ b/.github/actions/webifc-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract webifc version
       id: webifc_ver

--- a/.github/actions/webifc-install-dep/action.yml
+++ b/.github/actions/webifc-install-dep/action.yml
@@ -1,32 +1,41 @@
 name: "Install webifc Dependency"
 description: "Install webifc Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
-    required: true
+    required: false
     default: "x86_64"
-  version:
-    description: "Version of webifc to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract webifc version
+      id: webifc_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: webifc
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache webifc
       id: cache-webifc
       uses: actions/cache/restore@v5
       with:
         path: dependencies/webifc_install
-        key: webifc-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
+        key: webifc-${{steps.webifc_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-1
 
     - name: Checkout webifc
       if: steps.cache-webifc.outputs.cache-hit != 'true'

--- a/.github/actions/webp-install-dep/action.yml
+++ b/.github/actions/webp-install-dep/action.yml
@@ -44,7 +44,7 @@ runs:
       with:
         repository: webmproject/libwebp
         path: "./dependencies/webp"
-        ref: ${{inputs.version}}
+        ref: ${{steps.webp_ver.outputs.extract}}
 
     - name: Setup WebP
       if: steps.cache-webp.outputs.cache-hit != 'true'

--- a/.github/actions/webp-install-dep/action.yml
+++ b/.github/actions/webp-install-dep/action.yml
@@ -1,32 +1,41 @@
 name: "Install WebP Dependency"
 description: "Install WebP Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of WebP to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
-    - name: Cache WebP
+    - name: Extract webp version
+      id: webp_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: webp
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
+
+    - name: Cache webp
       id: cache-webp
       uses: actions/cache/restore@v5
       with:
         path: dependencies/webp_install
-        key: webp-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
+        key: webp-${{steps.webp_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-1
 
     - name: Checkout WebP
       if: steps.cache-webp.outputs.cache-hit != 'true'

--- a/.github/actions/webp-install-dep/action.yml
+++ b/.github/actions/webp-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract webp version
       id: webp_ver

--- a/.github/actions/webp-install-dep/action.yml
+++ b/.github/actions/webp-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: webp
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/zlib-install-dep/action.yml
+++ b/.github/actions/zlib-install-dep/action.yml
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: |
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract zlib version
       id: zlib_ver

--- a/.github/actions/zlib-install-dep/action.yml
+++ b/.github/actions/zlib-install-dep/action.yml
@@ -1,16 +1,13 @@
 name: "Install zlib Dependency"
 description: "Install zlib Dependency using cache when possible"
 inputs:
+  versions_file:
+    description: "File to recover versions from"
+    required: true
   cpu:
     description: "CPU architecture to build for"
     required: false
     default: "x86_64"
-  version:
-    description: "Version of zlib to build"
-    required: true
-  global_cache_index:
-    description: "Global cache index"
-    required: true
 
 runs:
   using: "composite"
@@ -18,15 +15,28 @@ runs:
     - name: Check required inputs
       shell: bash
       run: |
-        [[ "${{ inputs.version }}" ]] || { echo "version input is empty" ; exit 1; }
-        [[ "${{ inputs.global_cache_index }}" ]] || { echo "global_cache_index input is empty" ; exit 1; }
+        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+
+    - name: Extract zlib version
+      id: zlib_ver
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        name: zlib
+
+    - name: Extract global cache index
+      id: global_idx
+      uses: f3d-app/extract-version-action@main
+      with:
+        file: ${{inputs.versions_file}}
+        special_name: global_cache_index
 
     - name: Cache zlib
       id: cache-zlib
       uses: actions/cache/restore@v5
       with:
         path: dependencies/zlib_install
-        key: zlib-${{inputs.version}}-${{runner.os}}-${{inputs.cpu}}-${{inputs.global_cache_index}}-1
+        key: zlib-${{steps.zlib_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-1
 
     # Dependents: blosc openvdb vtk tiff geotiff pdal gdal
     - name: Checkout zlib
@@ -35,7 +45,7 @@ runs:
       with:
         repository: madler/zlib
         path: "./dependencies/zlib"
-        ref: ${{inputs.version}}
+        ref: ${{steps.zlib_ver.outputs.extract}}
 
     - name: Setup zlib
       if: steps.cache-zlib.outputs.cache-hit != 'true'

--- a/.github/actions/zlib-install-dep/action.yml
+++ b/.github/actions/zlib-install-dep/action.yml
@@ -4,6 +4,10 @@ inputs:
   versions_file:
     description: "File to recover versions from"
     required: true
+  mindeps_label:
+    description: "Label to flag for minimum versions dependencies"
+    required: false
+    default: "no-mindeps"
   cpu:
     description: "CPU architecture to build for"
     required: false
@@ -23,6 +27,7 @@ runs:
       with:
         file: ${{inputs.versions_file}}
         name: zlib
+        minver_label: ${{inputs.mindeps_label == 'mindeps' && 'minver' || ''}}
 
     - name: Extract global cache index
       id: global_idx

--- a/.github/actions/zlib-install-dep/action.yml
+++ b/.github/actions/zlib-install-dep/action.yml
@@ -14,8 +14,7 @@ runs:
   steps:
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
+      run: [[ "${{inputs.versions_file}}" ]] || { echo "versions_file is empty" ; exit 1; }
 
     - name: Extract zlib version
       id: zlib_ver

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,3 +1,5 @@
+name: Build docker images
+
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
@@ -8,18 +10,18 @@ on:
       - "doc/**"
       - "_config.yml"
 
-name: Build docker images
+concurrency:
+  group: "${{ github.workflow }}-${{GITHUB_HEAD_REF}}"
+  cancel-in-progress: true
+
 jobs:
   #----------------------------------------------------------------------------
-  # Default versions: Set default version for all dependencies
+  # Build android/wasm docker images if needed
   #----------------------------------------------------------------------------
-  default_versions:
-    runs-on: ubuntu-22.04
-    name: Set default versions
-    if: contains(github.event.pull_request.labels.*.name, 'ci:full')
-    outputs:
-      docker_timestamp: ${{ steps.set_default_versions.outputs.docker_timestamp }}
-
+  build_docker_images:
+    name: Build docker images
+    if: contains(github.event.pull_request.labels.*.name, 'ci:cache')
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,30 +31,23 @@ jobs:
           fetch-depth: 1
           lfs: false
 
-      - name: Set default versions
-        id: set_default_versions
-        uses: f3d-app/default-versions-action@main
+      - name: Extract docker timestamp
+        id: docker_timestamp
+        uses: f3d-app/extract-version-action@main
         with:
           file: ./source/.github/workflows/versions.json
+          special_name: docker_timestamp
 
-  #----------------------------------------------------------------------------
-  # Build android/wasm docker images if needed
-  #----------------------------------------------------------------------------
-  build_docker_images:
-    needs: default_versions
-    name: Build docker images
-    runs-on: ubuntu-latest
-    steps:
       - name: Check docker images exists
         shell: bash
         working-directory: ${{github.workspace}}
         run: |
           res=0
-          docker manifest inspect ghcr.io/f3d-app/f3d-wasm:${{needs.default_versions.outputs.docker_timestamp}} || res=$?
-          docker manifest inspect ghcr.io/f3d-app/f3d-android-armeabi-v7a:${{needs.default_versions.outputs.docker_timestamp}} || res=$?
-          docker manifest inspect ghcr.io/f3d-app/f3d-android-arm64-v8a:${{needs.default_versions.outputs.docker_timestamp}} || res=$?
-          docker manifest inspect ghcr.io/f3d-app/f3d-android-x86:${{needs.default_versions.outputs.docker_timestamp}} || res=$?
-          docker manifest inspect ghcr.io/f3d-app/f3d-android-x86_64:${{needs.default_versions.outputs.docker_timestamp}} || res=$?
+          docker manifest inspect ghcr.io/f3d-app/f3d-wasm:${{steps.docker_timestamp.outputs.extract}} || res=$?
+          docker manifest inspect ghcr.io/f3d-app/f3d-android-armeabi-v7a:${{steps.docker_timestamp.outputs.extract}} || res=$?
+          docker manifest inspect ghcr.io/f3d-app/f3d-android-arm64-v8a:${{steps.docker_timestamp.outputs.extract}} || res=$?
+          docker manifest inspect ghcr.io/f3d-app/f3d-android-x86:${{steps.docker_timestamp.outputs.extract}} || res=$?
+          docker manifest inspect ghcr.io/f3d-app/f3d-android-x86_64:${{steps.docker_timestamp.outputs.extract}} || res=$?
           echo "F3D_DOCKER_IMAGE_AVAILABLE=$res" >> $GITHUB_ENV
 
       # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -11,7 +11,7 @@ on:
       - "_config.yml"
 
 concurrency:
-  group: "${{ github.workflow }}-${{GITHUB_HEAD_REF}}"
+  group: "${{ github.workflow }}-${{  github.ref_name }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -45,4 +45,4 @@ jobs:
           versions_file: ./source/.github/workflows/versions.json
           optdeps_label: ${{matrix.optdeps_label}}
           mindeps_label: ${{matrix.mindeps_label}}
-          cpu: x86_64
+          cpu: cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -26,14 +26,14 @@ jobs:
         uses: f3d-app/extract-version-action@main
         with:
           file: ./.github/workflows/versions.json
-          name: versions.sqlite_csb
+          name: sqlite_csb
 
       - name: Extract global cache index
         id: global_idx
         uses: f3d-app/extract-version-action@main
         with:
           file: ./.github/workflows/versions.json
-          name: global_cache_index
+          special_name: global_cache_index
 
       - name: Dependencies Dir
         shell: bash

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -34,5 +34,3 @@ jobs:
         with:
           cpu: x86_64
           versions_file: .github/workflows/versions.json
-          csb_version: ${{steps.sqlite_ver.outputs.extract}}
-          global_cache_index: ${{steps.global_idx.outputs.extract}}

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -22,7 +22,6 @@ jobs:
           lfs: false
 
       - name: Install sqlite
-        if: inputs.sqlite_csb_version != ''
         uses: ./.actions/sqlite-install-dep
         with:
           cpu: x86_64

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Install Raytracing Dependencies
         uses: ./source/.github/actions/ospray-sb-install-dep
         with:
-          versions_file: .github/workflows/versions.json
+          versions_file: ./source/.github/workflows/versions.json
           cpu: x86_64
 
       - name: Install F3D dependencies
         uses: ./source/.github/actions/f3d-dependencies
         with:
-          versions_file: .github/workflows/versions.json
+          versions_file: ./source/.github/workflows/versions.json
           cpu: x86_64

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -14,19 +14,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-22.04, windows-latest, macos-15, macos-15-intel]
         build_type: [standard]
         include:
           - optdeps_label: optdeps
           - mindeps_label: no-mindeps
           - build_type: mindeps
+            os: ubuntu-22.04
             optdeps_label: optdeps
             mindeps_label: mindeps
-          - build_type: no-optdeps
-            optdeps_label: no-optdeps
-            mindeps_label: no-mindeps
 
-    runs-on: ubuntu-22.04
-    container: ghcr.io/f3d-app/f3d-ci
+    runs-on: ${{matrix.os}}
+    container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
 
     env:
       CMAKE_POLICY_VERSION_MINIMUM: 3.5

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-15, macos-15-intel]
-        vtk_version: [ commit, v9.6.1, v9.5.2, v9.4.2]
+        vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
         build_type: [standard]
         include:
           - optdeps_label: optdeps

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -45,4 +45,4 @@ jobs:
           versions_file: ./source/.github/workflows/versions.json
           optdeps_label: ${{matrix.optdeps_label}}
           mindeps_label: ${{matrix.mindeps_label}}
-          cpu: cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
+          cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -21,6 +21,13 @@ jobs:
           fetch-depth: 1
           lfs: false
 
+      - name: Extract sqlite version
+        id: extract_sqlite_versions
+        uses: f3d-app/extract-version-action@main
+        with:
+          file: ./.github/workflows/versions.json
+          name: sqlite_csb
+
       - name: Dependencies Dir
         shell: bash
         working-directory: ${{github.workspace}}
@@ -33,5 +40,5 @@ jobs:
         uses: ./.github/actions/sqlite-install-dep
         with:
           cpu: x86_64
-          csb_version: 08be462f7fa9816f881dbb93eacb2e287f319208
+          csb_version: ${{steps.extract_sqlite_versions.outputs.extracted}}
           global_cache_index: 0

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -1,0 +1,30 @@
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - master
+      - release
+name: Style Checks
+jobs:
+  #----------------------------------------------------------------------------
+  # Cache preheating
+  #----------------------------------------------------------------------------
+  cache_preheating:
+    name: Cache Preheating
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 1
+          lfs: false
+
+      - name: Install sqlite
+        if: inputs.sqlite_csb_version != ''
+        uses: ./.actions/sqlite-install-dep
+        with:
+          cpu: x86_64
+          csb_version: 08be462f7fa9816f881dbb93eacb2e287f319208
+          global_cache_index: 0

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -38,3 +38,15 @@ jobs:
         with:
           versions_file: ./source/.github/workflows/versions.json
           cpu: x86_64
+
+      - name: Install Raytracing Dependencies
+        uses: ./source/.github/actions/ospray-sb-install-dep
+        with:
+          versions_file: .github/workflows/versions.json
+          cpu: x86_64
+
+      - name: Install F3D dependencies
+        uses: ./source/.github/actions/f3d-dependencies
+        with:
+          versions_file: .github/workflows/versions.json
+          cpu: x86_64

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -11,13 +11,17 @@ jobs:
   #----------------------------------------------------------------------------
   cache_preheating:
     name: Cache Preheating
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    container: ghcr.io/f3d-app/f3d-ci
+    env:
+      CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+          path: "source"
           fetch-depth: 1
           lfs: false
 
@@ -29,8 +33,8 @@ jobs:
           cd dependencies
           mkdir install
 
-      - name: Install sqlite
-        uses: ./.github/actions/sqlite-install-dep
+      - name: VTK Dependencies
+        uses: ./source/.github/actions/vtk-dependencies
         with:
+          versions_file: ./source/.github/workflows/versions.json
           cpu: x86_64
-          versions_file: .github/workflows/versions.json

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -28,6 +28,13 @@ jobs:
           file: ./.github/workflows/versions.json
           name: versions.sqlite_csb
 
+      - name: Extract global cache index
+        id: global_idx
+        uses: f3d-app/extract-version-action@main
+        with:
+          file: ./.github/workflows/versions.json
+          name: global_cache_index
+
       - name: Dependencies Dir
         shell: bash
         working-directory: ${{github.workspace}}
@@ -41,4 +48,4 @@ jobs:
         with:
           cpu: x86_64
           csb_version: ${{steps.sqlite_ver.outputs.extract}}
-          global_cache_index: 0
+          global_cache_index: ${{steps.global_idx.outputs.extract}}

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
       - release
-name: Style Checks
+name: Cache preheating
 jobs:
   #----------------------------------------------------------------------------
   # Cache preheating

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -22,11 +22,11 @@ jobs:
           lfs: false
 
       - name: Extract sqlite version
-        id: extract_sqlite_versions
+        id: sqlite_ver
         uses: f3d-app/extract-version-action@main
         with:
           file: ./.github/workflows/versions.json
-          name: sqlite_csb
+          name: versions.sqlite_csb
 
       - name: Dependencies Dir
         shell: bash
@@ -40,5 +40,5 @@ jobs:
         uses: ./.github/actions/sqlite-install-dep
         with:
           cpu: x86_64
-          csb_version: ${{steps.extract_sqlite_versions.outputs.extracted}}
+          csb_version: ${{steps.sqlite_ver.outputs.extract}}
           global_cache_index: 0

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -7,10 +7,10 @@ on:
 name: Cache preheating
 jobs:
   #----------------------------------------------------------------------------
-  # Cache preheating
+  # Cache preheating all dependencies
   #----------------------------------------------------------------------------
-  cache_preheating:
-
+  cache_preheating_dependencies:
+    name: Preheat dependency caches
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +26,6 @@ jobs:
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
-
     env:
       CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
@@ -46,3 +45,48 @@ jobs:
           optdeps_label: ${{matrix.optdeps_label}}
           mindeps_label: ${{matrix.mindeps_label}}
           cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
+
+  #----------------------------------------------------------------------------
+  # Cache preheating VTK
+  #----------------------------------------------------------------------------
+  cache_preheating_vtk:
+    needs: [cache_preheating_dependencies]
+    name: Preheat VTK dependency caches
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-latest, macos-15, macos-15-intel]
+        vtk_version: [ commit, v9.6.1, v9.5.2, v9.4.2]
+        build_type: [standard]
+        include:
+          - optdeps_label: optdeps
+          - mindeps_label: no-mindeps
+          - build_type: mindeps
+            os: ubuntu-22.04
+            vtk_version: commit
+            optdeps_label: optdeps
+            mindeps_label: mindeps
+
+    runs-on: ${{matrix.os}}
+    container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
+
+    env:
+      CMAKE_POLICY_VERSION_MINIMUM: 3.5
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          path: "source"
+          fetch-depth: 1
+          lfs: false
+
+      - name: Cache VTK
+        uses: ./source/.github/actions/vtk-install-dep
+        with:
+          versions_file: ./source/.github/workflows/versions.json
+          optdeps_label: ${{matrix.optdeps_label}}
+          mindeps_label: ${{matrix.mindeps_label}}
+          cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
+          vtk_version: ${{matrix.vtk_version}}

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -10,9 +10,24 @@ jobs:
   # Cache preheating
   #----------------------------------------------------------------------------
   cache_preheating:
-    name: Cache Preheating
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [standard]
+        include:
+          - optdeps_label: optdeps
+          - mindeps_label: no-mindeps
+          - build_type: mindeps
+            optdeps_label: optdeps
+            mindeps_label: mindeps
+          - build_type: no-optdeps
+            optdeps_label: no-optdeps
+            mindeps_label: no-mindeps
+
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
+
     env:
       CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
@@ -25,28 +40,10 @@ jobs:
           fetch-depth: 1
           lfs: false
 
-      - name: Dependencies Dir
-        shell: bash
-        working-directory: ${{github.workspace}}
-        run: |
-          mkdir dependencies
-          cd dependencies
-          mkdir install
-
-      - name: VTK Dependencies
-        uses: ./source/.github/actions/vtk-dependencies
+      - name: Generic Dependencies
+        uses: ./source/.github/actions/generic-dependencies
         with:
           versions_file: ./source/.github/workflows/versions.json
-          cpu: x86_64
-
-      - name: Install Raytracing Dependencies
-        uses: ./source/.github/actions/ospray-sb-install-dep
-        with:
-          versions_file: ./source/.github/workflows/versions.json
-          cpu: x86_64
-
-      - name: Install F3D dependencies
-        uses: ./source/.github/actions/f3d-dependencies
-        with:
-          versions_file: ./source/.github/workflows/versions.json
+          optdeps_label: ${{matrix.optdeps_label}}
+          mindeps_label: ${{matrix.mindeps_label}}
           cpu: x86_64

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -103,14 +103,6 @@ jobs:
           mindeps_label: ${{matrix.mindeps_label}}
           cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
-      - name: Install Raytracing Dependencies
-        if: matrix.optdeps_label == 'optdeps'
-        uses: ./source/.github/actions/ospray-sb-install-dep
-        with:
-          versions_file: ./source/.github/workflows/versions.json
-          mindeps_label: ${{matrix.mindeps_label}}
-          cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
-
       - name: Cache VTK
         uses: ./source/.github/actions/vtk-install-dep
         with:

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -21,20 +21,6 @@ jobs:
           fetch-depth: 1
           lfs: false
 
-      - name: Extract sqlite version
-        id: sqlite_ver
-        uses: f3d-app/extract-version-action@main
-        with:
-          file: ./.github/workflows/versions.json
-          name: sqlite_csb
-
-      - name: Extract global cache index
-        id: global_idx
-        uses: f3d-app/extract-version-action@main
-        with:
-          file: ./.github/workflows/versions.json
-          special_name: global_cache_index
-
       - name: Dependencies Dir
         shell: bash
         working-directory: ${{github.workspace}}
@@ -47,5 +33,6 @@ jobs:
         uses: ./.github/actions/sqlite-install-dep
         with:
           cpu: x86_64
+          versions_file: .github/workflows/versions.json
           csb_version: ${{steps.sqlite_ver.outputs.extract}}
           global_cache_index: ${{steps.global_idx.outputs.extract}}

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -11,7 +11,7 @@ on:
       - "_config.yml"
 
 concurrency:
-  group: "${{ github.workflow }}-${{GITHUB_HEAD_REF}}"
+  group: "${{ github.workflow }}-${{  github.ref_name }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -24,16 +24,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-15, macos-15-intel]
+        os: [ubuntu-24.04, windows-2022, macos-15, macos-15-intel]
         build_type: [standard]
         include:
           - mindeps_label: no-mindeps
           - build_type: mindeps
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             mindeps_label: mindeps
 
     runs-on: ${{matrix.os}}
-    container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
+    container: ${{ matrix.os == 'ubuntu-24.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
     env:
       CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
@@ -63,25 +63,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-15, macos-15-intel]
+        os: [ubuntu-24.04, windows-2022, macos-15, macos-15-intel]
         vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
         build_type: [standard]
         include:
           - optdeps_label: optdeps
           - mindeps_label: no-mindeps
           - build_type: mindeps
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             vtk_version: commit
             optdeps_label: optdeps
             mindeps_label: mindeps
           - build_type: no-optdeps
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             vtk_version: commit
             optdeps_label: no-optdeps
             mindeps_label: no-mindeps
 
     runs-on: ${{matrix.os}}
-    container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
+    container: ${{ matrix.os == 'ubuntu-24.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
 
     env:
       CMAKE_POLICY_VERSION_MINIMUM: 3.5

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -17,11 +17,9 @@ jobs:
         os: [ubuntu-22.04, windows-latest, macos-15, macos-15-intel]
         build_type: [standard]
         include:
-          - optdeps_label: optdeps
           - mindeps_label: no-mindeps
           - build_type: mindeps
             os: ubuntu-22.04
-            optdeps_label: optdeps
             mindeps_label: mindeps
 
     runs-on: ${{matrix.os}}
@@ -42,7 +40,6 @@ jobs:
         uses: ./source/.github/actions/generic-dependencies
         with:
           versions_file: ./source/.github/workflows/versions.json
-          optdeps_label: ${{matrix.optdeps_label}}
           mindeps_label: ${{matrix.mindeps_label}}
           cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
@@ -66,6 +63,12 @@ jobs:
             vtk_version: commit
             optdeps_label: optdeps
             mindeps_label: mindeps
+          - build_type: no-optdeps
+            os: ubuntu-22.04
+            vtk_version: commit
+            optdeps_label: no-optdeps
+            mindeps_label: no-mindeps
+
 
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
@@ -81,6 +84,14 @@ jobs:
           path: "source"
           fetch-depth: 1
           lfs: false
+
+      - name: Generic Dependencies (already cached)
+        uses: ./source/.github/actions/generic-dependencies
+        with:
+          versions_file: ./source/.github/workflows/versions.json
+          optdeps_label: ${{matrix.optdeps_label}}
+          mindeps_label: ${{matrix.mindeps_label}}
+          cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
       - name: Cache VTK
         uses: ./source/.github/actions/vtk-install-dep

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -1,16 +1,23 @@
+name: Cache preheating
+
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
     branches:
       - master
       - release
-name: Cache preheating
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref_name }}"
+  cancel-in-progress: true
+
 jobs:
   #----------------------------------------------------------------------------
   # Cache preheating all dependencies
   #----------------------------------------------------------------------------
   cache_preheating_dependencies:
     name: Preheat dependency caches
+    if: contains(github.event.pull_request.labels.*.name, 'ci:cache')
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +56,7 @@ jobs:
   cache_preheating_vtk:
     needs: [cache_preheating_dependencies]
     name: Preheat VTK dependency caches
+    if: contains(github.event.pull_request.labels.*.name, 'ci:cache')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -21,6 +21,14 @@ jobs:
           fetch-depth: 1
           lfs: false
 
+      - name: Dependencies Dir
+        shell: bash
+        working-directory: ${{github.workspace}}
+        run: |
+          mkdir dependencies
+          cd dependencies
+          mkdir install
+
       - name: Install sqlite
         uses: ./.github/actions/sqlite-install-dep
         with:

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -6,9 +6,12 @@ on:
     branches:
       - master
       - release
+    paths-ignore:
+      - "doc/**"
+      - "_config.yml"
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref_name }}"
+  group: "${{ github.workflow }}-${{GITHUB_HEAD_REF}}"
   cancel-in-progress: true
 
 jobs:
@@ -77,7 +80,6 @@ jobs:
             optdeps_label: no-optdeps
             mindeps_label: no-mindeps
 
-
     runs-on: ${{matrix.os}}
     container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
 
@@ -93,11 +95,19 @@ jobs:
           fetch-depth: 1
           lfs: false
 
-      - name: Generic Dependencies (already cached)
-        uses: ./source/.github/actions/generic-dependencies
+      - name: VTK Dependencies (already cached)
+        uses: ./source/.github/actions/vtk-dependencies
         with:
           versions_file: ./source/.github/workflows/versions.json
           optdeps_label: ${{matrix.optdeps_label}}
+          mindeps_label: ${{matrix.mindeps_label}}
+          cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
+
+      - name: Install Raytracing Dependencies
+        if: matrix.optdeps_label == 'optdeps'
+        uses: ./source/.github/actions/ospray-sb-install-dep
+        with:
+          versions_file: ./source/.github/workflows/versions.json
           mindeps_label: ${{matrix.mindeps_label}}
           cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
 

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -22,7 +22,7 @@ jobs:
           lfs: false
 
       - name: Install sqlite
-        uses: ./.actions/sqlite-install-dep
+        uses: ./.github/actions/sqlite-install-dep
         with:
           cpu: x86_64
           csb_version: 08be462f7fa9816f881dbb93eacb2e287f319208

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,7 @@ jobs:
   # Recover docker timestamp
   #----------------------------------------------------------------------------
   recover_docker_timestamp:
+    name: Recover docker timestamp
     runs-on: ubuntu-22.04
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:android') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,40 +475,33 @@ jobs:
           versions_file: ./source/f3d/.github/workflows/versions.json
 
   #----------------------------------------------------------------------------
-  # Check android/wasm docker images TODO
+  # Recover docker timestamp
   #----------------------------------------------------------------------------
-  check_docker_images:
+  recover_docker_timestamp:
     runs-on: ubuntu-22.04
+    outputs:
+      docker_timestamp: ${{steps.docker_timestamp.outputs.extract}}
 
-    # Pull request can require a rebuild of docker image, wait for it to be done
-    # This job does not do anything in master branch but is not skipped for simpler logic
     steps:
-      - name: Extract branch name
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'ci:android') ||
-          contains(github.event.pull_request.labels.*.name, 'ci:wasm') ||
-          contains(github.event.pull_request.labels.*.name, 'ci:full')
-        shell: bash
-        run: echo "F3D_BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: "source/f3d"
+          fetch-depth: 0
+          lfs: false
 
-      - name: Wait for docker images
-        if: contains(github.event.pull_request.labels.*.name, 'ci:full')
-        run: |
-          gh run list -w build-docker-images.yml --repo ${{ github.repository }} -L 1 -b ${{ env.F3D_BRANCH_NAME }}
-          until gh run list -w build-docker-images.yml --repo ${{ github.repository }} -L 1 -b ${{ env.F3D_BRANCH_NAME }} --json status | jq '.[]| .status' | grep -q "completed";
-          do
-            echo "Waiting 1s"
-            sleep 1;
-          done
-          gh run list -w build-docker-images.yml --repo ${{ github.repository }} -L 1 -b ${{ env.F3D_BRANCH_NAME }} --json conclusion | jq '.[]| .conclusion' | grep -q "success"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract docker timestamp
+        id: docker_timestamp
+        uses: f3d-app/extract-version-action@main
+        with:
+          file: ./source/.github/workflows/versions.json
+          special_name: docker_timestamp
 
   #----------------------------------------------------------------------------
-  # android: Check build of F3D for android TODO
+  # android: Check build of F3D for android
   #----------------------------------------------------------------------------
   android:
-    needs: [check_docker_images]
+    needs: recover_docker_timestamp
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:android') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -519,7 +512,7 @@ jobs:
         arch: [armeabi-v7a, arm64-v8a, x86, x86_64]
 
     runs-on: ubuntu-22.04
-    container: ghcr.io/f3d-app/f3d-android-${{ matrix.arch }}:${{needs.default_versions.outputs.docker_timestamp}}
+    container: ghcr.io/f3d-app/f3d-android-${{ matrix.arch }}:${{needs.recover_docker_timestamp.outputs.docker_timestamp}}
 
     steps:
       - name: Checkout
@@ -535,7 +528,7 @@ jobs:
           arch: ${{matrix.arch}}
 
   #----------------------------------------------------------------------------
-  # webassembly: Build webassembly artifacts TODO
+  # webassembly: Build webassembly artifacts
   #----------------------------------------------------------------------------
   webassembly:
     needs: [cache_lfs, check_docker_images]
@@ -550,7 +543,7 @@ jobs:
 
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
-      F3D_DOCKER_TIMESTAMP: ${{needs.default_versions.outputs.docker_timestamp}}
+      F3D_DOCKER_TIMESTAMP: ${{needs.recover_docker_timestamp.outputs.docker_timestamp}}
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,10 @@ jobs:
   #----------------------------------------------------------------------------
   recover_docker_timestamp:
     runs-on: ubuntu-22.04
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:android') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
     outputs:
       docker_timestamp: ${{steps.docker_timestamp.outputs.extract}}
 
@@ -486,7 +490,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          path: "source/f3d"
+          path: "source"
           fetch-depth: 0
           lfs: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
   #----------------------------------------------------------------------------
   cache_lfs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Update LFS data cache
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
@@ -92,7 +92,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/f3d-app/f3d-ci
 
     env:
@@ -182,7 +182,7 @@ jobs:
             rendering_backend: auto
             static_label: no-static
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/f3d-app/f3d-ci
 
     env:
@@ -301,22 +301,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-15]
+        os: [ubuntu-24.04, windows-2022, macos-15]
         python_version: ["3.14"]
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python_version: "3.10"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python_version: "3.11"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python_version: "3.12"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python_version: "3.13"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python_version: "3.14"
 
     runs-on: ${{matrix.os}}
-    container: ${{ matrix.os == 'ubuntu-22.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
+    container: ${{ matrix.os == 'ubuntu-24.04' && 'ghcr.io/f3d-app/f3d-ci' || null }}
 
     env:
       DISPLAY: :0
@@ -347,7 +347,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/f3d-app/f3d-ci
 
     # Add dummy F3D_PLUGINS_PATH for coverage
@@ -386,7 +386,7 @@ jobs:
       matrix:
         sanitizer_type: [address, thread, undefined]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/f3d-app/f3d-ci
 
     env:
@@ -423,7 +423,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/f3d-app/f3d-ci
 
     env:
@@ -455,7 +455,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/f3d-app/f3d-ci
 
     env:
@@ -479,7 +479,7 @@ jobs:
   #----------------------------------------------------------------------------
   recover_docker_timestamp:
     name: Recover docker timestamp
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:android') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -516,7 +516,7 @@ jobs:
       matrix:
         arch: [armeabi-v7a, arm64-v8a, x86, x86_64]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/f3d-app/f3d-android-${{ matrix.arch }}:${{needs.recover_docker_timestamp.outputs.docker_timestamp}}
 
     steps:
@@ -544,7 +544,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,7 +531,7 @@ jobs:
   # webassembly: Build webassembly artifacts
   #----------------------------------------------------------------------------
   webassembly:
-    needs: [cache_lfs, check_docker_images]
+    needs: [cache_lfs, recover_docker_timestamp]
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:wasm') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,86 +16,6 @@ concurrency:
 
 jobs:
   #----------------------------------------------------------------------------
-  # Default versions: Set default version for all dependencies
-  #----------------------------------------------------------------------------
-  default_versions:
-    runs-on: ubuntu-22.04
-    name: Set default versions
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:android') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:wasm') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      github.ref == 'refs/heads/master'
-    outputs:
-      alembic_min_version: ${{ steps.set_default_versions.outputs.alembic_min_version }}
-      alembic_version: ${{ steps.set_default_versions.outputs.alembic_version }}
-      assimp_min_version: ${{ steps.set_default_versions.outputs.assimp_min_version }}
-      assimp_version: ${{ steps.set_default_versions.outputs.assimp_version }}
-      blosc_min_version: ${{ steps.set_default_versions.outputs.blosc_min_version }}
-      blosc_version: ${{ steps.set_default_versions.outputs.blosc_version }}
-      curl_min_version: ${{ steps.set_default_versions.outputs.curl_min_version }}
-      curl_version: ${{ steps.set_default_versions.outputs.curl_version }}
-      draco_min_version: ${{ steps.set_default_versions.outputs.draco_min_version }}
-      draco_version: ${{ steps.set_default_versions.outputs.draco_version }}
-      gdal_min_version: ${{ steps.set_default_versions.outputs.gdal_min_version }}
-      gdal_version: ${{ steps.set_default_versions.outputs.gdal_version }}
-      geotiff_min_version: ${{ steps.set_default_versions.outputs.geotiff_min_version }}
-      geotiff_version: ${{ steps.set_default_versions.outputs.geotiff_version }}
-      imath_min_version: ${{ steps.set_default_versions.outputs.imath_min_version }}
-      imath_version: ${{ steps.set_default_versions.outputs.imath_version }}
-      java_min_version: ${{ steps.set_default_versions.outputs.java_min_version }}
-      java_version: ${{ steps.set_default_versions.outputs.java_version }}
-      occt_min_version: ${{ steps.set_default_versions.outputs.occt_min_version }}
-      occt_version: ${{ steps.set_default_versions.outputs.occt_version }}
-      openexr_min_version: ${{ steps.set_default_versions.outputs.openexr_min_version }}
-      openexr_version: ${{ steps.set_default_versions.outputs.openexr_version }}
-      openvdb_min_version: ${{ steps.set_default_versions.outputs.openvdb_min_version }}
-      openvdb_version: ${{ steps.set_default_versions.outputs.openvdb_version }}
-      ospray_min_version: ${{ steps.set_default_versions.outputs.ospray_min_version }}
-      ospray_version: ${{ steps.set_default_versions.outputs.ospray_version }}
-      pdal_min_version: ${{ steps.set_default_versions.outputs.pdal_min_version }}
-      pdal_version: ${{ steps.set_default_versions.outputs.pdal_version }}
-      proj_min_version: ${{ steps.set_default_versions.outputs.proj_min_version }}
-      proj_version: ${{ steps.set_default_versions.outputs.proj_version }}
-      pybind11_min_version: ${{ steps.set_default_versions.outputs.pybind11_min_version }}
-      pybind11_version: ${{ steps.set_default_versions.outputs.pybind11_version }}
-      python_min_version: ${{ steps.set_default_versions.outputs.python_min_version }}
-      python_version: ${{ steps.set_default_versions.outputs.python_version }}
-      sqlite_csb_min_version: ${{ steps.set_default_versions.outputs.sqlite_csb_min_version }}
-      sqlite_csb_version: ${{ steps.set_default_versions.outputs.sqlite_csb_version }}
-      tbb_min_version: ${{ steps.set_default_versions.outputs.tbb_min_version }}
-      tbb_version: ${{ steps.set_default_versions.outputs.tbb_version }}
-      tiff_min_version: ${{ steps.set_default_versions.outputs.tiff_min_version }}
-      tiff_version: ${{ steps.set_default_versions.outputs.tiff_version }}
-      usd_min_version: ${{ steps.set_default_versions.outputs.usd_min_version }}
-      usd_version: ${{ steps.set_default_versions.outputs.usd_version }}
-      webifc_min_version: ${{ steps.set_default_versions.outputs.webifc_min_version }}
-      webifc_version: ${{ steps.set_default_versions.outputs.webifc_version }}
-      webp_min_version: ${{ steps.set_default_versions.outputs.webp_min_version }}
-      webp_version: ${{ steps.set_default_versions.outputs.webp_version }}
-      zlib_min_version: ${{ steps.set_default_versions.outputs.zlib_min_version }}
-      zlib_version: ${{ steps.set_default_versions.outputs.zlib_version }}
-      vtk_commit_sha: ${{ steps.set_default_versions.outputs.vtk_commit_sha }}
-      docker_timestamp: ${{ steps.set_default_versions.outputs.docker_timestamp }}
-      global_cache_index: ${{ steps.set_default_versions.outputs.global_cache_index }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: "source"
-          fetch-depth: 1
-          lfs: false
-
-      - name: Set default versions
-        id: set_default_versions
-        uses: f3d-app/default-versions-action@main
-        with:
-          file: ./source/.github/workflows/versions.json
-
-  #----------------------------------------------------------------------------
   # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
   #----------------------------------------------------------------------------
   cache_lfs:
@@ -124,466 +44,10 @@ jobs:
           cache_postfix: cache-0
 
   #----------------------------------------------------------------------------
-  # Cache Dependencies: Checkout and compile all dependencies but VTK if not cached
-  #----------------------------------------------------------------------------
-  cache_dependencies_linux:
-    name: Cache dependencies Linux
-    needs: default_versions
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:android') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:wasm') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      github.ref == 'refs/heads/master'
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [standard]
-        include:
-          - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          - blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          - curl_version: ${{needs.default_versions.outputs.curl_version}}
-          - draco_version: ${{needs.default_versions.outputs.draco_version}}
-          - gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          - geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          - imath_version: ${{needs.default_versions.outputs.imath_version}}
-          - occt_version: ${{needs.default_versions.outputs.occt_version}}
-          - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          - ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          - pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          - proj_version: ${{needs.default_versions.outputs.proj_version}}
-          - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          - sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          - tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          - tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          - usd_version: ${{needs.default_versions.outputs.usd_version}}
-          - webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          - webp_version: ${{needs.default_versions.outputs.webp_version}}
-          - zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          - build_type: mindeps
-            alembic_version: ${{needs.default_versions.outputs.alembic_min_version}}
-            assimp_version: ${{needs.default_versions.outputs.assimp_min_version}}
-            blosc_version: ${{needs.default_versions.outputs.blosc_min_version}}
-            curl_version: ${{needs.default_versions.outputs.curl_min_version}}
-            draco_version: ${{needs.default_versions.outputs.draco_min_version}}
-            gdal_version: ${{needs.default_versions.outputs.gdal_min_version}}
-            geotiff_version: ${{needs.default_versions.outputs.geotiff_min_version}}
-            imath_version: ${{needs.default_versions.outputs.imath_min_version}}
-            occt_version: ${{needs.default_versions.outputs.occt_min_version}}
-            openexr_version: ${{needs.default_versions.outputs.openexr_min_version}}
-            openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
-            ospray_version: ${{needs.default_versions.outputs.ospray_min_version}}
-            pdal_version: ${{needs.default_versions.outputs.pdal_min_version}}
-            proj_version: ${{needs.default_versions.outputs.proj_min_version}}
-            pybind11_version: ${{needs.default_versions.outputs.pybind11_min_version}}
-            sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_min_version}}
-            tbb_version: ${{needs.default_versions.outputs.tbb_min_version}}
-            tiff_version: ${{needs.default_versions.outputs.tiff_min_version}}
-            usd_version: ${{needs.default_versions.outputs.usd_min_version}}
-            webifc_version: ${{needs.default_versions.outputs.webifc_min_version}}
-            webp_version: ${{needs.default_versions.outputs.webp_min_version}}
-            zlib_version: ${{needs.default_versions.outputs.zlib_min_version}}
-
-    runs-on: ubuntu-22.04
-    container: ghcr.io/f3d-app/f3d-ci
-
-    env:
-      CMAKE_POLICY_VERSION_MINIMUM: 3.5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: "source"
-          fetch-depth: 1
-          lfs: false
-
-      - name: Generic Dependencies
-        uses: ./source/.github/actions/generic-dependencies
-        with:
-          cpu: x86_64
-          alembic_version: ${{matrix.alembic_version}}
-          assimp_version: ${{matrix.assimp_version}}
-          blosc_version: ${{matrix.blosc_version}}
-          curl_version: ${{matrix.curl_version}}
-          draco_version: ${{matrix.draco_version}}
-          gdal_version: ${{matrix.gdal_version}}
-          geotiff_version: ${{matrix.geotiff_version}}
-          imath_version: ${{matrix.imath_version}}
-          occt_version: ${{matrix.occt_version}}
-          openexr_version: ${{matrix.openexr_version}}
-          openvdb_version: ${{matrix.openvdb_version}}
-          ospray_version: ${{matrix.ospray_version}}
-          pdal_version: ${{matrix.pdal_version}}
-          proj_version: ${{matrix.proj_version}}
-          pybind11_version: ${{matrix.pybind11_version}}
-          sqlite_csb_version: ${{matrix.sqlite_csb_version}}
-          tbb_version: ${{matrix.tbb_version}}
-          tiff_version: ${{matrix.tiff_version}}
-          usd_version: ${{matrix.usd_version}}
-          webifc_version: ${{matrix.webifc_version}}
-          webp_version: ${{matrix.webp_version}}
-          zlib_version: ${{matrix.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
-
-  cache_dependencies_windows:
-    name: Cache dependencies Windows
-    needs: default_versions
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      github.ref == 'refs/heads/master'
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [standard]
-        include:
-          - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          - blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          - curl_version: ${{needs.default_versions.outputs.curl_version}}
-          - draco_version: ${{needs.default_versions.outputs.draco_version}}
-          - gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          - geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          - imath_version: ${{needs.default_versions.outputs.imath_version}}
-          - occt_version: ${{needs.default_versions.outputs.occt_version}}
-          - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          - ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          - pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          - proj_version: ${{needs.default_versions.outputs.proj_version}}
-          - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          - sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          - tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          - tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          - usd_version: ${{needs.default_versions.outputs.usd_version}}
-          - webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          - webp_version: ${{needs.default_versions.outputs.webp_version}}
-          - zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-
-    runs-on: windows-2022
-
-    env:
-      CMAKE_POLICY_VERSION_MINIMUM: 3.5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: "source"
-          fetch-depth: 1
-          lfs: false
-
-      - name: Generic Dependencies
-        uses: ./source/.github/actions/generic-dependencies
-        with:
-          cpu: x86_64
-          alembic_version: ${{matrix.alembic_version}}
-          assimp_version: ${{matrix.assimp_version}}
-          blosc_version: ${{matrix.blosc_version}}
-          curl_version: ${{matrix.curl_version}}
-          draco_version: ${{matrix.draco_version}}
-          gdal_version: ${{matrix.gdal_version}}
-          geotiff_version: ${{matrix.geotiff_version}}
-          imath_version: ${{matrix.imath_version}}
-          occt_version: ${{matrix.occt_version}}
-          openexr_version: ${{matrix.openexr_version}}
-          openvdb_version: ${{matrix.openvdb_version}}
-          ospray_version: ${{matrix.ospray_version}}
-          pdal_version: ${{matrix.pdal_version}}
-          proj_version: ${{matrix.proj_version}}
-          pybind11_version: ${{matrix.pybind11_version}}
-          sqlite_csb_version: ${{matrix.sqlite_csb_version}}
-          tbb_version: ${{matrix.tbb_version}}
-          tiff_version: ${{matrix.tiff_version}}
-          usd_version: ${{matrix.usd_version}}
-          webifc_version: ${{matrix.webifc_version}}
-          webp_version: ${{matrix.webp_version}}
-          zlib_version: ${{matrix.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
-
-  cache_dependencies_macos_intel:
-    name: Cache dependencies macOS intel
-    needs: default_versions
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      github.ref == 'refs/heads/master'
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [standard]
-        include:
-          - cpu: x86_64
-          - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          - blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          - curl_version: ${{needs.default_versions.outputs.curl_version}}
-          - draco_version: ${{needs.default_versions.outputs.draco_version}}
-          - gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          - geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          - imath_version: ${{needs.default_versions.outputs.imath_version}}
-          - occt_version: ${{needs.default_versions.outputs.occt_version}}
-          - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          - ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          - pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          - proj_version: ${{needs.default_versions.outputs.proj_version}}
-          - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          - sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          - tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          - tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          - usd_version: ${{needs.default_versions.outputs.usd_version}}
-          - webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          - webp_version: ${{needs.default_versions.outputs.webp_version}}
-          - zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-
-    runs-on: macos-15-intel
-
-    env:
-      CMAKE_POLICY_VERSION_MINIMUM: 3.5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: "source"
-          fetch-depth: 1
-          lfs: false
-
-      - name: Generic Dependencies
-        uses: ./source/.github/actions/generic-dependencies
-        with:
-          cpu: x86_64
-          alembic_version: ${{matrix.alembic_version}}
-          assimp_version: ${{matrix.assimp_version}}
-          blosc_version: ${{matrix.blosc_version}}
-          curl_version: ${{matrix.curl_version}}
-          draco_version: ${{matrix.draco_version}}
-          gdal_version: ${{matrix.gdal_version}}
-          geotiff_version: ${{matrix.geotiff_version}}
-          imath_version: ${{matrix.imath_version}}
-          occt_version: ${{matrix.occt_version}}
-          openexr_version: ${{matrix.openexr_version}}
-          openvdb_version: ${{matrix.openvdb_version}}
-          ospray_version: ${{matrix.ospray_version}}
-          pdal_version: ${{matrix.pdal_version}}
-          proj_version: ${{matrix.proj_version}}
-          pybind11_version: ${{matrix.pybind11_version}}
-          sqlite_csb_version: ${{matrix.sqlite_csb_version}}
-          tbb_version: ${{matrix.tbb_version}}
-          tiff_version: ${{matrix.tiff_version}}
-          usd_version: ${{matrix.usd_version}}
-          webifc_version: ${{matrix.webifc_version}}
-          webp_version: ${{matrix.webp_version}}
-          zlib_version: ${{matrix.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
-
-  cache_dependencies_macos_arm:
-    name: Cache dependencies macOS arm
-    needs: default_versions
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      github.ref == 'refs/heads/master'
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [standard]
-        include:
-          - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          - blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          - curl_version: ${{needs.default_versions.outputs.curl_version}}
-          - draco_version: ${{needs.default_versions.outputs.draco_version}}
-          - gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          - geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          - imath_version: ${{needs.default_versions.outputs.imath_version}}
-          - occt_version: ${{needs.default_versions.outputs.occt_version}}
-          - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          - ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          - pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          - proj_version: ${{needs.default_versions.outputs.proj_version}}
-          - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          - sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          - tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          - tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          - usd_version: ${{needs.default_versions.outputs.usd_version}}
-          - webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          - webp_version: ${{needs.default_versions.outputs.webp_version}}
-          - zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-
-    runs-on: macos-15
-
-    env:
-      CMAKE_POLICY_VERSION_MINIMUM: 3.5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: "source"
-          fetch-depth: 1
-          lfs: false
-
-      - name: Generic Dependencies
-        uses: ./source/.github/actions/generic-dependencies
-        with:
-          cpu: arm64
-          alembic_version: ${{matrix.alembic_version}}
-          assimp_version: ${{matrix.assimp_version}}
-          blosc_version: ${{matrix.blosc_version}}
-          curl_version: ${{matrix.curl_version}}
-          draco_version: ${{matrix.draco_version}}
-          gdal_version: ${{matrix.gdal_version}}
-          geotiff_version: ${{matrix.geotiff_version}}
-          imath_version: ${{matrix.imath_version}}
-          occt_version: ${{matrix.occt_version}}
-          openexr_version: ${{matrix.openexr_version}}
-          openvdb_version: ${{matrix.openvdb_version}}
-          ospray_version: ${{matrix.ospray_version}}
-          pdal_version: ${{matrix.pdal_version}}
-          proj_version: ${{matrix.proj_version}}
-          pybind11_version: ${{matrix.pybind11_version}}
-          sqlite_csb_version: ${{matrix.sqlite_csb_version}}
-          tbb_version: ${{matrix.tbb_version}}
-          tiff_version: ${{matrix.tiff_version}}
-          usd_version: ${{matrix.usd_version}}
-          webifc_version: ${{matrix.webifc_version}}
-          webp_version: ${{matrix.webp_version}}
-          zlib_version: ${{matrix.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
-
-  #---------------------------------------------------------------------------------------------------
-  # Cache VTK Dependency: Checkout and compile VTK if not cached, to avoid building VTK multiple times
-  #---------------------------------------------------------------------------------------------------
-  cache_vtk_dependency_linux:
-    name: Cache VTK dependency Linux
-    needs: [default_versions, cache_dependencies_linux]
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      github.ref == 'refs/heads/master'
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [standard]
-        include:
-          - blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          - curl_version: ${{needs.default_versions.outputs.curl_version}}
-          - gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          - geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          - ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          - pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          - proj_version: ${{needs.default_versions.outputs.proj_version}}
-          - sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          - tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          - tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          - zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          - build_type: mindeps
-            blosc_version: ${{needs.default_versions.outputs.blosc_min_version}}
-            curl_version: ${{needs.default_versions.outputs.curl_min_version}}
-            gdal_version: ${{needs.default_versions.outputs.gdal_min_version}}
-            geotiff_version: ${{needs.default_versions.outputs.geotiff_min_version}}
-            openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
-            ospray_version: ${{needs.default_versions.outputs.ospray_min_version}}
-            pdal_version: ${{needs.default_versions.outputs.pdal_min_version}}
-            proj_version: ${{needs.default_versions.outputs.proj_min_version}}
-            sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_min_version}}
-            tbb_version: ${{needs.default_versions.outputs.tbb_min_version}}
-            tiff_version: ${{needs.default_versions.outputs.tiff_min_version}}
-            zlib_version: ${{needs.default_versions.outputs.zlib_min_version}}
-          - build_type: no_optional_deps
-            blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-            tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-            zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          - build_type: no_raytracing
-            blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-            curl_version: ${{needs.default_versions.outputs.curl_version}}
-            gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-            geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-            pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-            proj_version: ${{needs.default_versions.outputs.proj_version}}
-            sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-            tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-            tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-            zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-
-    runs-on: ubuntu-22.04
-    container: ghcr.io/f3d-app/f3d-ci
-
-    env:
-      CMAKE_POLICY_VERSION_MINIMUM: 3.5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: "source"
-          fetch-depth: 1
-          lfs: false
-
-      - name: Dependencies Dir
-        shell: bash
-        working-directory: ${{github.workspace}}
-        run: |
-          mkdir dependencies
-          cd dependencies
-          mkdir install
-
-      - name: Install VTK dependencies
-        uses: ./source/.github/actions/vtk-dependencies
-        with:
-          cpu: x86_64
-          blosc_version: ${{matrix.blosc_version}}
-          curl_version: ${{matrix.curl_version}}
-          gdal_version: ${{matrix.gdal_version}}
-          geotiff_version: ${{matrix.geotiff_version}}
-          openvdb_version: ${{matrix.openvdb_version}}
-          pdal_version: ${{matrix.pdal_version}}
-          proj_version: ${{matrix.proj_version}}
-          sqlite_csb_version: ${{matrix.sqlite_csb_version}}
-          tbb_version: ${{matrix.tbb_version}}
-          tiff_version: ${{matrix.tiff_version}}
-          zlib_version: ${{matrix.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
-
-      - name: Install Raytracing Dependencies
-        if: matrix.ospray_version != ''
-        uses: ./source/.github/actions/ospray-sb-install-dep
-        with:
-          version: ${{matrix.ospray_version}}
-          cpu: x86_64
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
-
-      - name: VTK dependency
-        uses: ./source/.github/actions/vtk-install-dep
-        with:
-          vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-          cpu: x86_64
-          blosc_version: ${{matrix.blosc_version}}
-          curl_version: ${{matrix.curl_version}}
-          gdal_version: ${{matrix.gdal_version}}
-          geotiff_version: ${{matrix.geotiff_version}}
-          openvdb_version: ${{matrix.openvdb_version}}
-          ospray_version: ${{matrix.ospray_version}}
-          pdal_version: ${{matrix.pdal_version}}
-          proj_version: ${{matrix.proj_version}}
-          sqlite_csb_version: ${{matrix.sqlite_csb_version}}
-          tbb_version: ${{matrix.tbb_version}}
-          tiff_version: ${{matrix.tiff_version}}
-          zlib_version: ${{matrix.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
-
-  #----------------------------------------------------------------------------
   # Windows CI: Build and test, cross-vtk build matrix
   #----------------------------------------------------------------------------
   windows:
-    needs: [cache_lfs, cache_dependencies_windows, default_versions]
+    needs: cache_lfs
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -591,16 +55,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vtk_version:
-          [
-            "${{needs.default_versions.outputs.vtk_commit_sha}}",
-            v9.6.1,
-            v9.5.2,
-            v9.4.2,
-          ]
+        vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
         static_label: [no-static]
         include:
-          - vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
+          - vtk_version: commit
             static_label: static
 
     runs-on: windows-2022
@@ -619,40 +77,16 @@ jobs:
       - name: Generic CI
         uses: ./source/.github/actions/generic-ci
         with:
+          versions_file: ./source/.github/workflows/versions.json
           vtk_version: ${{matrix.vtk_version}}
           static_label: ${{matrix.static_label}}
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          java_version: ${{needs.default_versions.outputs.java_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          python_version: ${{needs.default_versions.outputs.python_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Linux fast CI: Build and test a single fast CI
   #----------------------------------------------------------------------------
   linux_fast:
-    needs: [cache_lfs, default_versions]
+    needs: cache_lfs
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
@@ -676,23 +110,20 @@ jobs:
       - name: Generic CI
         uses: ./source/.github/actions/generic-ci
         with:
+          versions_file: ./source/.github/workflows/versions.json
           build_type: fast
+          vtk_version: v9.6.1
           rendering_backend: auto
-          optional_deps_label: no-optional-deps
+          optdeps_label: no-optdeps
           exclude_deprecated_label: exclude-deprecated
           static_label: no-static
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          vtk_version: v9.6.1
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Linux CI: Build and test, cross-vtk build matrix
   #----------------------------------------------------------------------------
   linux:
-    needs: [cache_lfs, cache_vtk_dependency_linux, default_versions]
+    needs: cache_lfs
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -700,201 +131,56 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vtk_version:
-          [
-            "${{needs.default_versions.outputs.vtk_commit_sha}}",
-            v9.6.1,
-            v9.5.2,
-            v9.4.2,
-          ]
+        vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
         build_type: [standard]
         include:
           - exclude_deprecated_label: no-exclude-deprecated
-          - optional_deps_label: optional-deps
+          - optdeps_label: optdeps
+          - mindeps_label: no-mindeps
           - rendering_backend: auto
           - static_label: no-static
-          - alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          - assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          - blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          - curl_version: ${{needs.default_versions.outputs.curl_version}}
-          - draco_version: ${{needs.default_versions.outputs.draco_version}}
-          - gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          - geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          - imath_version: ${{needs.default_versions.outputs.imath_version}}
-          - java_version: ${{needs.default_versions.outputs.java_version}}
-          - occt_version: ${{needs.default_versions.outputs.occt_version}}
-          - openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          - openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          - ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          - pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          - proj_version: ${{needs.default_versions.outputs.proj_version}}
-          - pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          - python_version: ${{needs.default_versions.outputs.python_version}}
-          - sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          - tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          - tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          - usd_version: ${{needs.default_versions.outputs.usd_version}}
-          - webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          - webp_version: ${{needs.default_versions.outputs.webp_version}}
-          - zlib_version: ${{needs.default_versions.outputs.zlib_version}}
           - build_type: egl
-            vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-            optional_deps_label: optional-deps
+            vtk_version: commit
+            optdeps_label: optdeps
+            mindeps_label: no-mindeps
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: egl
             static_label: no-static
-            alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-            assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-            blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-            curl_version: ${{needs.default_versions.outputs.curl_version}}
-            draco_version: ${{needs.default_versions.outputs.draco_version}}
-            gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-            geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-            imath_version: ${{needs.default_versions.outputs.imath_version}}
-            java_version: ${{needs.default_versions.outputs.java_version}}
-            occt_version: ${{needs.default_versions.outputs.occt_version}}
-            openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-            ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-            pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-            proj_version: ${{needs.default_versions.outputs.proj_version}}
-            pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-            python_version: ${{needs.default_versions.outputs.python_version}}
-            sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-            tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-            tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-            usd_version: ${{needs.default_versions.outputs.usd_version}}
-            webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-            webp_version: ${{needs.default_versions.outputs.webp_version}}
-            zlib_version: ${{needs.default_versions.outputs.zlib_version}}
           - build_type: osmesa
-            vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-            optional_deps_label: optional-deps
+            vtk_version: commit
+            optdeps_label: optdeps
+            mindeps_label: no-mindeps
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: osmesa
             static_label: no-static
-            alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-            assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-            blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-            curl_version: ${{needs.default_versions.outputs.curl_version}}
-            draco_version: ${{needs.default_versions.outputs.draco_version}}
-            gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-            geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-            imath_version: ${{needs.default_versions.outputs.imath_version}}
-            java_version: ${{needs.default_versions.outputs.java_version}}
-            occt_version: ${{needs.default_versions.outputs.occt_version}}
-            openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-            ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-            pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-            proj_version: ${{needs.default_versions.outputs.proj_version}}
-            pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-            python_version: ${{needs.default_versions.outputs.python_version}}
-            sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-            tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-            tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-            usd_version: ${{needs.default_versions.outputs.usd_version}}
-            webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-            webp_version: ${{needs.default_versions.outputs.webp_version}}
-            zlib_version: ${{needs.default_versions.outputs.zlib_version}}
           - build_type: exclude_deprecated
-            vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-            optional_deps_label: optional-deps
+            vtk_version: commit
+            optdeps_label: optdeps
+            mindeps_label: no-mindeps
             exclude_deprecated_label: exclude-deprecated
             rendering_backend: auto
             static_label: no-static
-            alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-            assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-            blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-            curl_version: ${{needs.default_versions.outputs.curl_version}}
-            draco_version: ${{needs.default_versions.outputs.draco_version}}
-            gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-            geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-            imath_version: ${{needs.default_versions.outputs.imath_version}}
-            java_version: ${{needs.default_versions.outputs.java_version}}
-            occt_version: ${{needs.default_versions.outputs.occt_version}}
-            openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-            ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-            pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-            proj_version: ${{needs.default_versions.outputs.proj_version}}
-            pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-            python_version: ${{needs.default_versions.outputs.python_version}}
-            sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-            tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-            tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-            usd_version: ${{needs.default_versions.outputs.usd_version}}
-            webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-            webp_version: ${{needs.default_versions.outputs.webp_version}}
-            zlib_version: ${{needs.default_versions.outputs.zlib_version}}
           - build_type: no_optional_deps
-            blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-            tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-            vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-            zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-            optional_deps_label: no-optional-deps
+            vtk_version: commit
+            optdeps_label: no-optdeps
+            mindeps_label: no-mindeps
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: auto
             static_label: no-static
           - build_type: static_libs
-            vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-            optional_deps_label: optional-deps
+            vtk_version: commit
+            optdeps_label: optdeps
+            mindeps_label: no-mindeps
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: auto
             static_label: static
-            alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-            assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-            blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-            curl_version: ${{needs.default_versions.outputs.curl_version}}
-            draco_version: ${{needs.default_versions.outputs.draco_version}}
-            gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-            geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-            imath_version: ${{needs.default_versions.outputs.imath_version}}
-            java_version: ${{needs.default_versions.outputs.java_version}}
-            occt_version: ${{needs.default_versions.outputs.occt_version}}
-            openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-            openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-            pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-            proj_version: ${{needs.default_versions.outputs.proj_version}}
-            pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-            python_version: ${{needs.default_versions.outputs.python_version}}
-            sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-            tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-            tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-            usd_version: ${{needs.default_versions.outputs.usd_version}}
-            webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-            webp_version: ${{needs.default_versions.outputs.webp_version}}
-            zlib_version: ${{needs.default_versions.outputs.zlib_version}}
           - build_type: mindeps
-            vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-            optional_deps_label: optional-deps
+            vtk_version: commit
+            optdeps_label: optdeps
+            mindeps_label: mindeps
             exclude_deprecated_label: no-exclude-deprecated
             rendering_backend: auto
             static_label: no-static
-            alembic_version: ${{needs.default_versions.outputs.alembic_min_version}}
-            assimp_version: ${{needs.default_versions.outputs.assimp_min_version}}
-            blosc_version: ${{needs.default_versions.outputs.blosc_min_version}}
-            curl_version: ${{needs.default_versions.outputs.curl_min_version}}
-            draco_version: ${{needs.default_versions.outputs.draco_min_version}}
-            gdal_version: ${{needs.default_versions.outputs.gdal_min_version}}
-            geotiff_version: ${{needs.default_versions.outputs.geotiff_min_version}}
-            imath_version: ${{needs.default_versions.outputs.imath_min_version}}
-            java_version: ${{needs.default_versions.outputs.java_min_version}}
-            occt_version: ${{needs.default_versions.outputs.occt_min_version}}
-            openexr_version: ${{needs.default_versions.outputs.openexr_min_version}}
-            openvdb_version: ${{needs.default_versions.outputs.openvdb_min_version}}
-            ospray_version: ${{needs.default_versions.outputs.ospray_min_version}}
-            pdal_version: ${{needs.default_versions.outputs.pdal_min_version}}
-            proj_version: ${{needs.default_versions.outputs.proj_min_version}}
-            pybind11_version: ${{needs.default_versions.outputs.pybind11_min_version}}
-            python_version: ${{needs.default_versions.outputs.python_min_version}}
-            sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_min_version}}
-            tbb_version: ${{needs.default_versions.outputs.tbb_min_version}}
-            tiff_version: ${{needs.default_versions.outputs.tiff_min_version}}
-            usd_version: ${{needs.default_versions.outputs.usd_min_version}}
-            webifc_version: ${{needs.default_versions.outputs.webifc_min_version}}
-            webp_version: ${{needs.default_versions.outputs.webp_min_version}}
-            zlib_version: ${{needs.default_versions.outputs.zlib_min_version}}
 
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -914,57 +200,28 @@ jobs:
       - name: Generic CI
         uses: ./source/.github/actions/generic-ci
         with:
+          versions_file: ./source/.github/workflows/versions.json
           build_type: ${{matrix.build_type}}
           vtk_version: ${{matrix.vtk_version}}
           rendering_backend: ${{matrix.rendering_backend}}
-          optional_deps_label: ${{matrix.optional_deps_label}}
+          optdeps_label: ${{matrix.optdeps_label}}
+          mindeps_label: ${{matrix.mindeps_label}}
           exclude_deprecated_label: ${{matrix.exclude_deprecated_label}}
           static_label: ${{matrix.static_label}}
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{matrix.alembic_version}}
-          assimp_version: ${{matrix.assimp_version}}
-          blosc_version: ${{matrix.blosc_version}}
-          curl_version: ${{matrix.curl_version}}
-          draco_version: ${{matrix.draco_version}}
-          gdal_version: ${{matrix.gdal_version}}
-          geotiff_version: ${{matrix.geotiff_version}}
-          imath_version: ${{matrix.imath_version}}
-          java_version: ${{matrix.java_version}}
-          occt_version: ${{matrix.occt_version}}
-          openexr_version: ${{matrix.openexr_version}}
-          openvdb_version: ${{matrix.openvdb_version}}
-          ospray_version: ${{matrix.ospray_version}}
-          pdal_version: ${{matrix.pdal_version}}
-          proj_version: ${{matrix.proj_version}}
-          pybind11_version: ${{matrix.pybind11_version}}
-          python_version: ${{matrix.python_version}}
-          sqlite_csb_version: ${{matrix.sqlite_csb_version}}
-          tbb_version: ${{matrix.tbb_version}}
-          tiff_version: ${{matrix.tiff_version}}
-          usd_version: ${{matrix.usd_version}}
-          webifc_version: ${{matrix.webifc_version}}
-          webp_version: ${{matrix.webp_version}}
-          zlib_version: ${{matrix.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # MacOS CI: Build and test, cross-vtk build matrix
   #----------------------------------------------------------------------------
   macos_intel:
-    needs: [cache_lfs, cache_dependencies_macos_intel, default_versions]
+    needs: cache_lfs
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
-        vtk_version:
-          [
-            "${{needs.default_versions.outputs.vtk_commit_sha}}",
-            v9.6.1,
-            v9.5.2,
-            v9.4.2,
-          ]
+        vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
 
     runs-on: macos-15-intel
 
@@ -982,39 +239,16 @@ jobs:
       - name: Generic CI
         uses: ./source/.github/actions/generic-ci
         with:
+          versions_file: ./source/.github/workflows/versions.json
           vtk_version: ${{matrix.vtk_version}}
           cpu: x86_64
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          python_version: ${{needs.default_versions.outputs.python_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
   #----------------------------------------------------------------------------
   macos_arm:
-    needs: [cache_lfs, cache_dependencies_macos_arm, default_versions]
+    needs: cache_lfs
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -1022,20 +256,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vtk_version:
-          [
-            "${{needs.default_versions.outputs.vtk_commit_sha}}",
-            v9.6.1,
-            v9.5.2,
-            v9.4.2,
-          ]
+        vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
         bundle_label: [no-bundle]
         static_label: [no-static]
         include:
-          - vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
+          - vtk_version: commit
             bundle_label: bundle
             static_label: no-static
-          - vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
+          - vtk_version: commit
             bundle_label: no-bundle
             static_label: static
 
@@ -1055,46 +283,18 @@ jobs:
       - name: Generic CI
         uses: ./source/.github/actions/generic-ci
         with:
+          versions_file: ./source/.github/workflows/versions.json
           vtk_version: ${{matrix.vtk_version}}
           bundle_label: ${{matrix.bundle_label}}
           static_label: ${{matrix.static_label}}
           cpu: arm64
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          python_version: ${{needs.default_versions.outputs.python_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Python packaging: Build and test the Python wheel
   #----------------------------------------------------------------------------
   python_packaging:
-    needs:
-      - cache_lfs
-      - cache_vtk_dependency_linux
-      - cache_dependencies_windows
-      - cache_dependencies_macos_arm
-      - default_versions
+    needs: cache_lfs
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
@@ -1133,38 +333,16 @@ jobs:
       - name: Python CI
         uses: ./source/.github/actions/python-ci
         with:
+          versions_file: ./source/.github/workflows/versions.json
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
           cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
           python_version: ${{matrix.python_version}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Coverage: Build and test on linux with last VTK with coverage option
   #----------------------------------------------------------------------------
   coverage:
-    needs: [cache_lfs, cache_vtk_dependency_linux, default_versions]
+    needs: cache_lfs
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -1188,31 +366,9 @@ jobs:
       - name: Coverage CI
         uses: ./source/.github/actions/coverage-ci
         with:
+          versions_file: ./source/.github/workflows/versions.json
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
           codecov_token: ${{secrets.CODECOV_TOKEN}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -1221,7 +377,7 @@ jobs:
   # "memory" returns false positives in VTK:
   # https://stackoverflow.com/questions/60097307/memory-sanitizer-reports-use-of-uninitialized-value-in-global-object-constructio
   sanitizer:
-    needs: [cache_lfs, cache_vtk_dependency_linux, default_versions]
+    needs: cache_lfs
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
@@ -1251,34 +407,15 @@ jobs:
       - name: Sanitizer CI
         uses: ./source/.github/actions/sanitizer-ci
         with:
+          versions_file: ./source/.github/workflows/versions.json
           sanitizer_type: ${{matrix.sanitizer_type}}
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # static-analysis: Run static analysis on linux
   #----------------------------------------------------------------------------
   static-analysis:
-    needs: [cache_lfs, cache_vtk_dependency_linux, default_versions]
+    needs: cache_lfs
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -1305,35 +442,13 @@ jobs:
       - name: Static analysis CI
         uses: ./source/.github/actions/static-analysis-ci
         with:
+          versions_file: ./source/.github/workflows/versions.json
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # external-build: Check build of F3D as sub-project
   #----------------------------------------------------------------------------
   external-build:
-    needs: [cache_vtk_dependency_linux, default_versions]
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
@@ -1357,17 +472,12 @@ jobs:
       - name: External build CI
         uses: ./source/f3d/.github/actions/external-build-ci
         with:
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          vtk_version: ${{needs.default_versions.outputs.vtk_commit_sha}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
+          versions_file: ./source/f3d/.github/workflows/versions.json
 
   #----------------------------------------------------------------------------
-  # Check android/wasm docker images
+  # Check android/wasm docker images TODO
   #----------------------------------------------------------------------------
   check_docker_images:
-    needs: default_versions
     runs-on: ubuntu-22.04
 
     # Pull request can require a rebuild of docker image, wait for it to be done
@@ -1395,10 +505,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   #----------------------------------------------------------------------------
-  # android: Check build of F3D for android
+  # android: Check build of F3D for android TODO
   #----------------------------------------------------------------------------
   android:
-    needs: [default_versions, check_docker_images]
+    needs: [check_docker_images]
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:android') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -1425,10 +535,10 @@ jobs:
           arch: ${{matrix.arch}}
 
   #----------------------------------------------------------------------------
-  # webassembly: Build webassembly artifacts
+  # webassembly: Build webassembly artifacts TODO
   #----------------------------------------------------------------------------
   webassembly:
-    needs: [cache_lfs, default_versions, check_docker_images]
+    needs: [cache_lfs, check_docker_images]
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:wasm') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||

--- a/.github/workflows/labelize.yml
+++ b/.github/workflows/labelize.yml
@@ -38,6 +38,12 @@ jobs:
           label=${label//[^a-z-]/}
           echo "F3D_LABEL_COMMENT=$label" >> $GITHUB_ENV
 
+      # Stop the job if cache is being added
+      - name: cache stop
+        if: env.F3D_LABEL_COMMENT == 'cache'
+        shell: bash
+        run: exit 0
+
       - name: Add ack reaction
         uses: GrantBirki/comment@v2.1.1
         with:

--- a/.github/workflows/nightly_vtk_master.yml
+++ b/.github/workflows/nightly_vtk_master.yml
@@ -10,7 +10,7 @@ jobs:
   #----------------------------------------------------------------------------
   check_nightly:
     if: github.repository == 'f3d-app/f3d'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Check nightly
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
@@ -40,7 +40,7 @@ jobs:
   cache_lfs:
     needs: check_nightly
     if: ${{ needs.check_nightly.outputs.should_run == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Update LFS data cache
     outputs:
       lfs_sha: ${{ steps.lfs_sha_recover.outputs.lfs_sha }}
@@ -68,16 +68,16 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [standard]
-        os: [ubuntu-22.04, windows-latest, macos-15, macos-15-intel]
+        os: [ubuntu-24.04, windows-2022, macos-15, macos-15-intel]
         include:
           - rendering_backend: auto
           - build_type: egl
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             rendering_backend: egl
           - build_type: osmesa
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             rendering_backend: osmesa
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/f3d-app/f3d-ci
 
     env:
@@ -117,7 +117,7 @@ jobs:
       matrix:
         sanitizer_type: [address, thread, undefined]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/f3d-app/f3d-ci
 
     env:
@@ -169,7 +169,7 @@ jobs:
   # Recover docker timestamp
   #----------------------------------------------------------------------------
   recover_docker_timestamp:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Recover docker timestamp
     needs: check_nightly
     if: ${{ needs.check_nightly.outputs.should_run == 'true' }}
@@ -201,7 +201,7 @@ jobs:
       matrix:
         arch: [armeabi-v7a, arm64-v8a, x86, x86_64]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/f3d-app/f3d-android-${{ matrix.arch }}:${{needs.recover_docker_timestamp.outputs.docker_timestamp}}_${{needs.check_nightly.outputs.vtk_sha}}
 
     steps:
@@ -225,7 +225,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4

--- a/.github/workflows/nightly_vtk_master.yml
+++ b/.github/workflows/nightly_vtk_master.yml
@@ -34,54 +34,6 @@ jobs:
         run: echo "vtk_sha=$(git log -n 1 --pretty=format:%H)" >> $GITHUB_OUTPUT
 
   #----------------------------------------------------------------------------
-  # Default versions: Set default version for all dependencies
-  #----------------------------------------------------------------------------
-  default_versions:
-    runs-on: ubuntu-22.04
-    name: Set default versions
-    outputs:
-      alembic_version: ${{ steps.set_default_versions.outputs.alembic_version }}
-      assimp_version: ${{ steps.set_default_versions.outputs.assimp_version }}
-      blosc_version: ${{ steps.set_default_versions.outputs.blosc_version }}
-      curl_version: ${{ steps.set_default_versions.outputs.curl_version }}
-      draco_version: ${{ steps.set_default_versions.outputs.draco_version }}
-      gdal_version: ${{ steps.set_default_versions.outputs.gdal_version }}
-      geotiff_version: ${{ steps.set_default_versions.outputs.geotiff_version }}
-      imath_version: ${{ steps.set_default_versions.outputs.imath_version }}
-      java_version: ${{ steps.set_default_versions.outputs.java_version }}
-      occt_version: ${{ steps.set_default_versions.outputs.occt_version }}
-      openexr_version: ${{ steps.set_default_versions.outputs.openexr_version }}
-      openvdb_version: ${{ steps.set_default_versions.outputs.openvdb_version }}
-      ospray_version: ${{ steps.set_default_versions.outputs.ospray_version }}
-      pdal_version: ${{ steps.set_default_versions.outputs.pdal_version }}
-      proj_version: ${{ steps.set_default_versions.outputs.proj_version }}
-      pybind11_version: ${{ steps.set_default_versions.outputs.pybind11_version }}
-      python_version: ${{ steps.set_default_versions.outputs.python_version }}
-      sqlite_csb_version: ${{ steps.set_default_versions.outputs.sqlite_csb_version }}
-      tbb_version: ${{ steps.set_default_versions.outputs.tbb_version }}
-      tiff_version: ${{ steps.set_default_versions.outputs.tiff_version }}
-      usd_version: ${{ steps.set_default_versions.outputs.usd_version }}
-      webifc_version: ${{ steps.set_default_versions.outputs.webifc_version }}
-      webp_version: ${{ steps.set_default_versions.outputs.webp_version }}
-      zlib_version: ${{ steps.set_default_versions.outputs.zlib_version }}
-      docker_timestamp: ${{ steps.set_default_versions.outputs.docker_timestamp }}
-      global_cache_index: ${{ steps.set_default_versions.outputs.global_cache_index }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: "source"
-          fetch-depth: 1
-          lfs: false
-
-      - name: Set default versions
-        id: set_default_versions
-        uses: f3d-app/default-versions-action@main
-        with:
-          file: ./source/.github/workflows/versions.json
-
-  #----------------------------------------------------------------------------
   # Cache LFS: Checkout LFS data and update the cache to limit LFS bandwidth
   #----------------------------------------------------------------------------
 
@@ -107,72 +59,23 @@ jobs:
           cache_postfix: cache-0
 
   #----------------------------------------------------------------------------
-  # Windows CI: Build and test
+  # Cross-platform CI: Build and test
   #----------------------------------------------------------------------------
-  windows:
-    needs: [cache_lfs, check_nightly, default_versions]
-    if: ${{ needs.check_nightly.outputs.should_run == 'true' }}
-    strategy:
-      fail-fast: false
-    runs-on: windows-2022
-
-    env:
-      CMAKE_POLICY_VERSION_MINIMUM: 3.5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: "source"
-          fetch-depth: 0
-          lfs: false
-
-      - name: Generic CI
-        uses: ./source/.github/actions/generic-ci
-        with:
-          vtk_version: ${{needs.check_nightly.outputs.vtk_sha}}
-          lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          java_version: ${{needs.default_versions.outputs.java_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          python_version: ${{needs.default_versions.outputs.python_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
-
-  #----------------------------------------------------------------------------
-  # Linux CI: Build and test
-  #----------------------------------------------------------------------------
-  linux:
-    needs: [cache_lfs, check_nightly, default_versions]
+  cross-platform:
+    needs: [cache_lfs, check_nightly]
     if: ${{ needs.check_nightly.outputs.should_run == 'true' }}
     strategy:
       fail-fast: false
       matrix:
         build_type: [standard]
+        os: [ubuntu-22.04, windows-latest, macos-15, macos-15-intel]
         include:
           - rendering_backend: auto
           - build_type: egl
+            os: ubuntu-22.04
             rendering_backend: egl
           - build_type: osmesa
+            os: ubuntu-22.04
             rendering_backend: osmesa
     runs-on: ubuntu-22.04
     container: ghcr.io/f3d-app/f3d-ci
@@ -196,139 +99,8 @@ jobs:
           vtk_version: ${{needs.check_nightly.outputs.vtk_sha}}
           rendering_backend: ${{matrix.rendering_backend}}
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          java_version: ${{needs.default_versions.outputs.java_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          python_version: ${{needs.default_versions.outputs.python_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
-
-  #----------------------------------------------------------------------------
-  # MacOS CI: Build and test
-  #----------------------------------------------------------------------------
-  macos:
-    needs: [cache_lfs, check_nightly, default_versions]
-    if: ${{ needs.check_nightly.outputs.should_run == 'true' }}
-    strategy:
-      fail-fast: false
-
-    runs-on: macos-15-intel
-
-    env:
-      CMAKE_POLICY_VERSION_MINIMUM: 3.5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: "source"
-          fetch-depth: 0
-          lfs: false
-
-      - name: Generic CI
-        uses: ./source/.github/actions/generic-ci
-        with:
-          vtk_version: ${{needs.check_nightly.outputs.vtk_sha}}
-          cpu: x86_64
-          lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          java_version: ${{needs.default_versions.outputs.java_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          python_version: ${{needs.default_versions.outputs.python_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
-
-  #----------------------------------------------------------------------------
-  # MacOS arm64 CI: Build and test
-  #----------------------------------------------------------------------------
-  macos_arm:
-    needs: [cache_lfs, check_nightly, default_versions]
-    if: ${{ needs.check_nightly.outputs.should_run == 'true' }}
-    strategy:
-      fail-fast: false
-
-    runs-on: macos-15
-
-    env:
-      CMAKE_POLICY_VERSION_MINIMUM: 3.5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: "source"
-          fetch-depth: 0
-          lfs: false
-
-      - name: Generic CI
-        uses: ./source/.github/actions/generic-ci
-        with:
-          vtk_version: ${{needs.check_nightly.outputs.vtk_sha}}
-          cpu: arm64
-          lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          java_version: ${{needs.default_versions.outputs.java_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          python_version: ${{needs.default_versions.outputs.python_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
+          versions_file: ./source/.github/workflows/versions.json
+          cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
   #----------------------------------------------------------------------------
   # Sanitizer: Build and test on linux with last VTK with sanitizer options
@@ -337,7 +109,7 @@ jobs:
   # "memory" returns false positives in VTK:
   # https://stackoverflow.com/questions/60097307/memory-sanitizer-reports-use-of-uninitialized-value-in-global-object-constructio
   sanitizer:
-    needs: [cache_lfs, check_nightly, default_versions]
+    needs: [cache_lfs, check_nightly]
     if: ${{ needs.check_nightly.outputs.should_run == 'true' }}
 
     strategy:
@@ -369,38 +141,14 @@ jobs:
           vtk_version: ${{needs.check_nightly.outputs.vtk_sha}}
           sanitizer_type: ${{matrix.sanitizer_type}}
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
-          alembic_version: ${{needs.default_versions.outputs.alembic_version}}
-          assimp_version: ${{needs.default_versions.outputs.assimp_version}}
-          blosc_version: ${{needs.default_versions.outputs.blosc_version}}
-          curl_version: ${{needs.default_versions.outputs.curl_version}}
-          draco_version: ${{needs.default_versions.outputs.draco_version}}
-          gdal_version: ${{needs.default_versions.outputs.gdal_version}}
-          geotiff_version: ${{needs.default_versions.outputs.geotiff_version}}
-          imath_version: ${{needs.default_versions.outputs.imath_version}}
-          java_version: ${{needs.default_versions.outputs.java_version}}
-          occt_version: ${{needs.default_versions.outputs.occt_version}}
-          openexr_version: ${{needs.default_versions.outputs.openexr_version}}
-          openvdb_version: ${{needs.default_versions.outputs.openvdb_version}}
-          ospray_version: ${{needs.default_versions.outputs.ospray_version}}
-          pdal_version: ${{needs.default_versions.outputs.pdal_version}}
-          proj_version: ${{needs.default_versions.outputs.proj_version}}
-          pybind11_version: ${{needs.default_versions.outputs.pybind11_version}}
-          python_version: ${{needs.default_versions.outputs.python_version}}
-          sqlite_csb_version: ${{needs.default_versions.outputs.sqlite_csb_version}}
-          tbb_version: ${{needs.default_versions.outputs.tbb_version}}
-          tiff_version: ${{needs.default_versions.outputs.tiff_version}}
-          usd_version: ${{needs.default_versions.outputs.usd_version}}
-          webifc_version: ${{needs.default_versions.outputs.webifc_version}}
-          webp_version: ${{needs.default_versions.outputs.webp_version}}
-          zlib_version: ${{needs.default_versions.outputs.zlib_version}}
-          global_cache_index: ${{needs.default_versions.outputs.global_cache_index}}
 
   #----------------------------------------------------------------------------
   # Build android/wasm docker images
   #----------------------------------------------------------------------------
   build_docker_images:
-    needs: check_nightly
     name: Build docker images
+    needs: check_nightly
+    if: ${{ needs.check_nightly.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       # This require a F3D_DOCKER_CI_DISPATCH secret contain a PAT with read and write admin access
@@ -418,17 +166,43 @@ jobs:
           wait_workflow: true
 
   #----------------------------------------------------------------------------
+  # Recover docker timestamp
+  #----------------------------------------------------------------------------
+  recover_docker_timestamp:
+    runs-on: ubuntu-22.04
+    name: Recover docker timestamp
+    needs: check_nightly
+    if: ${{ needs.check_nightly.outputs.should_run == 'true' }}
+    outputs:
+      docker_timestamp: ${{steps.docker_timestamp.outputs.extract}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: "source"
+          fetch-depth: 0
+          lfs: false
+
+      - name: Extract docker timestamp
+        id: docker_timestamp
+        uses: f3d-app/extract-version-action@main
+        with:
+          file: ./source/.github/workflows/versions.json
+          special_name: docker_timestamp
+
+  #----------------------------------------------------------------------------
   # android: Check build of F3D for android
   #----------------------------------------------------------------------------
   android:
-    needs: [check_nightly, default_versions, build_docker_images]
+    needs: [check_nightly, build_docker_images]
     strategy:
       fail-fast: false
       matrix:
         arch: [armeabi-v7a, arm64-v8a, x86, x86_64]
 
     runs-on: ubuntu-22.04
-    container: ghcr.io/f3d-app/f3d-android-${{ matrix.arch }}:${{needs.default_versions.outputs.docker_timestamp}}_${{needs.check_nightly.outputs.vtk_sha}}
+    container: ghcr.io/f3d-app/f3d-android-${{ matrix.arch }}:${{needs.recover_docker_timestamp.outputs.docker_timestamp}}_${{needs.check_nightly.outputs.vtk_sha}}
 
     steps:
       - name: Checkout
@@ -447,7 +221,7 @@ jobs:
   # webassembly: Build webassembly artifacts
   #----------------------------------------------------------------------------
   webassembly:
-    needs: [cache_lfs, check_nightly, default_versions, build_docker_images]
+    needs: [cache_lfs, check_nightly, build_docker_images]
     strategy:
       fail-fast: false
 
@@ -455,7 +229,7 @@ jobs:
 
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
-      F3D_DOCKER_TIMESTAMP: ${{needs.default_versions.outputs.docker_timestamp}}
+      F3D_DOCKER_TIMESTAMP: ${{needs.recover_docker_timestamp.outputs.docker_timestamp}}_${{needs.check_nightly.outputs.vtk_sha}}
 
     steps:
       - name: Checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 include(CMakeDependentOption)
 
+
 # Generic CMake variables, should be done before project()
 set(output_postfix "")
 get_property(F3D_MULTI_CONFIG_GENERATOR GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 cmake_minimum_required(VERSION 3.21)
 include(CMakeDependentOption)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 3.21)
 include(CMakeDependentOption)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 include(CMakeDependentOption)
 
-
 # Generic CMake variables, should be done before project()
 set(output_postfix "")
 get_property(F3D_MULTI_CONFIG_GENERATOR GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)


### PR DESCRIPTION
### Describe your changes

Complete rework of the cache mechanism with the addition of a "Cache Preheating" dedicated workflow, that should be used only when needed and generate caches directly in master.
 - Fix the "runner interlock" problem with the previous cache mechanism
 - Generate caches directly from PR into master
 - Generate caches only when needed, means faster CI in the general case
 
In order to achieve that, a new `pull_request_target` workflow that uses matrixes to pre-heat all depencies caches, including VTK, have been added and all cache heating cache removing from CI workflow. 

In order to be able to add new dependency without problems and to avoid tons of boilerplate and simplify our CI, the versions extraction has been moved from a dedicated action to individual dependency action.

- Move version extractions to every single dependency action
- Transfer the needed info through `versions_file`, `mindeps-label` and `optdeps-label`
- Move "first dependency steps" to vtk-dependencies action for simplicity
- `build_docker_images` workflow is now a cache only action, which means that even though most of the CI will work without pre-heating cache, webassembly and android will when changing the docker time steps
- Update nightly ci accordingly (not tested yet)
- Update all OS in uses (windows-2022, ubuntu-24.04)
- Fix an issue with docker image used in nightly webassembly
- Moved ospray step to vtk dependencies
- Fix small issues found along the way
 
 TODO:
 - Rework versions.json for clarity (another PR)
 - Finish https://github.com/f3d-app/f3d-papers
 
### Issue ticket number and link if any

Fix: https://github.com/f3d-app/f3d/issues/3081

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
