### PR TITLE
USD: Fix crash for unsupported geometry types

### DIFF
--- a/application/testing/tests.usd.cmake
+++ b/application/testing/tests.usd.cmake
@@ -8,6 +8,7 @@ f3d_test(NAME TestUSDAInstancing DATA instancing.usda PLUGIN usd)
 f3d_test(NAME TestUSDAGlyphs DATA glyphs.usda PLUGIN usd)
 f3d_test(NAME TestUSDPurpose DATA purpose.usdc PLUGIN usd)
 f3d_test(NAME TestUSDInterpolation DATA two_quads_interp.usda PLUGIN usd)
+f3d_test(NAME TestUSDUnsupportedGeom DATA nurb.usda ARGS --verbose REGEXP "Unknown geometry type" PLUGIN usd NO_BASELINE)
 
 if(F3D_MODULE_EXR)
   f3d_test(NAME TestUSDZMemEXR DATA small.usdz PLUGIN usd)

--- a/plugins/usd/module/vtkF3DUSDImporter.cxx
+++ b/plugins/usd/module/vtkF3DUSDImporter.cxx
@@ -756,6 +756,12 @@ public:
           transform->Update();
           polydata = vtkPolyData::SafeDownCast(transform->GetOutput());
         }
+        else
+        {
+          // unsupported primitive, fallback to an empty polydata
+          vtkWarningWithObjectMacro(nullptr, "Unknown geometry type: " << prim.GetName());
+          polydata = vtkSmartPointer<vtkPolyData>::New();
+        }
 
         // create actors
 

--- a/testing/data/DATA_LICENSES.md
+++ b/testing/data/DATA_LICENSES.md
@@ -47,6 +47,7 @@
 - McUSD.usdz: [USD Working Group](https://github.com/usd-wg/assets): CC-NC-BY-SA, textures by [jasonjgardner](https://github.com/jasonjgardner)
 - normal.png: glTF-Sample-Models: Public Domain
 - normalMapping.fbx: assimp test models: BSD-3-Clause; rubberduck: [CC0](https://creativecommons.org/publicdomain/zero/1.0/)
+- nurb.usda: [Arnold USD](https://github.com/Autodesk/arnold-usd): Apache 2.0
 - palermo_park_1k.hdr: Polyhaven: [CC0](https://creativecommons.org/publicdomain/zero/1.0/)
 - Part-4-Buildings-V4-one.gml: VTK Data: BSD-3-Clause
 - phong_cube.fbx: assimp test models: BSD-3-Clause

--- a/testing/data/nurb.usda
+++ b/testing/data/nurb.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef78f17f704225b25476cbd1fa6f52a953d56a21acb6b46efb32b7783591fb5c
+size 4320


### PR DESCRIPTION
### Describe your changes

Fix crash when the geometry type is unsupported by providing an empty (but valid) polydata

### Issue ticket number and link if any

https://github.com/f3d-app/f3d/issues/3210

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
