### PR TITLE
CI: Downgrade zlib to v1.3.1

### DIFF
--- a/.github/workflows/versions.json
+++ b/.github/workflows/versions.json
@@ -8,7 +8,8 @@
     "OSPRay is fixed at 2.12.0 until full support for OSPRay 3.0 is added in VTK",
     "TBB is set at v2021.13.1 because OpenUSD seems to not support more recent versions: https://github.com/PixarAnimationStudios/OpenUSD/issues/3878 and https://github.com/PixarAnimationStudios/OpenUSD/issues/4078",
     "sqlite is using a common-superbuild hash as it is not a CMake project",
-    "OpenEXR v3.0.1 is actually not using OpenJPH"
+    "OpenEXR v3.0.1 is actually not using OpenJPH",
+    "zlib is fixed at v1.3.1 until https://github.com/madler/zlib/issues/1181 is fixed"
   ],
   "alembic": {
     "version": "1.8.11",
@@ -107,7 +108,7 @@
     "min_version": "v1.2.4"
   },
   "zlib": {
-    "version": "v1.3.2",
+    "version": "v1.3.1",
     "min_version": "v1.2.13"
   },
   "vtk_commit_sha": "27b3522610458af6daf36fd1bbee96e32e676761",


### PR DESCRIPTION
### Describe your changes

See https://github.com/madler/zlib/issues/1181 for more details, TLDR v1.3.2 completely revamp the naming of libs on Windows. This is not breaking anything in F3D but breaks the superbuild, so I'm downgrading to ensure that we test what we ship.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
