### PR TITLE
Fix OpenGL error when showing fps

### DIFF
--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2163,7 +2163,6 @@ void vtkF3DRenderer::Render()
   }
 
   vtkInformation* info = this->GetInformation();
-
   bool uiOnly = info->Get(vtkF3DRenderPass::RENDER_UI_ONLY());
 
 #if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2162,17 +2162,20 @@ void vtkF3DRenderer::Render()
     glGenQueries(1, &this->Timer);
   }
 
+  vtkInformation* info = this->GetInformation();
+
+  bool uiOnly = info->Get(vtkF3DRenderPass::RENDER_UI_ONLY());
+
 #if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
-  glBeginQuery(GL_TIME_ELAPSED, this->Timer);
+  if (!uiOnly)
+  {
+    glBeginQuery(GL_TIME_ELAPSED, this->Timer);
+  }
 #endif
 
   this->Superclass::Render();
 
   auto cpuElapsed = std::chrono::high_resolution_clock::now() - cpuStart;
-
-  vtkInformation* info = this->GetInformation();
-
-  bool uiOnly = info->Get(vtkF3DRenderPass::RENDER_UI_ONLY());
 
   if (!uiOnly)
   {


### PR DESCRIPTION
### Describe your changes

Fix an OpenGL error cause by `glBeginQuery` called multiple time without equivalent `glEndQuery`

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
