### PR TITLE
2446 multiple cli options

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -191,7 +191,7 @@ f3d_generate_cli_options(
   F3D_SOURCE_DIR "${F3D_SOURCE_DIR}"
   F3D_BINARY_DIR "${F3D_BINARY_DIR}"
   ENABLED_CONDITIONALS ${f3d_enabled_conditionals} # Do NOT quote so this stays a list
-  CPP_CLI_OPTIONS_TO_SKIP input;define # Do NOT quote so this stays a list
+  CPP_CLI_OPTIONS_TO_SKIP input # Do NOT quote so this stays a list
 )
 
 set(F3D_SOURCE_FILES

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -191,7 +191,7 @@ f3d_generate_cli_options(
   F3D_SOURCE_DIR "${F3D_SOURCE_DIR}"
   F3D_BINARY_DIR "${F3D_BINARY_DIR}"
   ENABLED_CONDITIONALS ${f3d_enabled_conditionals} # Do NOT quote so this stays a list
-  CPP_CLI_OPTIONS_TO_SKIP input;define;reset # Do NOT quote so this stays a list
+  CPP_CLI_OPTIONS_TO_SKIP input;define # Do NOT quote so this stays a list
 )
 
 set(F3D_SOURCE_FILES

--- a/application/F3DOptionsTools.cxx
+++ b/application/F3DOptionsTools.cxx
@@ -268,9 +268,6 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
   std::vector<std::shared_ptr<cxxopts::Value>> cxxoptsValues;
   auto cxxoptsInputPositionals = cxxopts::value<std::vector<std::string>>(positionals);
 
-  std::vector<std::string> defines;
-  auto cxxoptsDefines = cxxopts::value<std::vector<std::string>>(defines);
-
   try
   {
     cxxopts::Options cxxOptions(execName, F3D::AppTitle);
@@ -284,7 +281,6 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
       if (std::string(optionGroup.GroupName) == "Applicative")
       {
         group("input", "Input files", cxxoptsInputPositionals, "<files>");
-        group("D,define", "Define libf3d options", cxxoptsDefines, "libf3d.option=value");
       }
 
       // Add each option to cxxopts
@@ -446,36 +442,24 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
         continue;
       }
       auto iter = cliOptionsDict.find(res.key());
-      if(iter == cliOptionsDict.end())
+      if (iter == cliOptionsDict.end())
       {
         cliOptionsDict[res.key()] = res.value();
       }
-      else  
+      else
       {
         // key already exists. Create or append to vector
-        if(std::holds_alternative<std::vector<std::string>>(iter->second))
+        if (std::holds_alternative<std::vector<std::string>>(iter->second))
         {
-          auto& vec =  std::get<std::vector<std::string>>(iter->second);
+          auto& vec = std::get<std::vector<std::string>>(iter->second);
           vec.push_back(res.value());
         }
-        else 
+        else
         {
-          auto& item =  std::get<std::string>(iter->second);
-          cliOptionsDict[res.key()] = std::vector<std::string>{item,res.value()};
+          auto& item = std::get<std::string>(iter->second);
+          cliOptionsDict[res.key()] = std::vector<std::string>{ item, res.value() };
         }
       }
-    }
-
-    // Handle defines and add them as proper options
-    for (const std::string& define : defines)
-    {
-      std::string::size_type sepIdx = define.find_first_of('=');
-      if (sepIdx == std::string::npos)
-      {
-        f3d::log::warn("Could not parse a define '", define, "'");
-        continue;
-      }
-      cliOptionsDict[define.substr(0, sepIdx)] = define.substr(sepIdx + 1);
     }
 
     return cliOptionsDict;

--- a/application/F3DOptionsTools.cxx
+++ b/application/F3DOptionsTools.cxx
@@ -490,7 +490,7 @@ std::vector<std::pair<std::string, F3DOptionsTools::OptionValue>>
 F3DOptionsTools::ConvertToLibf3dOptions(const std::string& key, const OptionValue& value)
 {
   std::vector<std::pair<std::string, F3DOptionsTools::OptionValue>> libf3dOptions;
-  const bool is_single_valued = std::holds_alternative<std::string>(value);
+  [[maybe_unused]] const bool is_single_valued = std::holds_alternative<std::string>(value);
 
   // Simple one-to-one case
   auto libf3dIter = F3DOptionsTools::LibOptionsNames.find(key);

--- a/application/F3DOptionsTools.cxx
+++ b/application/F3DOptionsTools.cxx
@@ -312,7 +312,9 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
           auto appIter = F3DOptionsTools::DefaultAppOptions.find(longName);
           if (appIter != F3DOptionsTools::DefaultAppOptions.end())
           {
-            defaultValue = appIter->second;
+            // defaults are always stored as strings
+            assert(std::holds_alternative<std::string>(appIter->second));
+            defaultValue = std::get<std::string>(appIter->second);
           }
           else
           {
@@ -431,7 +433,7 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
       throw F3DExFailure("unknown options");
     }
 
-    // Add each CLI options into a vector of string/string and return it
+    // Add each CLI options into a OptionsDict and return it
     F3DOptionsTools::OptionsDict cliOptionsDict;
     for (const auto& res : result)
     {
@@ -484,10 +486,11 @@ void F3DOptionsTools::PrintHelpPair(
 }
 
 //----------------------------------------------------------------------------
-std::vector<std::pair<std::string, std::string>> F3DOptionsTools::ConvertToLibf3dOptions(
-  const std::string& key, const std::string& value)
+std::vector<std::pair<std::string, F3DOptionsTools::OptionValue>>
+F3DOptionsTools::ConvertToLibf3dOptions(const std::string& key, const OptionValue& value)
 {
-  std::vector<std::pair<std::string, std::string>> libf3dOptions;
+  std::vector<std::pair<std::string, F3DOptionsTools::OptionValue>> libf3dOptions;
+  const bool is_single_valued = std::holds_alternative<std::string>(value);
 
   // Simple one-to-one case
   auto libf3dIter = F3DOptionsTools::LibOptionsNames.find(key);
@@ -502,4 +505,20 @@ std::vector<std::pair<std::string, std::string>> F3DOptionsTools::ConvertToLibf3
   }
 
   return libf3dOptions;
+}
+
+std::string F3DOptionsTools::ConvertToString(const F3DOptionsTools::OptionValue& optionValue)
+{
+  if (std::holds_alternative<std::string>(optionValue))
+  {
+    return std::get<std::string>(optionValue);
+  }
+  else if (std::holds_alternative<std::vector<std::string>>(optionValue))
+  {
+    const auto& vec = std::get<std::vector<std::string>>(optionValue);
+    auto concatenate = [](const std::string& result, const std::string& value)
+    { return result + " , " + value; };
+    return std::accumulate(vec.cbegin(), vec.cend(), std::string{ "" }, concatenate);
+  }
+  return "";
 }

--- a/application/F3DOptionsTools.cxx
+++ b/application/F3DOptionsTools.cxx
@@ -26,11 +26,10 @@ namespace
 {
 /**
  * True boolean options need to be filtered out in ParseCLIOptions
- * Also filter out special options like `define` and `reset`
  * This is the easiest, compile time way to do it
  */
 constexpr std::array CLIBooleans = { "version", "help", "list-readers", "scan-plugins",
-  "list-rendering-backends", "define", "reset" };
+  "list-rendering-backends" };
 
 //----------------------------------------------------------------------------
 /**
@@ -272,9 +271,6 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
   std::vector<std::string> defines;
   auto cxxoptsDefines = cxxopts::value<std::vector<std::string>>(defines);
 
-  std::vector<std::string> resets;
-  auto cxxoptsResets = cxxopts::value<std::vector<std::string>>(resets);
-
   try
   {
     cxxopts::Options cxxOptions(execName, F3D::AppTitle);
@@ -289,7 +285,6 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
       {
         group("input", "Input files", cxxoptsInputPositionals, "<files>");
         group("D,define", "Define libf3d options", cxxoptsDefines, "libf3d.option=value");
-        group("R,reset", "Reset libf3d options", cxxoptsResets, "libf3d.option");
       }
 
       // Add each option to cxxopts
@@ -307,6 +302,7 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
           std::string defaultValue;
           std::string helpText(cliOption.HelpText);
           std::string longName(cliOption.LongName);
+          std::string valueHelper(cliOption.ValueHelper);
 
           // Recover default value from app options
           auto appIter = F3DOptionsTools::DefaultAppOptions.find(longName);
@@ -339,7 +335,14 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
           }
 
           // Recover the implicit value and set it if any
-          cxxoptsValues.emplace_back(cxxopts::value<std::string>());
+          if (valueHelper == "<string_list>")
+          {
+            cxxoptsValues.emplace_back(cxxopts::value<std::vector<std::string>>());
+          }
+          else
+          {
+            cxxoptsValues.emplace_back(cxxopts::value<std::string>());
+          }
           auto& val = cxxoptsValues.back();
           if (!cliOption.ImplicitValue.empty())
           {
@@ -438,9 +441,28 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
     for (const auto& res : result)
     {
       // Discard boolean option like `--version` or `--help`
-      if (std::ranges::find(::CLIBooleans, res.key()) == ::CLIBooleans.end())
+      if (std::ranges::find(::CLIBooleans, res.key()) != ::CLIBooleans.end())
+      {
+        continue;
+      }
+      auto iter = cliOptionsDict.find(res.key());
+      if(iter == cliOptionsDict.end())
       {
         cliOptionsDict[res.key()] = res.value();
+      }
+      else  
+      {
+        // key already exists. Create or append to vector
+        if(std::holds_alternative<std::vector<std::string>>(iter->second))
+        {
+          auto& vec =  std::get<std::vector<std::string>>(iter->second);
+          vec.push_back(res.value());
+        }
+        else 
+        {
+          auto& item =  std::get<std::string>(iter->second);
+          cliOptionsDict[res.key()] = std::vector<std::string>{item,res.value()};
+        }
       }
     }
 
@@ -454,12 +476,6 @@ F3DOptionsTools::OptionsDict F3DOptionsTools::ParseCLIOptions(
         continue;
       }
       cliOptionsDict[define.substr(0, sepIdx)] = define.substr(sepIdx + 1);
-    }
-
-    // Handles reset using the dedicated syntax
-    for (const std::string& reset : resets)
-    {
-      cliOptionsDict["reset-" + reset] = "";
     }
 
     return cliOptionsDict;

--- a/application/F3DOptionsTools.h
+++ b/application/F3DOptionsTools.h
@@ -9,13 +9,15 @@
 
 #include <filesystem>
 #include <map>
+#include <set>
 #include <string>
 #include <tuple>
 #include <vector>
 
 namespace F3DOptionsTools
 {
-using OptionsDict = std::map<std::string, std::string>;
+using OptionValue = std::variant<std::vector<std::string>, std::string>;
+using OptionsDict = std::map<std::string, OptionValue>;
 using OptionsEntry = std::tuple<OptionsDict, std::string, std::string, std::string>;
 using OptionsEntries = std::vector<OptionsEntry>;
 
@@ -27,7 +29,7 @@ using OptionsEntries = std::vector<OptionsEntry>;
  * and ParseCLIOptions
  */
 static inline const OptionsDict DefaultAppOptions = {
-  { "input", "" },
+  { "input", { "" } },
   { "output", "" },
   { "list-bindings", "false" },
   { "no-background", "false" },
@@ -160,10 +162,15 @@ static inline const std::map<std::string_view, std::string_view> LibOptionsNames
 };
 
 /**
+ * List of CLI option names that can accept multiple values
+ */
+static inline const std::set<std::string_view> MultiValueOptions = { "define", "input", "reset" };
+
+/**
  * Convert a CLI options key/value to a vector of libf3d options key/value
  */
-std::vector<std::pair<std::string, std::string>> ConvertToLibf3dOptions(
-  const std::string& key, const std::string& value);
+std::vector<std::pair<std::string, F3DOptionsTools::OptionValue>> ConvertToLibf3dOptions(
+  const std::string& key, const OptionValue& value);
 
 /**
  * Browse through all possible option names to find one that have the smallest distance to the
@@ -189,12 +196,18 @@ void PrintHelpPair(
   std::string_view key, std::string_view help, int keyWidth = 10, int helpWidth = 70);
 
 /**
+ * Convert the variant-based OptionValue to a string. Useful for debugging
+ */
+std::string ConvertToString(const OptionValue& optionValue);
+
+/**
  * Parse provided string into provided typed var.
  * Return true if successful, false otherwise.
  */
 template<typename T>
-bool Parse(const std::string& optionString, T& option)
+bool Parse(const OptionValue& optionValue, T& option)
 {
+  const std::string optionString = ConvertToString(optionValue);
   try
   {
     option = f3d::options::parse<T>(optionString);

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -102,6 +102,18 @@ void apply_to_all(F3DOptionsTools::OptionValue& option, Callable f)
     },
     option);
 }
+void HandleDefine(f3d::options& libOptions, const std::string& optionValue)
+{
+  std::string::size_type sepidx = optionValue.find_first_of('=');
+  if (sepidx == std::string::npos)
+  {
+    f3d::log::warn("Could not parse a define '", optionValue, "'");
+    return;
+  }
+  const auto key = optionValue.substr(0, sepidx);
+  const auto value = optionValue.substr(sepidx + 1);
+  libOptions.setAsString(key, value);
+}
 }
 
 class F3DStarter::F3DInternals
