### PR TITLE
Support for OpenUSD static library

### DIFF
--- a/plugins/usd/CMakeLists.txt
+++ b/plugins/usd/CMakeLists.txt
@@ -29,15 +29,11 @@ f3d_plugin_declare_reader(
   FORMAT_DESCRIPTION "Universal Scene Descriptor"
 )
 
-set(rpaths "")
-list(GET PXR_LIBRARIES 0 first_lib)
-get_target_property(target_type ${first_lib} TYPE)
-if(target_type STREQUAL SHARED_LIBRARY)
-  list(APPEND rpaths "$<TARGET_FILE_DIR:${first_lib}>")
-else()
-  # When built as a static library, OpenUSD has to be linked with the WHOLE_ARCHIVE link option.
-  # It's not done currently, so just exit with a fatal error.
-  message(FATAL_ERROR "OpenUSD seems to have been built as static libraries. This is currently not supported.")
+set(_additional_rpath "")
+list(GET PXR_LIBRARIES 0 _first_lib)
+get_target_property(_target_type ${_first_lib} TYPE)
+if(_target_type STREQUAL SHARED_LIBRARY)
+  list(APPEND _additional_rpath "$<TARGET_FILE_DIR:${_first_lib}>")
 endif ()
 
 f3d_plugin_build(
@@ -45,7 +41,7 @@ f3d_plugin_build(
   VERSION 1.0
   DESCRIPTION "USD support"
   VTK_MODULES IOImage
-  ADDITIONAL_RPATHS ${rpaths}
+  ADDITIONAL_RPATHS ${_additional_rpath}
   MIMETYPE_XML_FILES "${CMAKE_CURRENT_SOURCE_DIR}/f3d-usd-formats.xml"
   CONFIGURATION_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/configs/config.d" "${CMAKE_CURRENT_SOURCE_DIR}/configs/thumbnail.d"
   FREEDESKTOP

--- a/plugins/usd/module/CMakeLists.txt
+++ b/plugins/usd/module/CMakeLists.txt
@@ -6,7 +6,13 @@ vtk_module_add_module(f3d::vtkextUSD
   FORCE_STATIC
   CLASSES ${classes})
 
-vtk_module_link(f3d::vtkextUSD PRIVATE ${PXR_LIBRARIES})
+list(GET PXR_LIBRARIES 0 _first_lib)
+get_target_property(_target_type ${_first_lib} TYPE)
+if(_target_type STREQUAL "STATIC_LIBRARY")
+  vtk_module_link(f3d::vtkextUSD PRIVATE $<LINK_LIBRARY:WHOLE_ARCHIVE,${PXR_LIBRARIES}>)
+else()
+  vtk_module_link(f3d::vtkextUSD PRIVATE ${PXR_LIBRARIES})
+endif()
 
 vtk_module_include(f3d::vtkextUSD PRIVATE ${PXR_INCLUDE_DIRS})
 

--- a/plugins/usd/module/vtkF3DUSDImporter.cxx
+++ b/plugins/usd/module/vtkF3DUSDImporter.cxx
@@ -1363,8 +1363,6 @@ private:
 
     void IssueFatalError(const pxr::TfCallContext&, const std::string& msg) override
     {
-      vtkErrorWithObjectMacro(this->Parent, << msg);
-
       // if we do not throw here, OpenUSD just exit(1) the process
       // we catch this exception upstream and only report an importer failure
       throw std::runtime_error(msg);
@@ -1416,6 +1414,7 @@ int vtkF3DUSDImporter::ImportBegin()
   }
   catch (const std::runtime_error& e)
   {
+    vtkErrorMacro(<< e.what());
     return 0;
   }
 

--- a/plugins/usd/module/vtkF3DUSDImporter.cxx
+++ b/plugins/usd/module/vtkF3DUSDImporter.cxx
@@ -1364,6 +1364,10 @@ private:
     void IssueFatalError(const pxr::TfCallContext&, const std::string& msg) override
     {
       vtkErrorWithObjectMacro(this->Parent, << msg);
+
+      // if we do not throw here, OpenUSD just exit(1) the process
+      // we catch this exception upstream and only report an importer failure
+      throw std::runtime_error(msg);
     }
 
     void IssueStatus(const pxr::TfStatus& status) override
@@ -1406,7 +1410,14 @@ vtkF3DUSDImporter::~vtkF3DUSDImporter() = default;
 //----------------------------------------------------------------------------
 int vtkF3DUSDImporter::ImportBegin()
 {
-  this->Internals->ReadScene(this->GetFileName());
+  try
+  {
+    this->Internals->ReadScene(this->GetFileName());
+  }
+  catch (const std::runtime_error& e)
+  {
+    return 0;
+  }
 
   return 1;
 }


### PR DESCRIPTION
### Describe your changes

- Add support for static library by linking with `WHOLE_ARCHIVE`.
- Avoid process exit when OpenUSD reports a fatal error (which happens when `plugInfo.json` is not found).

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
