### PR TITLE
Imagereader error reporting & handling

### DIFF
--- a/plugins/native/module/vtkF3DImageImporter.cxx
+++ b/plugins/native/module/vtkF3DImageImporter.cxx
@@ -52,7 +52,13 @@ void vtkF3DImageImporter::ImportActors(vtkRenderer* renderer)
     reader->SetFileName(fileName);
   }
 
-  reader->UpdateInformation();
+  // If UpdateInformation() returns false or the error code is set, we assume there was an error reading the image
+  if (!reader->UpdateInformation() || reader->GetErrorCode() != 0)
+  {
+    vtkErrorMacro("Reader failed to read the image");
+    this->SetFailureStatus();
+    return;
+  }
 
   int extent[6];
   reader->GetDataExtent(extent);


### PR DESCRIPTION
### Describe your changes
In normal f3d usage, Imagereader failing to read a file would result in silenced errors and produce a un-intialized buffer. E.g. `f3d --no-config --force-reader=PNG f3d.glb` results in :
* No visible warnings in the GUI (or CLI if run from a terminal)
* A corrupted image (square, usually red or sometimes random text could be seen)

Note : this behaviour would change if --verbose was specified to the command line `f3d --no-config --force-reader=PNG f3d.glb --verbose` and warnings would be visible in the CLI and GUI, however the corrupted image would still appear.

I have implemented 2 main changes to improve this.

1.  When `vtkF3DImageImporter` is trying to import an image it will check if the reader called `UpdateInformation()` correctly and also check if the error codes were set on reader `reader->GetErrorCode() != 0`. 

2. When the f3d::scene is trying to first add the image importer to the list of importers we check if `reader->canRead(...)` returns successful.

* If unsuccessful & running with default verbosity an error is thrown\* which specifies the user can use the `--verbose` flag for more information.

* If unsuccessful & running with verbosity == debug then a warning is thrown but the code will continue on like it used to\*\*.

\* should we throw an error or simply print a debug line? It seems a lot of similar code in this file throws an error e.g. if f3d couldn't find a reader for the file type specified. But this implies that one bad file in a batch import can throw the entire scene correct?   
\*\* as canRead() generally does not provide any VTK errors as to why an image failed, a debug option (locked behind verbosity == debug) is provided which will continue on to run the code listed above and will print any VTK errors provided by the reader.

Before any changes
```bash
f3d --no-config --force-reader=PNG ./testing/data/f3d.glb
# No errors printed, but random image displayed
```
After change 1
```bash
f3d --no-config --force-reader=PNG ./testing/data/f3d.glb
Some of these files could not be loaded: failed to load scene
  /home/iommu/Desktop/f3d/testing/data/f3d.glb
# Error (as shown ^^^) is printed to terminal and to GUI "!" and no image is displayed
```

After change 2
```bash
f3d --no-config --force-reader=PNG ./testing/data/f3d.glb
Some of these files could not be loaded: /home/iommu/Desktop/f3d/testing/data/f3d.glb could not be read by the forced reader "PNG" , use the --verbose command flag for more information
  /home/iommu/Desktop/f3d/testing/data/f3d.glb
# Error (as shown ^^^) is printed to terminal and to GUI "!" and no image is displayed 
```

After change 2 : verbose
```bash
f3d --no-config --force-reader=PNG ./testing/data/f3d.glb --verbose
... normal debug logs...
Checking files:
Forcing reader PNG for /home/iommu/Desktop/f3d/testing/data/f3d.glb
The reader "PNG" is reporting it cannot read the file "/home/iommu/Desktop/f3d/testing/data/f3d.glb".

Loading files: 
/home/iommu/Desktop/f3d/testing/data/f3d.glb

ERROR: In vtkPNGReader.cxx, line 161
vtkPNGReader (0x560203fa7040): Unknown file type! Not a PNG file!

ERROR: In vtkPNGReader.cxx, line 338
vtkPNGReader (0x560203fa7040): Invalid file header: not a PNG file

ERROR: In vtkExecutive.cxx, line 729
vtkCompositeDataPipeline (0x560204074ba0): Algorithm vtkPNGReader (0x560203fa7040) returned failure for request: vtkInformation (0x560204076840)
  Debug: Off
  Modified Time: 16406
  Reference Count: 1
  Registered Events: (none)
  Request: REQUEST_INFORMATION
  ALGORITHM_AFTER_FORWARD: 1
  FORWARD_DIRECTION: 0

ERROR: In vtkF3DImageImporter.cxx, line 58
vtkF3DImageImporter (0x560203fa66d0): Reader failed to read the image

Some of these files could not be loaded: failed to load scene
  /home/iommu/Desktop/f3d/testing/data/f3d.glb
# Error (as shown ^^^) is printed to terminal and to GUI "!" and no image is displayed 
```


### Issue ticket number and link if any
https://github.com/f3d-app/f3d/issues/2929 

### Checklist for finalizing the PR

- [X] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [X] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- [X] AI was used for research purposes for debugging only and all relevant code was deleted for this PR. (Model was the default google one that pops up when you search things)

### Continuous integration

