### PR TITLE
Bump numpy to 2.3

### DIFF
--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -98,7 +98,7 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install pytest==8.0.0
         python -m pip install pybind11_stubgen
-        python -m pip install numpy==2.2.0
+        python -m pip install numpy==2.3.0
 
     - name: Extract java version
       id: java_ver

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -56,7 +56,7 @@ runs:
         python -m pip install pytest==8.0.0
         python -m pip install pyopengltk==0.0.4
         python -m pip install PySide6==6.10.1
-        python -m pip install numpy==2.2.0
+        python -m pip install numpy==2.3.0
 
     - name: Set PATH windows
       if: runner.os == 'Windows'


### PR DESCRIPTION
### Describe your changes

Bump numpy to 2.3 because 2.2 is not officially compatible with Python 3.14 which may explain the crashes on Windows CI.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
