### PR TITLE
CI: Recover VTK matrix from versions.json

### DIFF
--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15, macos-15-intel]
-        vtk_version: ${{needs.recover_vtk_matrix.outputs.vtk_matrix}}
+        vtk_version: ${{fromJSON(needs.recover_vtk_matrix.outputs.vtk_matrix)}}
         build_type: [standard]
         include:
           - optdeps_label: optdeps

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15, macos-15-intel]
-        vtk_version: ${{needs.recover_vtk_matrix.outputs.docker_timestamp}}
+        vtk_version: ${{needs.recover_vtk_matrix.outputs.vtk_matrix}}
         build_type: [standard]
         include:
           - optdeps_label: optdeps

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -50,16 +50,42 @@ jobs:
           cpu: ${{ matrix.os == 'macos-15' && 'arm64' || 'x86_64' }}
 
   #----------------------------------------------------------------------------
+  # Recover vtk matrix
+  #----------------------------------------------------------------------------
+  recover_vtk_matrix:
+    name: Recover VTK matrix
+    runs-on: ubuntu-24.04
+    if: contains(github.event.pull_request.labels.*.name, 'ci:cache')
+    outputs:
+      vtk_matrix: ${{steps.vtk_matrix.outputs.extract}}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          path: "source"
+          fetch-depth: 1
+          lfs: false
+
+      - name: Extract VTK matrix
+        id: vtk_matrix
+        uses: f3d-app/extract-version-action@main
+        with:
+          file: ./source/.github/workflows/versions.json
+          special_name: vtk_matrix
+
+  #----------------------------------------------------------------------------
   # Cache preheating VTK
   #----------------------------------------------------------------------------
   cache_preheating_vtk:
-    needs: [cache_preheating_dependencies]
+    needs: [cache_preheating_dependencies, recover_vtk_matrix]
     name: Preheat VTK dependency caches
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15, macos-15-intel]
-        vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
+        vtk_version: ${{needs.recover_vtk_matrix.outputs.docker_timestamp}}
         build_type: [standard]
         include:
           - optdeps_label: optdeps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,38 @@ jobs:
           cache_postfix: cache-0
 
   #----------------------------------------------------------------------------
+  # Recover vtk matrix
+  #----------------------------------------------------------------------------
+  recover_vtk_matrix:
+    name: Recover VTK matrix
+    runs-on: ubuntu-24.04
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
+    outputs:
+      vtk_matrix: ${{steps.vtk_matrix.outputs.extract}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: "source"
+          fetch-depth: 1
+          lfs: false
+
+      - name: Extract VTK matrix
+        id: vtk_matrix
+        uses: f3d-app/extract-version-action@main
+        with:
+          file: ./source/.github/workflows/versions.json
+          special_name: vtk_matrix
+
+  #----------------------------------------------------------------------------
   # Windows CI: Build and test, cross-vtk build matrix
   #----------------------------------------------------------------------------
   windows:
-    needs: cache_lfs
+    needs: [cache_lfs, recover_vtk_matrix]
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -55,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
+        vtk_version: ${{fromJSON(needs.recover_vtk_matrix.outputs.vtk_matrix)}}
         static_label: [no-static]
         include:
           - vtk_version: commit
@@ -123,7 +151,7 @@ jobs:
   # Linux CI: Build and test, cross-vtk build matrix
   #----------------------------------------------------------------------------
   linux:
-    needs: cache_lfs
+    needs: [cache_lfs, recover_vtk_matrix]
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -131,7 +159,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
+        vtk_version: ${{fromJSON(needs.recover_vtk_matrix.outputs.vtk_matrix)}}
         build_type: [standard]
         include:
           - exclude_deprecated_label: no-exclude-deprecated
@@ -214,14 +242,14 @@ jobs:
   # MacOS CI: Build and test, cross-vtk build matrix
   #----------------------------------------------------------------------------
   macos_intel:
-    needs: cache_lfs
+    needs: [cache_lfs, recover_vtk_matrix]
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
-        vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
+        vtk_version: ${{fromJSON(needs.recover_vtk_matrix.outputs.vtk_matrix)}}
 
     runs-on: macos-15-intel
 
@@ -248,7 +276,7 @@ jobs:
   # MacOS ARM CI: Build and test, cross-vtk build matrix with a few optional builds
   #----------------------------------------------------------------------------
   macos_arm:
-    needs: cache_lfs
+    needs: [cache_lfs, recover_vtk_matrix]
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -256,7 +284,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vtk_version: [commit, v9.6.1, v9.5.2, v9.4.2]
+        vtk_version: ${{fromJSON(needs.recover_vtk_matrix.outputs.vtk_matrix)}}
         bundle_label: [no-bundle]
         static_label: [no-static]
         include:

--- a/.github/workflows/versions.json
+++ b/.github/workflows/versions.json
@@ -108,5 +108,5 @@
   "vtk_commit_sha": "7e081f7b626d935b6217d044c42ff9bfec0958b3",
   "docker_timestamp": "20260512_0",
   "global_cache_index": "2",
-  "vtk_matrix": "['commit', 'v9.6.2', 'v9.5.2', 'v9.4.2']"
+  "vtk_matrix": "['commit', 'v9.6.1', 'v9.5.2', 'v9.4.2']"
 }

--- a/.github/workflows/versions.json
+++ b/.github/workflows/versions.json
@@ -108,5 +108,5 @@
   "vtk_commit_sha": "7e081f7b626d935b6217d044c42ff9bfec0958b3",
   "docker_timestamp": "20260512_0",
   "global_cache_index": "2",
-  "vtk_matrix": "['commit', 'v9.6.1', 'v9.5.2', 'v9.4.2']"
+  "vtk_matrix": "['commit', 'v9.6.2', 'v9.5.2', 'v9.4.2']"
 }

--- a/.github/workflows/versions.json
+++ b/.github/workflows/versions.json
@@ -108,5 +108,5 @@
   "vtk_commit_sha": "7e081f7b626d935b6217d044c42ff9bfec0958b3",
   "docker_timestamp": "20260512_0",
   "global_cache_index": "2",
-  "vtk_matrix": "[commit, v9.6.1, v9.5.2, v9.4.2]"
+  "vtk_matrix": "['commit', 'v9.6.1', 'v9.5.2', 'v9.4.2']"
 }

--- a/.github/workflows/versions.json
+++ b/.github/workflows/versions.json
@@ -107,5 +107,6 @@
   },
   "vtk_commit_sha": "7e081f7b626d935b6217d044c42ff9bfec0958b3",
   "docker_timestamp": "20260512_0",
-  "global_cache_index": "2"
+  "global_cache_index": "2",
+  "vtk_matrix": "[commit, v9.6.1, v9.5.2, v9.4.2]"
 }


### PR DESCRIPTION
### Describe your changes
Set vtk_version matrix in versions.json in order to support cache preheating for VTK releases too.

cache preheating tested here: https://github.com/mwestphal/f3d/actions/runs/26306625568

ci ported too it too for coherency.

### Issue ticket number and link if any

Fix https://github.com/f3d-app/f3d/issues/3081

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