@@ -706,6 +718,15 @@ public:
                           return;
                         }
                         libOptions.reset(value);
+                      });
+                  }
+                  else if (libf3dOptionName == "define")
+                  {
+                    apply_to_all(libf3dOptionValue,
+                      [&libOptions, &keyForLog](const std::string& value)
+                      {
+                        keyForLog = value;
+                        HandleDefine(libOptions, value);
                       });
                   }
                   else

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -71,6 +71,39 @@ f3d::interactor* GlobalInteractor = nullptr;
 
 constexpr std::string_view F3D_PIPED = "-";
 
+namespace
+{
+// helper to apply Callable to all items of OptionValue no matter if it is a
+// single valued string or a vector of strings
+// based on example at https://en.cppreference.com/cpp/utility/variant/visit2
+
+template<typename Callable>
+void apply_to_all(F3DOptionsTools::OptionValue& option, Callable f)
+{
+  std::visit(
+    [f](auto&& value)
+    {
+      using T = std::decay_t<decltype(value)>;
+      if constexpr (std::is_same_v<T, std::string>)
+      {
+        f(value);
+      }
+      else if constexpr (std::is_same_v<T, std::vector<std::string>>)
+      {
+        for (auto& item : value)
+        {
+          f(item);
+        }
+      }
+      else
+      {
+        static_assert(false, "non-exhaustive visitor!");
+      }
+    },
+    option);
+}
+}
+
 class F3DStarter::F3DInternals
 {
 public:
@@ -646,26 +679,6 @@ public:
               {
                 auto [libf3dOptionName, libf3dOptionValue] = libf3dOption;
 
-                bool reset = false;
-
-                // Handle options reset
-                if (libf3dOptionName.starts_with("reset-"))
-                {
-                  if (libf3dOptionName.size() > 6)
-                  {
-                    reset = true;
-                    libf3dOptionName = libf3dOptionName.substr(6);
-                    keyForLog = libf3dOptionName;
-                    libf3dOptionValue = "reset";
-                  }
-                  else
-                  {
-                    f3d::log::warn("Invalid option: 'reset' must be followed by a valid option "
-                                   "name, ignoring entry");
-                    continue;
-                  }
-                }
-
                 // Handle reader options
                 std::vector<std::string> readerOptionNames = f3d::engine::getAllReaderOptionNames();
                 if (std::ranges::find(readerOptionNames, libf3dOptionName) !=
@@ -680,10 +693,20 @@ public:
 
                 try
                 {
-                  // Assume this is a libf3d option and set/reset the value
-                  if (reset)
+                  if (libf3dOptionName == "reset")
                   {
-                    libOptions.reset(libf3dOptionName);
+                    apply_to_all(libf3dOptionValue,
+                      [&libOptions, &keyForLog](const std::string& value)
+                      {
+                        keyForLog = value;
+                        if (value.empty())
+                        {
+                          f3d::log::warn("Invalid option: 'reset' must be followed by a valid "
+                                         "option name, ignoring entry");
+                          return;
+                        }
+                        libOptions.reset(value);
+                      });
                   }
                   else
                   {
@@ -715,8 +738,7 @@ public:
                   if (!quiet)
                   {
                     const std::string origin = F3DInternals::FormatOrigin(source, matchType, match);
-                    auto [closestName, dist] =
-                      F3DOptionsTools::GetClosestOption(libf3dOptionName, true);
+                    auto [closestName, dist] = F3DOptionsTools::GetClosestOption(keyForLog, true);
                     f3d::log::warn("'", keyForLog, "' option from ", origin,
                       " does not exists , did you mean '", closestName, "'?");
                   }
@@ -1580,6 +1602,7 @@ void F3DStarter::LoadFileGroupInternal(
   // options names are shared between options instance
   F3DOptionsTools::OptionsDict dynamicOptionsDict;
   std::vector<std::string> optionNames = dynamicOptions.getAllNames();
+  std::vector<std::string> resets;
   for (const auto& name : optionNames)
   {
     if (!dynamicOptions.isSame(this->Internals->LibOptions, name))
@@ -1588,7 +1611,7 @@ void F3DStarter::LoadFileGroupInternal(
       {
         // If a dynamic option has been changed and does not have value, it means it was reset using
         // the command line reset it using the dedicated syntax
-        dynamicOptionsDict["reset-" + name] = "";
+        resets.push_back(name);
       }
       else
       {
@@ -1598,6 +1621,7 @@ void F3DStarter::LoadFileGroupInternal(
       }
     }
   }
+  dynamicOptionsDict["reset"] = resets;
 
   // Detect interactively changed verbose level and add it to dynamic options
   f3d::log::VerboseLevel currentVerboseLevel = f3d::log::getVerboseLevel();

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -76,7 +76,8 @@ class F3DStarter::F3DInternals
 public:
   F3DInternals() = default;
 
-  using log_entry_t = std::tuple<std::string, std::string, std::string, std::string, std::string>;
+  using log_entry_t =
+    std::tuple<std::string, std::string, std::string, std::string, F3DOptionsTools::OptionValue>;
 
   // XXX: The values in the following two structs
   // are left uninitialized as the will all be initialized from
@@ -571,7 +572,8 @@ public:
     {
       const auto& [bindStr, source, matchType, match, commands] = tuple;
       const std::string origin = F3DInternals::FormatOrigin(source, matchType, match);
-      f3d::log::debug(" '", bindStr, "' ", sep, " '", commands, "' from ", origin);
+      f3d::log::debug(" '", bindStr, "' ", sep, " '", F3DOptionsTools::ConvertToString(commands),
+        "' from ", origin);
     }
     f3d::log::debug("");
   }
@@ -669,7 +671,10 @@ public:
                 if (std::ranges::find(readerOptionNames, libf3dOptionName) !=
                   readerOptionNames.end())
                 {
-                  f3d::engine::setReaderOption(libf3dOptionName, libf3dOptionValue);
+                  assert(std::holds_alternative<std::string>(libf3dOptionValue));
+                  std::string libf3dOptionValueStr = std::get<std::string>(libf3dOptionValue);
+
+                  f3d::engine::setReaderOption(libf3dOptionName, libf3dOptionValueStr);
                   continue;
                 }
 
@@ -682,7 +687,10 @@ public:
                   }
                   else
                   {
-                    libOptions.setAsString(libf3dOptionName, libf3dOptionValue);
+                    assert(std::holds_alternative<std::string>(libf3dOptionValue));
+                    const std::string libf3dOptionValueStr =
+                      std::get<std::string>(libf3dOptionValue);
+                    libOptions.setAsString(libf3dOptionName, libf3dOptionValueStr);
                   }
 
                   // Log the option if needed
@@ -697,8 +705,9 @@ public:
                   if (!quiet)
                   {
                     const std::string origin = F3DInternals::FormatOrigin(source, matchType, match);
-                    f3d::log::warn("Could not set '", keyForLog, "' to '", libf3dOptionValue,
-                      "' from ", origin, " because: ", ex.what());
+                    f3d::log::warn("Could not set '", keyForLog, "' to '",
+                      F3DOptionsTools::ConvertToString(libf3dOptionValue), "' from ", origin,
+                      " because: ", ex.what());
                   }
                 }
                 catch (const f3d::options::inexistent_exception&)
@@ -750,7 +759,8 @@ public:
   {
     if (!F3DOptionsTools::Parse(appOptions.at(name), option))
     {
-      f3d::log::warn("Could not parse '" + appOptions.at(name) + "' into '" + name + "' option");
+      f3d::log::warn("Could not parse '" + F3DOptionsTools::ConvertToString(appOptions.at(name)) +
+        "' into '" + name + "' option");
     }
   }
 
@@ -762,7 +772,7 @@ public:
   void ParseOption(const F3DOptionsTools::OptionsDict& appOptions, const std::string& name,
     std::optional<T>& option)
   {
-    const std::string& optStr = appOptions.at(name);
+    const std::string& optStr = F3DOptionsTools::ConvertToString(appOptions.at(name));
     if (optStr.empty())
     {
       option = std::nullopt;
@@ -1071,8 +1081,8 @@ int F3DStarter::Start(int argc, char** argv)
   {
     if (!F3DOptionsTools::Parse(iter->second, noConfig))
     {
-      f3d::log::warn(
-        "Could not parse '" + iter->second + "' into 'no-config' option, assuming false");
+      f3d::log::warn("Could not parse '" + F3DOptionsTools::ConvertToString(iter->second) +
+        "' into 'no-config' option, assuming false");
     }
   }
 

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -708,25 +708,25 @@ public:
                   if (libf3dOptionName == "reset")
                   {
                     apply_to_all(libf3dOptionValue,
-                      [&libOptions, &keyForLog](const std::string& value)
+                      [&libOptions, &keyForLog](const std::string& optionValue)
                       {
-                        keyForLog = value;
-                        if (value.empty())
+                        keyForLog = optionValue;
+                        if (optionValue.empty())
                         {
                           f3d::log::warn("Invalid option: 'reset' must be followed by a valid "
                                          "option name, ignoring entry");
                           return;
                         }
-                        libOptions.reset(value);
+                        libOptions.reset(optionValue);
                       });
                   }
                   else if (libf3dOptionName == "define")
                   {
                     apply_to_all(libf3dOptionValue,
-                      [&libOptions, &keyForLog](const std::string& value)
+                      [&libOptions, &keyForLog](const std::string& optionValue)
                       {
-                        keyForLog = value;
-                        HandleDefine(libOptions, value);
+                        keyForLog = optionValue;
+                        HandleDefine(libOptions, optionValue);
                       });
                   }
                   else

--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -238,13 +238,16 @@ f3d_test(NAME TestFontColor DATA suzanne.ply ARGS -n --font-color=Orange UI)
 
 ## Special CLI syntax
 f3d_test(NAME TestDefines DATA dragon.vtu ARGS -Dscene.up_direction=+Z --define=model.color.rgb=red)
+f3d_test(NAME TestDefinesMultiple DATA dragon.vtu ARGS --define=scene.up_direction=+Z --define=model.color.rgb=red)
 f3d_test(NAME TestDefinesInvalid DATA dragon.vtu ARGS -Dscene.up_direction+Z REGEXP "Could not parse a define" NO_BASELINE)
 f3d_test(NAME TestDefinesInexistent DATA dragon.vtu ARGS -Dscene.up_director=+Z REGEXP "option from CLI options does not exists" NO_BASELINE)
 f3d_test(NAME TestAlternativeOptionSyntax DATA WaterBottle.glb ARGS --max-size 0.2 REGEXP "file is bigger than max size" NO_BASELINE)
 f3d_test(NAME TestCustomOptionsNone DATA red_translucent_monkey.gltf ARGS --blending=none --anti-aliasing=none --point-sprites=none)
+f3d_test(NAME TestDefineAndReset DATA dragon.vtu ARGS -Drender.show_edges=1 --define=render.background.color=1,1,1 -Rrender.show_edges --reset=render.background.color)
 
 ## Config
 f3d_test(NAME TestConfigReset DATA suzanne.stl ARGS -Rrender.grid.enable --reset=ui.axis CONFIG ${F3D_SOURCE_DIR}/testing/configs/complex.json)
+f3d_test(NAME TestConfigResetMultiple DATA suzanne.stl ARGS --reset=render.grid.enable --reset=ui.axis CONFIG ${F3D_SOURCE_DIR}/testing/configs/complex.json)
 f3d_test(NAME TestConfigResetInexistent DATA suzanne.stl ARGS -Rrender.glid.enable REGEXP "option from CLI options does not exists" NO_BASELINE)
 f3d_test(NAME TestConfigOrder DATA suzanne.ply ARGS CONFIG ${F3D_SOURCE_DIR}/testing/configs/config_order.json) # `.+` > `.*` alphabetically but overridden by the order
 # Needs https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12489

--- a/resources/cli-options.json
+++ b/resources/cli-options.json
@@ -12,7 +12,8 @@
         {
           "longName": "define",
           "shortName": "D",
-          "helpText": "Define libf3d options"
+          "helpText": "Define libf3d options",
+          "valueHelper": "<string_list>"
         },
         {
           "longName": "reset",

--- a/resources/cli-options.json
+++ b/resources/cli-options.json
@@ -17,7 +17,8 @@
         {
           "longName": "reset",
           "shortName": "R",
-          "helpText": "Reset libf3d options"
+          "helpText": "Reset libf3d options",
+          "valueHelper": "<string_list>"
         },
         {
           "longName": "output",

--- a/testing/baselines/TestConfigResetMultiple.png
+++ b/testing/baselines/TestConfigResetMultiple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e6e2b95e9ad761851cc0c767bcc4c04d0e9a38687350bf5401fd4f4da630789
+size 23695

--- a/testing/baselines/TestDefineAndReset.png
+++ b/testing/baselines/TestDefineAndReset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64feff09fbb315240054a0c163dbd97e18f00ab8732cb1f9719bc39496baacf5
+size 22986

--- a/testing/baselines/TestDefinesMultiple.png
+++ b/testing/baselines/TestDefinesMultiple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed55b928b8bfd5d027840d84487eaaca5945a5d8fcacc3b792204f92b0529f53
+size 26830


### PR DESCRIPTION
### Describe your changes

This MR adds support for multivalued options. The new infrastructure is applied on `--define` and `--reset`.  The parsing of these two flags use no longer custom code. Instead, the two options are tagged with `"valueHelper": "<string_list>"`  in `resources/cli-options.json`  which signifies that they could hold one or more values.

### Issue ticket number and link if any

#2446 

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
