### PR TITLE
Add name in f3d::mesh_view

### DIFF
--- a/library/public/mesh_view.h
+++ b/library/public/mesh_view.h
@@ -35,6 +35,14 @@ public:
   }
 
   /**
+   * Get the name of the mesh
+   */
+  [[nodiscard]] virtual std::string getName() const
+  {
+    return "";
+  }
+
+  /**
    * Enumeration of supported scalar types for point and face scalars
    */
   enum class data_type : uint8_t

--- a/library/src/scene_impl.cxx
+++ b/library/src/scene_impl.cxx
@@ -450,6 +450,11 @@ scene& scene_impl::add(const mesh_t& mesh)
 //----------------------------------------------------------------------------
 scene& scene_impl::add([[maybe_unused]] std::shared_ptr<mesh_view> mesh)
 {
+  if (!mesh)
+  {
+    throw scene::load_failure_exception("Null mesh view provided");
+  }
+
   // requires https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12411
 #if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 20251110)
   vtkNew<vtkF3DMemoryMesh> vtkSource;
@@ -460,7 +465,7 @@ scene& scene_impl::add([[maybe_unused]] std::shared_ptr<mesh_view> mesh)
   vtkSource->SetTimeRange(timeRange[0], timeRange[1]);
 
   vtkSource->SetUpdateFunction(
-    [mesh = std::move(mesh)](double time, vtkPolyData* polydata)
+    [=](double time, vtkPolyData* polydata)
     {
       const auto memoryView = mesh->getMemoryView(time);
 
@@ -726,8 +731,10 @@ scene& scene_impl::add([[maybe_unused]] std::shared_ptr<mesh_view> mesh)
   vtkNew<vtkF3DGenericImporter> importer;
   importer->SetInternalReader(vtkSource);
 
+  std::string name = mesh->getName();
+
   log::debug("Loading 3D scene from memory");
-  this->Internals->Load({ { "<mesh_view>", importer } });
+  this->Internals->Load({ { name.empty() ? "<mesh_view>" : name, importer } });
   return *this;
 #else
   throw scene::load_failure_exception(

--- a/library/testing/CMakeLists.txt
+++ b/library/testing/CMakeLists.txt
@@ -52,6 +52,15 @@ if(F3D_MODULE_UI)
       TestSDKInteractorCallBack.cxx
       )
   endif()
+
+  # Needs stride arrays
+  # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12411
+  if(VTK_VERSION VERSION_GREATER_EQUAL 9.6.20251110)
+    list(APPEND libf3dSDKTests_list
+      TestSDKSceneFromMemoryZeroCopy.cxx
+      TestSDKSceneFromMemoryZeroCopyExceptions.cxx
+      )
+  endif()
 endif()
 
 # Invalid header detection need proper CanReadFile support
@@ -59,15 +68,6 @@ endif()
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.6.20260128)
   list(APPEND libf3dSDKTests_list
     TestSDKSceneInvalidHeader.cxx
-    )
-endif()
-
-# Needs stride arrays
-# https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12411
-if(VTK_VERSION VERSION_GREATER_EQUAL 9.6.20251110)
-  list(APPEND libf3dSDKTests_list
-    TestSDKSceneFromMemoryZeroCopy.cxx
-    TestSDKSceneFromMemoryZeroCopyExceptions.cxx
     )
 endif()
 

--- a/library/testing/TestSDKSceneFromMemoryZeroCopy.cxx
+++ b/library/testing/TestSDKSceneFromMemoryZeroCopy.cxx
@@ -198,6 +198,11 @@ public:
   {
   }
 
+  std::string getName() const override
+  {
+    return "static_mesh";
+  }
+
   f3d::mesh_view::memory_view_t getMemoryView(double) const override
   {
     const float* points = reinterpret_cast<const float*>(this->Grid.Vertices.data());
@@ -321,6 +326,7 @@ int TestSDKSceneFromMemoryZeroCopy([[maybe_unused]] int argc, [[maybe_unused]] c
   eng.getOptions().model.scivis.enable = true;
   eng.getOptions().model.scivis.cells = true;
   eng.getOptions().ui.scalar_bar = true;
+  eng.getOptions().ui.scene_hierarchy = true;
 
   WavyGridMesh grid(20, 20);
 
@@ -336,6 +342,7 @@ int TestSDKSceneFromMemoryZeroCopy([[maybe_unused]] int argc, [[maybe_unused]] c
       "TestSDKSceneFromMemoryZeroCopyTexturedStaticMesh"));
 
   eng.getOptions().model.color.texture = std::nullopt;
+  eng.getOptions().ui.scene_hierarchy = false;
 
   test("clear the scene", [&]() { sce.clear(); });
 

--- a/library/testing/TestSDKSceneFromMemoryZeroCopyExceptions.cxx
+++ b/library/testing/TestSDKSceneFromMemoryZeroCopyExceptions.cxx
@@ -17,6 +17,8 @@ int TestSDKSceneFromMemoryZeroCopyExceptions(
   f3d::engine eng = f3d::engine::create(true);
   f3d::scene& sce = eng.getScene();
 
+  test.expect<f3d::scene::load_failure_exception>("add nullptr", [&]() { sce.add(nullptr); });
+
   // Mesh view must have points
   class NoPointMesh : public f3d::mesh_view
   {

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -648,6 +648,17 @@ PYBIND11_MODULE(pyf3d, module)
       return f3d::mesh_view::getTimeRange();
     }
 
+    std::string getName() const override
+    {
+      py::gil_scoped_acquire gil;
+      py::function fn = py::get_override(this, "get_name");
+      if (fn)
+      {
+        return fn().cast<std::string>();
+      }
+      return f3d::mesh_view::getName();
+    }
+
     memory_view_t getMemoryView(double time) const override
     {
       py::gil_scoped_acquire gil;
@@ -663,6 +674,7 @@ PYBIND11_MODULE(pyf3d, module)
   py::class_<f3d::mesh_view, PyMesh, py::smart_holder>(module, "MeshView")
     .def(py::init<>())
     .def("get_time_range", &f3d::mesh_view::getTimeRange)
+    .def("get_name", &f3d::mesh_view::getName)
     .def("get_memory_view", &f3d::mesh_view::getMemoryView);
 
   // f3d::color_t

--- a/python/testing/CMakeLists.txt
+++ b/python/testing/CMakeLists.txt
@@ -26,10 +26,12 @@ if(VTK_VERSION VERSION_GREATER_EQUAL 9.4.20250501)
     )
 endif()
 
-if(VTK_VERSION VERSION_GREATER_EQUAL 9.5.20251110)
-  list(APPEND pyf3dTests_list
-     test_scene_zero_copy.py
-    )
+if(F3D_MODULE_UI)
+  if(VTK_VERSION VERSION_GREATER_EQUAL 9.5.20251110)
+    list(APPEND pyf3dTests_list
+      test_scene_zero_copy.py
+      )
+  endif()
 endif()
 
 list(APPEND pyf3dTestsNoRender_list

--- a/python/testing/test_scene_zero_copy.py
+++ b/python/testing/test_scene_zero_copy.py
@@ -22,6 +22,7 @@ def test_scene_zero_copy():
             "model.material.base_ior": 1.0,
             "scene.animation.autoplay": True,
             "ui.animation_progress": True,
+            "ui.scene_hierarchy": True,
         }
     )
 
@@ -44,6 +45,9 @@ def test_scene_zero_copy():
     class CustomMesh(f3d.MeshView):
         def get_time_range(self):
             return 0.0, 2 * math.pi
+
+        def get_name(self):
+            return "CustomMesh"
 
         def get_memory_view(self, time):
             c = 0.5 + math.cos(time) * 0.5

--- a/testing/baselines/TestPythonSceneZeroCopy.png
+++ b/testing/baselines/TestPythonSceneZeroCopy.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fc2c57655b5963b0349f7318df0b232c3e1ecb456a7d15b294ab90c54933c70
-size 5264
+oid sha256:53f15a322f6ae0f1f1e6b40cc6a78a61444e73f25420c0ee7c3b603958f9538e
+size 11689

--- a/testing/baselines/TestSDKSceneFromMemoryZeroCopyTexturedStaticMesh.png
+++ b/testing/baselines/TestSDKSceneFromMemoryZeroCopyTexturedStaticMesh.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48489b79c1d7d4b929acefffd8466bdf1a4e044778da8343be3bf33c37593d91
-size 179681
+oid sha256:2d37f8b776510942ae1c557ed8ee467d1132d0ecf125c03a60c13a25c909b3eb
+size 152373


### PR DESCRIPTION
### Describe your changes

Add `f3d::mesh_view::getName` API to change the name in the scene hierarchy.
Also adds a missing check for `nullptr`

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
