### PR TITLE
doc: Fix libf3d opacity_map doc

### DIFF
--- a/doc/libf3d/03-OPTIONS.md
+++ b/doc/libf3d/03-OPTIONS.md
@@ -204,7 +204,7 @@ Set a _custom colormap for the coloring_.See [colormap parsing](../user/08-PARSI
 
 CLI: `--colormap`.
 
-### `model.scivis.opacity_map` (_opacity_map_, default: "0.0,0.0,1.0,1.0")
+### `model.scivis.opacity_map` (_vector\<double\>_, default: "0.0,0.0,1.0,1.0")
 
 Set a _custom opacity map for the coloring_. The format of the opacity map should be `val, opacity, ...`.
 It is only used for volume rendering currently.


### PR DESCRIPTION
### Describe your changes

Fix a small error in libf3d doc regarding opacity map type.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
