### PR TITLE
CI: Use fixed version for actions deemed not safe

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -61,7 +61,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@v3.0.4
         if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1'}}
         with:
           message: New docker images have been generated

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -9,4 +9,4 @@ jobs:
 
     steps:
       - name: Clear caches
-        uses: easimon/wipe-cache@v2
+        uses: easimon/wipe-cache@5f305e3ee1b681c44328cdf11eaedf943b60edff

--- a/.github/workflows/public-api-warn.yml
+++ b/.github/workflows/public-api-warn.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           message: |
             You are modifying libf3d public API! :warning:Please update bindings accordingly:warning:!

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -35,7 +35,7 @@ jobs:
           codespell -fHw .
 
       - name: C++ Formatting
-        uses: DoozyX/clang-format-lint-action@v0.16
+        uses: DoozyX/clang-format-lint-action@8b8bbdd8669eec54682e720ebe2fb19d9387fdb0
         with:
           source: "."
           extensions: "h,cxx,in"
@@ -50,7 +50,7 @@ jobs:
 
       - name: Prettier Formatting
         continue-on-error: true
-        uses: creyD/prettier_action@v4.3
+        uses: creyD/prettier_action@8c18391fdc98ed0d884c6345f03975edac71b8f0
         with:
           dry: True
           prettier_options: "-w **/*.{js,json,md,html,yml}"
@@ -83,14 +83,14 @@ jobs:
           name: f3d-style-checks-diff-${{ github.event.pull_request.head.ref }}
 
       - name: Delete comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: style
           delete: true
 
       - name: Create comment
         if: failure()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: style
           message: |

--- a/.github/workflows/version-timestamp-warn.yml
+++ b/.github/workflows/version-timestamp-warn.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           message: You are modifying versions.json, please update the docker timestamp as well, then run the cache preheating workflow (maintainers only). This will generate new docker images and caches needed for CI.


### PR DESCRIPTION
### Describe your changes

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [ ] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
