### PR TITLE
Add USD reader resources path option

### DIFF
--- a/application/testing/tests.usd.cmake
+++ b/application/testing/tests.usd.cmake
@@ -13,6 +13,9 @@ if(F3D_MODULE_EXR)
   f3d_test(NAME TestUSDZMemEXR DATA small.usdz PLUGIN usd)
 endif()
 
+# This test only covers the reader option, as providing a new path is not required to make the test pass
+f3d_test(NAME TestUSDDefines DATA suzanne.usd PLUGIN usd ARGS -DUSD.resources_path=/foo/bar NO_BASELINE)
+
 # This test is there to test occlusion texture and face-varying point data
 # TODO: Note that the result looks incorrect because of face-varying attributes and must be fixed later
 f3d_test(NAME TestUSDTeapot DATA Teapot.usd PLUGIN usd)

--- a/doc/user/02-SUPPORTED_FORMATS.md
+++ b/doc/user/02-SUPPORTED_FORMATS.md
@@ -72,7 +72,7 @@ For booleans, 0 means false, not 0 means true. Unsigned int will interpret anyth
 
 | Plugin   | Option Name                | Argument Type  | Description                                                                          |
 | -------- | -------------------------- | -------------- | ------------------------------------------------------------------------------------ |
-| `vdb`    | `VDB.downsampling_factor`  | `double`       | Control the level of downsampling when reading a volume, default is 0.1.             |
+| `mdl`    | `QuakeMDL.skin_index`      | `unsigned int` | Select a particular skin from a `mdl` file. Uses 0-indexing, default is 0.           |
 | `occt`   | `STEP.linear_deflection`   | `double`       | Control the distance between a curve and the resulting tessellation, default is 0.1. |
 | `occt`   | `STEP.angular_deflection`  | `double`       | Control the angle between two subsequent segments, default is 0.5.                   |
 | `occt`   | `STEP.relative_deflection` | `bool`         | Control if the deflection values are relative to object size, default is false.      |
@@ -89,7 +89,8 @@ For booleans, 0 means false, not 0 means true. Unsigned int will interpret anyth
 | `occt`   | `XBF.angular_deflection`   | `double`       | Control the angle between two subsequent segments, default is 0.5.                   |
 | `occt`   | `XBF.relative_deflection`  | `bool`         | Control if the deflection values are relative to object size, default is false.      |
 | `occt`   | `XBF.read_wire`            | `bool`         | Control if lines should be read, default is true.                                    |
-| `mdl`    | `QuakeMDL.skin_index`      | `unsigned int` | Select a particular skin from a `mdl` file. Uses 0-indexing, default is 0.           |
+| `usd`    | `USD.resources_path`       | `string`       | Additional path to find USD plugInfo.json resources                                  |
+| `vdb`    | `VDB.downsampling_factor`  | `double`       | Control the level of downsampling when reading a volume, default is 0.1.             |
 | `webifc` | `IFC.circle_segments`      | `int`          | Number of segments for circular geometry, default is 12.                             |
 | `webifc` | `IFC.read_openings`        | `bool`         | Read IfcOpeningElement entities (doors/windows cutouts), default is false.           |
 | `webifc` | `IFC.read_spaces`          | `bool`         | Read IfcSpace entities (room volumes), default is false.                             |

--- a/plugins/usd/CMakeLists.txt
+++ b/plugins/usd/CMakeLists.txt
@@ -36,6 +36,8 @@ f3d_plugin_declare_reader(
   FORMAT_DESCRIPTION "Universal Scene Descriptor"
   ${_SUPPORTS_STREAM}
   CAN_READ STATIC
+  CUSTOM_CODE "${CMAKE_CURRENT_SOURCE_DIR}/usd.inl"
+  OPTIONS resources_path
 )
 
 set(_additional_rpath "")

--- a/plugins/usd/module/vtkF3DUSDImporter.cxx
+++ b/plugins/usd/module/vtkF3DUSDImporter.cxx
@@ -1598,3 +1598,9 @@ bool vtkF3DUSDImporter::CanReadFile(vtkResourceStream* stream, std::string& hint
 
   return false;
 }
+
+//------------------------------------------------------------------------------
+void vtkF3DUSDImporter::SetResourcesPath(const std::string& path)
+{
+  pxr::PlugRegistry::GetInstance().RegisterPlugins(path);
+}

--- a/plugins/usd/module/vtkF3DUSDImporter.h
+++ b/plugins/usd/module/vtkF3DUSDImporter.h
@@ -101,6 +101,13 @@ public:
    */
   bool UpdateAtTimeValue(double timeValue) override;
 
+  /**
+   * Set additional resources path to find plugInfo.json files
+   * It's usually not needed except if the files location is not relative to the binaries,
+   * which can be the case on sandboxed environment like Android.
+   */
+  void SetResourcesPath(const std::string& path);
+
 protected:
   vtkF3DUSDImporter();
   ~vtkF3DUSDImporter() override;

--- a/plugins/usd/usd.inl
+++ b/plugins/usd/usd.inl
@@ -1,0 +1,8 @@
+// clang-format off
+void applyCustomImporter(
+  vtkImporter* importer, const std::string& vtkNotUsed(fileName), vtkResourceStream*) const override
+{
+  vtkF3DUSDImporter* usdImporter = vtkF3DUSDImporter::SafeDownCast(importer);
+  usdImporter->SetResourcesPath(this->ReaderOptions.at("USD.resources_path"));
+}
+// clang-format on


### PR DESCRIPTION
### Describe your changes

Add an option in USD to specify custom resources path.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
