### PR TITLE
Handle exceptions in C bindings

### DIFF
--- a/c/interactor_c_api.cxx
+++ b/c/interactor_c_api.cxx
@@ -358,14 +358,7 @@ void f3d_interactor_init_commands(f3d_interactor_t* interactor)
   }
 
   f3d::interactor* cpp_interactor = reinterpret_cast<f3d::interactor*>(interactor);
-  try
-  {
-    cpp_interactor->initCommands();
-  }
-  catch (const f3d::interactor::invalid_args_exception& ex)
-  {
-    f3d::log::error(ex.what());
-  }
+  cpp_interactor->initCommands();
 }
 
 //----------------------------------------------------------------------------

--- a/c/interactor_c_api.cxx
+++ b/c/interactor_c_api.cxx
@@ -358,7 +358,14 @@ void f3d_interactor_init_commands(f3d_interactor_t* interactor)
   }
 
   f3d::interactor* cpp_interactor = reinterpret_cast<f3d::interactor*>(interactor);
-  cpp_interactor->initCommands();
+  try
+  {
+    cpp_interactor->initCommands();
+  }
+  catch (const f3d::interactor::invalid_args_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -380,7 +387,14 @@ void f3d_interactor_add_command(f3d_interactor_t* interactor, const char* action
     callback(c_args.data(), static_cast<int>(c_args.size()), user_data);
   };
 
-  cpp_interactor->addCommand(action, cpp_callback);
+  try
+  {
+    cpp_interactor->addCommand(action, cpp_callback);
+  }
+  catch (const f3d::interactor::already_exists_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -437,7 +451,15 @@ int f3d_interactor_trigger_command(
   }
 
   f3d::interactor* cpp_interactor = reinterpret_cast<f3d::interactor*>(interactor);
-  return cpp_interactor->triggerCommand(command, keep_comments != 0) ? 1 : 0;
+  try
+  {
+    return cpp_interactor->triggerCommand(command, keep_comments != 0) ? 1 : 0;
+  }
+  catch (const f3d::interactor::command_runtime_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -477,8 +499,15 @@ void f3d_interactor_add_binding(f3d_interactor_t* interactor, const f3d_interact
 
   std::string cpp_group = group ? group : "";
 
-  cpp_interactor->addBinding(cpp_bind, cpp_commands, cpp_group, nullptr,
-    static_cast<f3d::interactor::BindingType>(type), notify != 0);
+  try
+  {
+    cpp_interactor->addBinding(cpp_bind, cpp_commands, cpp_group, nullptr,
+      static_cast<f3d::interactor::BindingType>(type), notify != 0);
+  }
+  catch (const f3d::interactor::already_exists_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -542,24 +571,32 @@ f3d_interaction_bind_t* f3d_interactor_get_binds_for_group(
   }
 
   const f3d::interactor* cpp_interactor = reinterpret_cast<f3d::interactor*>(interactor);
-  std::vector<f3d::interaction_bind_t> binds = cpp_interactor->getBindsForGroup(group);
-
-  *count = static_cast<int>(binds.size());
-  if (binds.empty())
+  try
   {
+    std::vector<f3d::interaction_bind_t> binds = cpp_interactor->getBindsForGroup(group);
+
+    *count = static_cast<int>(binds.size());
+    if (binds.empty())
+    {
+      return nullptr;
+    }
+
+    f3d_interaction_bind_t* result = new f3d_interaction_bind_t[binds.size()];
+
+    for (size_t i = 0; i < binds.size(); ++i)
+    {
+      result[i].mod = static_cast<f3d_interaction_bind_modifier_keys_t>(binds[i].mod);
+      std::strncpy(result[i].inter, binds[i].inter.c_str(), sizeof(result[i].inter) - 1);
+      result[i].inter[sizeof(result[i].inter) - 1] = '\0';
+    }
+
+    return result;
+  }
+  catch (const f3d::interactor::does_not_exists_exception& ex)
+  {
+    f3d::log::error(ex.what());
     return nullptr;
   }
-
-  f3d_interaction_bind_t* result = new f3d_interaction_bind_t[binds.size()];
-
-  for (size_t i = 0; i < binds.size(); ++i)
-  {
-    result[i].mod = static_cast<f3d_interaction_bind_modifier_keys_t>(binds[i].mod);
-    std::strncpy(result[i].inter, binds[i].inter.c_str(), sizeof(result[i].inter) - 1);
-    result[i].inter[sizeof(result[i].inter) - 1] = '\0';
-  }
-
-  return result;
 }
 
 //----------------------------------------------------------------------------
@@ -609,13 +646,20 @@ void f3d_interactor_get_binding_documentation(f3d_interactor_t* interactor,
   cpp_bind.mod = static_cast<f3d::interaction_bind_t::ModifierKeys>(bind->mod);
   cpp_bind.inter = bind->inter;
 
-  auto [doc_str, value_str] = cpp_interactor->getBindingDocumentation(cpp_bind);
+  try
+  {
+    auto [doc_str, value_str] = cpp_interactor->getBindingDocumentation(cpp_bind);
 
-  std::strncpy(doc->doc, doc_str.c_str(), sizeof(doc->doc) - 1);
-  doc->doc[sizeof(doc->doc) - 1] = '\0';
+    std::strncpy(doc->doc, doc_str.c_str(), sizeof(doc->doc) - 1);
+    doc->doc[sizeof(doc->doc) - 1] = '\0';
 
-  std::strncpy(doc->value, value_str.c_str(), sizeof(doc->value) - 1);
-  doc->value[sizeof(doc->value) - 1] = '\0';
+    std::strncpy(doc->value, value_str.c_str(), sizeof(doc->value) - 1);
+    doc->value[sizeof(doc->value) - 1] = '\0';
+  }
+  catch (const f3d::interactor::does_not_exists_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -631,8 +675,16 @@ f3d_interactor_binding_type_t f3d_interactor_get_binding_type(
   f3d::interaction_bind_t cpp_bind;
   cpp_bind.mod = static_cast<f3d::interaction_bind_t::ModifierKeys>(bind->mod);
   cpp_bind.inter = bind->inter;
-  f3d::interactor::BindingType cpp_type = cpp_interactor->getBindingType(cpp_bind);
-  return static_cast<f3d_interactor_binding_type_t>(cpp_type);
+  try
+  {
+    f3d::interactor::BindingType cpp_type = cpp_interactor->getBindingType(cpp_bind);
+    return static_cast<f3d_interactor_binding_type_t>(cpp_type);
+  }
+  catch (const f3d::interactor::does_not_exists_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return F3D_INTERACTOR_BINDING_OTHER;
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/c/interactor_c_api.h
+++ b/c/interactor_c_api.h
@@ -247,7 +247,7 @@ extern "C"
    * @param group Group name.
    * @param count Output parameter for number of binds.
    * @return Array of binds. Caller must free the array with
-   *         f3d_interactor_free_bind_array().
+   *         f3d_interactor_free_bind_array(). NULL if group does not exist.
    */
   F3D_EXPORT f3d_interaction_bind_t* f3d_interactor_get_binds_for_group(
     f3d_interactor_t* interactor, const char* group, int* count);
@@ -287,7 +287,7 @@ extern "C"
    *
    * @param interactor Interactor handle.
    * @param bind Interaction bind.
-   * @return Binding type.
+   * @return Binding type. F3D_INTERACTOR_BINDING_OTHER if bind does not exist.
    */
   F3D_EXPORT f3d_interactor_binding_type_t f3d_interactor_get_binding_type(
     f3d_interactor_t* interactor, const f3d_interaction_bind_t* bind);

--- a/c/options_c_api.cxx
+++ b/c/options_c_api.cxx
@@ -334,7 +334,7 @@ void f3d_options_remove_value(f3d_options_t* options, const char* name)
   {
     cpp_options->removeValue(name);
   }
-  catch (f3d::options::incompatible_exception& ex)
+  catch (const f3d::options::incompatible_exception& ex)
   {
     f3d::log::error(ex.what());
   }

--- a/c/options_c_api.cxx
+++ b/c/options_c_api.cxx
@@ -1,4 +1,5 @@
 #include "options_c_api.h"
+#include "log.h"
 #include "options.h"
 
 #include <cstring>

--- a/c/options_c_api.cxx
+++ b/c/options_c_api.cxx
@@ -38,11 +38,11 @@ void f3d_options_set_as_bool(f3d_options_t* options, const char* name, int value
     f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
     cpp_options->set(name, static_cast<bool>(value));
   }
-  catch (const f3d::options::inexistent_exception& ex)
+  catch (const f3d::options::incompatible_exception& ex)
   {
     f3d::log::error(ex.what());
   }
-  catch (const f3d::options::incompatible_exception& ex)
+  catch (const f3d::options::inexistent_exception& ex)
   {
     f3d::log::error(ex.what());
   }
@@ -61,11 +61,11 @@ void f3d_options_set_as_int(f3d_options_t* options, const char* name, int value)
     f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
     cpp_options->set(name, value);
   }
-  catch (const f3d::options::inexistent_exception& ex)
+  catch (const f3d::options::incompatible_exception& ex)
   {
     f3d::log::error(ex.what());
   }
-  catch (const f3d::options::incompatible_exception& ex)
+  catch (const f3d::options::inexistent_exception& ex)
   {
     f3d::log::error(ex.what());
   }
@@ -84,11 +84,11 @@ void f3d_options_set_as_double(f3d_options_t* options, const char* name, double 
     f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
     cpp_options->set(name, value);
   }
-  catch (const f3d::options::inexistent_exception& ex)
+  catch (const f3d::options::incompatible_exception& ex)
   {
     f3d::log::error(ex.what());
   }
-  catch (const f3d::options::incompatible_exception& ex)
+  catch (const f3d::options::inexistent_exception& ex)
   {
     f3d::log::error(ex.what());
   }
@@ -107,11 +107,11 @@ void f3d_options_set_as_string(f3d_options_t* options, const char* name, const c
     f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
     cpp_options->set(name, std::string(value));
   }
-  catch (const f3d::options::inexistent_exception& ex)
+  catch (const f3d::options::incompatible_exception& ex)
   {
     f3d::log::error(ex.what());
   }
-  catch (const f3d::options::incompatible_exception& ex)
+  catch (const f3d::options::inexistent_exception& ex)
   {
     f3d::log::error(ex.what());
   }
@@ -132,11 +132,11 @@ void f3d_options_set_as_double_vector(
     std::vector<double> vec(values, values + count);
     cpp_options->set(name, vec);
   }
-  catch (const f3d::options::inexistent_exception& ex)
+  catch (const f3d::options::incompatible_exception& ex)
   {
     f3d::log::error(ex.what());
   }
-  catch (const f3d::options::incompatible_exception& ex)
+  catch (const f3d::options::inexistent_exception& ex)
   {
     f3d::log::error(ex.what());
   }
@@ -157,11 +157,11 @@ void f3d_options_set_as_int_vector(
     std::vector<int> vec(values, values + count);
     cpp_options->set(name, vec);
   }
-  catch (const f3d::options::inexistent_exception& ex)
+  catch (const f3d::options::incompatible_exception& ex)
   {
     f3d::log::error(ex.what());
   }
-  catch (const f3d::options::incompatible_exception& ex)
+  catch (const f3d::options::inexistent_exception& ex)
   {
     f3d::log::error(ex.what());
   }
@@ -343,11 +343,11 @@ void f3d_options_toggle(f3d_options_t* options, const char* name)
     f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
     cpp_options->toggle(name);
   }
-  catch (const f3d::options::inexistent_exception& ex)
+  catch (const f3d::options::incompatible_exception& ex)
   {
     f3d::log::error(ex.what());
   }
-  catch (const f3d::options::incompatible_exception& ex)
+  catch (const f3d::options::inexistent_exception& ex)
   {
     f3d::log::error(ex.what());
   }
@@ -523,6 +523,10 @@ void f3d_options_remove_value(f3d_options_t* options, const char* name)
   {
     f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
     cpp_options->removeValue(name);
+  }
+  catch (const f3d::options::incompatible_exception& ex)
+  {
+    f3d::log::error(ex.what());
   }
   catch (const f3d::options::inexistent_exception& ex)
   {

--- a/c/options_c_api.cxx
+++ b/c/options_c_api.cxx
@@ -190,7 +190,14 @@ void f3d_options_toggle(f3d_options_t* options, const char* name)
   }
 
   f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  cpp_options->toggle(name);
+  try
+  {
+    cpp_options->toggle(name);
+  }
+  catch (const f3d::options::incompatible_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -322,7 +329,14 @@ void f3d_options_remove_value(f3d_options_t* options, const char* name)
   }
 
   f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  cpp_options->removeValue(name);
+  try
+  {
+    cpp_options->removeValue(name);
+  }
+  catch (f3d::options::incompatible_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/c/options_c_api.cxx
+++ b/c/options_c_api.cxx
@@ -33,8 +33,19 @@ void f3d_options_set_as_bool(f3d_options_t* options, const char* name, int value
     return;
   }
 
-  f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  cpp_options->set(name, static_cast<bool>(value));
+  try
+  {
+    f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
+    cpp_options->set(name, static_cast<bool>(value));
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
+  catch (const f3d::options::incompatible_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -45,8 +56,19 @@ void f3d_options_set_as_int(f3d_options_t* options, const char* name, int value)
     return;
   }
 
-  f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  cpp_options->set(name, value);
+  try
+  {
+    f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
+    cpp_options->set(name, value);
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
+  catch (const f3d::options::incompatible_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -57,8 +79,19 @@ void f3d_options_set_as_double(f3d_options_t* options, const char* name, double 
     return;
   }
 
-  f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  cpp_options->set(name, value);
+  try
+  {
+    f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
+    cpp_options->set(name, value);
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
+  catch (const f3d::options::incompatible_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -69,8 +102,19 @@ void f3d_options_set_as_string(f3d_options_t* options, const char* name, const c
     return;
   }
 
-  f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  cpp_options->set(name, std::string(value));
+  try
+  {
+    f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
+    cpp_options->set(name, std::string(value));
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
+  catch (const f3d::options::incompatible_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -82,9 +126,20 @@ void f3d_options_set_as_double_vector(
     return;
   }
 
-  f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  std::vector<double> vec(values, values + count);
-  cpp_options->set(name, vec);
+  try
+  {
+    f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
+    std::vector<double> vec(values, values + count);
+    cpp_options->set(name, vec);
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
+  catch (const f3d::options::incompatible_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -96,9 +151,20 @@ void f3d_options_set_as_int_vector(
     return;
   }
 
-  f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  std::vector<int> vec(values, values + count);
-  cpp_options->set(name, vec);
+  try
+  {
+    f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
+    std::vector<int> vec(values, values + count);
+    cpp_options->set(name, vec);
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
+  catch (const f3d::options::incompatible_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -109,8 +175,21 @@ int f3d_options_get_as_bool(const f3d_options_t* options, const char* name)
     return 0;
   }
 
-  const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
-  return std::get<bool>(cpp_options->get(name)) ? 1 : 0;
+  try
+  {
+    const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
+    return std::get<bool>(cpp_options->get(name)) ? 1 : 0;
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0;
+  }
+  catch (const f3d::options::no_value_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -121,8 +200,21 @@ int f3d_options_get_as_int(const f3d_options_t* options, const char* name)
     return 0;
   }
 
-  const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
-  return std::get<int>(cpp_options->get(name));
+  try
+  {
+    const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
+    return std::get<int>(cpp_options->get(name));
+  }
+  catch (f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0;
+  }
+  catch (f3d::options::no_value_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -133,8 +225,21 @@ double f3d_options_get_as_double(const f3d_options_t* options, const char* name)
     return 0.0;
   }
 
-  const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
-  return std::get<double>(cpp_options->get(name));
+  try
+  {
+    const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
+    return std::get<double>(cpp_options->get(name));
+  }
+  catch (f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0.0;
+  }
+  catch (f3d::options::no_value_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0.0;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -145,11 +250,24 @@ const char* f3d_options_get_as_string(const f3d_options_t* options, const char* 
     return nullptr;
   }
 
-  const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
-  const std::string str = std::get<std::string>(cpp_options->get(name));
-  char* result = new char[str.length() + 1];
-  std::strcpy(result, str.c_str());
-  return result;
+  try
+  {
+    const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
+    const std::string str = std::get<std::string>(cpp_options->get(name));
+    char* result = new char[str.length() + 1];
+    std::strcpy(result, str.c_str());
+    return result;
+  }
+  catch (f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return nullptr;
+  }
+  catch (f3d::options::no_value_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return nullptr;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -161,10 +279,25 @@ void f3d_options_get_as_double_vector(
     return;
   }
 
-  const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
-  const std::vector<double> vec = std::get<std::vector<double>>(cpp_options->get(name));
-  *count = vec.size();
-  std::copy(vec.begin(), vec.end(), values);
+  try
+  {
+    const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
+    const std::vector<double> vec = std::get<std::vector<double>>(cpp_options->get(name));
+    *count = vec.size();
+    std::copy(vec.begin(), vec.end(), values);
+  }
+  catch (f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    *count = 0;
+    return;
+  }
+  catch (f3d::options::no_value_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    *count = 0;
+    return;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -176,10 +309,25 @@ void f3d_options_get_as_int_vector(
     return;
   }
 
-  const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
-  const std::vector<int> vec = std::get<std::vector<int>>(cpp_options->get(name));
-  *count = vec.size();
-  std::copy(vec.begin(), vec.end(), values);
+  try
+  {
+    const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
+    const std::vector<int> vec = std::get<std::vector<int>>(cpp_options->get(name));
+    *count = vec.size();
+    std::copy(vec.begin(), vec.end(), values);
+  }
+  catch (f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    *count = 0;
+    return;
+  }
+  catch (f3d::options::no_value_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    *count = 0;
+    return;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -190,10 +338,14 @@ void f3d_options_toggle(f3d_options_t* options, const char* name)
     return;
   }
 
-  f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
   try
   {
+    f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
     cpp_options->toggle(name);
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
   }
   catch (const f3d::options::incompatible_exception& ex)
   {
@@ -209,9 +361,17 @@ int f3d_options_is_same(const f3d_options_t* options, const f3d_options_t* other
     return 0;
   }
 
-  const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
-  const f3d::options* cpp_other = reinterpret_cast<const f3d::options*>(other);
-  return cpp_options->isSame(*cpp_other, name) ? 1 : 0;
+  try
+  {
+    const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
+    const f3d::options* cpp_other = reinterpret_cast<const f3d::options*>(other);
+    return cpp_options->isSame(*cpp_other, name) ? 1 : 0;
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -222,8 +382,16 @@ int f3d_options_has_value(const f3d_options_t* options, const char* name)
     return 0;
   }
 
-  const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
-  return cpp_options->hasValue(name) ? 1 : 0;
+  try
+  {
+    const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
+    return cpp_options->hasValue(name) ? 1 : 0;
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -234,9 +402,16 @@ void f3d_options_copy(f3d_options_t* options, const f3d_options_t* other, const 
     return;
   }
 
-  f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  const f3d::options* cpp_other = reinterpret_cast<const f3d::options*>(other);
-  cpp_options->copy(*cpp_other, name);
+  try
+  {
+    f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
+    const f3d::options* cpp_other = reinterpret_cast<const f3d::options*>(other);
+    cpp_options->copy(*cpp_other, name);
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -305,8 +480,16 @@ int f3d_options_is_optional(const f3d_options_t* options, const char* name)
     return 0;
   }
 
-  const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
-  return cpp_options->isOptional(name) ? 1 : 0;
+  try
+  {
+    const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
+    return cpp_options->isOptional(name) ? 1 : 0;
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -317,8 +500,15 @@ void f3d_options_reset(f3d_options_t* options, const char* name)
     return;
   }
 
-  f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  cpp_options->reset(name);
+  try
+  {
+    f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
+    cpp_options->reset(name);
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -329,12 +519,12 @@ void f3d_options_remove_value(f3d_options_t* options, const char* name)
     return;
   }
 
-  f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
   try
   {
+    f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
     cpp_options->removeValue(name);
   }
-  catch (const f3d::options::incompatible_exception& ex)
+  catch (const f3d::options::inexistent_exception& ex)
   {
     f3d::log::error(ex.what());
   }
@@ -349,10 +539,23 @@ const char* f3d_options_get_as_string_representation(const f3d_options_t* option
   }
 
   const f3d::options* cpp_options = reinterpret_cast<const f3d::options*>(options);
-  std::string str = cpp_options->getAsString(name);
-  char* result = new char[str.length() + 1];
-  std::strcpy(result, str.c_str());
-  return result;
+  try
+  {
+    std::string str = cpp_options->getAsString(name);
+    char* result = new char[str.length() + 1];
+    std::strcpy(result, str.c_str());
+    return result;
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return nullptr;
+  }
+  catch (const f3d::options::no_value_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return nullptr;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -365,7 +568,18 @@ void f3d_options_set_as_string_representation(
   }
 
   f3d::options* cpp_options = reinterpret_cast<f3d::options*>(options);
-  cpp_options->setAsString(name, str);
+  try
+  {
+    cpp_options->setAsString(name, str);
+  }
+  catch (const f3d::options::inexistent_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
+  catch (const f3d::options::parsing_exception& ex)
+  {
+    f3d::log::error(ex.what());
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -405,7 +619,15 @@ int f3d_options_parse_bool(const char* str)
     return 0;
   }
 
-  return f3d::options::parse<bool>(str) ? 1 : 0;
+  try
+  {
+    return f3d::options::parse<bool>(str) ? 1 : 0;
+  }
+  catch (const f3d::options::parsing_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -416,7 +638,15 @@ int f3d_options_parse_int(const char* str)
     return 0;
   }
 
-  return f3d::options::parse<int>(str);
+  try
+  {
+    return f3d::options::parse<int>(str);
+  }
+  catch (const f3d::options::parsing_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -427,7 +657,15 @@ double f3d_options_parse_double(const char* str)
     return 0.0;
   }
 
-  return f3d::options::parse<double>(str);
+  try
+  {
+    return f3d::options::parse<double>(str);
+  }
+  catch (const f3d::options::parsing_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return 0.0;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -438,10 +676,18 @@ const char* f3d_options_parse_string(const char* str)
     return nullptr;
   }
 
-  std::string result = f3d::options::parse<std::string>(str);
-  char* result_str = new char[result.length() + 1];
-  std::strcpy(result_str, result.c_str());
-  return result_str;
+  try
+  {
+    std::string result = f3d::options::parse<std::string>(str);
+    char* result_str = new char[result.length() + 1];
+    std::strcpy(result_str, result.c_str());
+    return result_str;
+  }
+  catch (const f3d::options::parsing_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return nullptr;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -452,9 +698,17 @@ void f3d_options_parse_double_vector(const char* str, double* values, size_t* co
     return;
   }
 
-  std::vector<double> vec = f3d::options::parse<std::vector<double>>(str);
-  *count = vec.size();
-  std::copy(vec.begin(), vec.end(), values);
+  try
+  {
+    std::vector<double> vec = f3d::options::parse<std::vector<double>>(str);
+    *count = vec.size();
+    std::copy(vec.begin(), vec.end(), values);
+  }
+  catch (const f3d::options::parsing_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -465,9 +719,17 @@ void f3d_options_parse_int_vector(const char* str, int* values, size_t* count)
     return;
   }
 
-  std::vector<int> vec = f3d::options::parse<std::vector<int>>(str);
-  *count = vec.size();
-  std::copy(vec.begin(), vec.end(), values);
+  try
+  {
+    std::vector<int> vec = f3d::options::parse<std::vector<int>>(str);
+    *count = vec.size();
+    std::copy(vec.begin(), vec.end(), values);
+  }
+  catch (const f3d::options::parsing_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return;
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/c/options_c_api.h
+++ b/c/options_c_api.h
@@ -96,7 +96,8 @@ extern "C"
    *
    * @param options Options handle.
    * @param name Option name.
-   * @return Boolean value (0 for false, non-zero for true).
+   * @return Boolean value (0 for false or if the option hasn't been set or doesn't exist, non-zero
+   * for true).
    */
   F3D_EXPORT int f3d_options_get_as_bool(const f3d_options_t* options, const char* name);
 
@@ -105,7 +106,7 @@ extern "C"
    *
    * @param options Options handle.
    * @param name Option name.
-   * @return Integer value.
+   * @return Integer value. 0 if the option hasn't been set or doesn't exist.
    */
   F3D_EXPORT int f3d_options_get_as_int(const f3d_options_t* options, const char* name);
 
@@ -114,7 +115,7 @@ extern "C"
    *
    * @param options Options handle.
    * @param name Option name.
-   * @return Double value.
+   * @return Double value. 0.0 if the option hasn't been set or doesn't exist.
    */
   F3D_EXPORT double f3d_options_get_as_double(const f3d_options_t* options, const char* name);
 
@@ -125,7 +126,7 @@ extern "C"
    *
    * @param options Options handle.
    * @param name Option name.
-   * @return String value.
+   * @return String value. NULL if the option hasn't been set or doesn't exist.
    */
   F3D_EXPORT const char* f3d_options_get_as_string(const f3d_options_t* options, const char* name);
 
@@ -136,7 +137,8 @@ extern "C"
    *
    * @param options Options handle.
    * @param name Option name.
-   * @return String representation of the option value.
+   * @return String representation of the option value. NULL if the option hasn't been set or
+   * doesn't exist.
    */
   F3D_EXPORT const char* f3d_options_get_as_string_representation(
     const f3d_options_t* options, const char* name);
@@ -171,7 +173,8 @@ extern "C"
    * @param options Options handle.
    * @param name Option name.
    * @param values Pre-allocated array to store the double values.
-   * @param count Pointer to store the number of values retrieved.
+   * @param count Pointer to store the number of values retrieved. Set to 0 if the option hasn't
+   * been set or doesn't exist.
    */
   F3D_EXPORT void f3d_options_get_as_double_vector(
     const f3d_options_t* options, const char* name, double* values, size_t* count);
@@ -184,7 +187,8 @@ extern "C"
    * @param options Options handle.
    * @param name Option name.
    * @param values Pre-allocated array to store the integer values.
-   * @param count Pointer to store the number of values retrieved.
+   * @param count Pointer to store the number of values retrieved. Set to 0 if the option hasn't
+   * been set or doesn't exist.
    */
   F3D_EXPORT void f3d_options_get_as_int_vector(
     const f3d_options_t* options, const char* name, int* values, size_t* count);
@@ -205,7 +209,7 @@ extern "C"
    * @param options Options handle.
    * @param other Other options handle to compare with.
    * @param name Option name.
-   * @return 1 if the values are the same, 0 otherwise.
+   * @return 1 if the values are the same, 0 otherwise or if the other option doesn't exist.
    */
   F3D_EXPORT int f3d_options_is_same(
     const f3d_options_t* options, const f3d_options_t* other, const char* name);
@@ -215,14 +219,14 @@ extern "C"
    *
    * @param options Options handle.
    * @param name Option name.
-   * @return 1 if the option has a value, 0 otherwise.
+   * @return 1 if the option has a value, 0 otherwise or if the option doesn't exist.
    */
   F3D_EXPORT int f3d_options_has_value(const f3d_options_t* options, const char* name);
 
   /**
    * @brief Copy an option value from another options object.
    *
-   * @param options Destination options handle.
+   * @param options Destination options handle. Will remain as-is if the option doesn't exist.
    * @param other Source options handle to copy from.
    * @param name Option name.
    */
@@ -276,7 +280,7 @@ extern "C"
    *
    * @param options Options handle.
    * @param name Option name.
-   * @return 1 if the option is optional, 0 otherwise.
+   * @return 1 if the option is optional, 0 otherwise or if the option doesn't exist.
    */
   F3D_EXPORT int f3d_options_is_optional(const f3d_options_t* options, const char* name);
 
@@ -301,7 +305,7 @@ extern "C"
    * @brief Parse a string as a boolean.
    *
    * @param str String to parse.
-   * @return 1 for true, 0 for false.
+   * @return 1 for true, 0 for false. 0 if the option cannot be parsed.
    */
   F3D_EXPORT int f3d_options_parse_bool(const char* str);
 
@@ -309,7 +313,7 @@ extern "C"
    * @brief Parse a string as an integer.
    *
    * @param str String to parse.
-   * @return Parsed integer value.
+   * @return Parsed integer value. 0 if the option cannot be parsed.
    */
   F3D_EXPORT int f3d_options_parse_int(const char* str);
 
@@ -317,7 +321,7 @@ extern "C"
    * @brief Parse a string as a double.
    *
    * @param str String to parse.
-   * @return Parsed double value.
+   * @return Parsed double value. 0.0 if the option cannot be parsed.
    */
   F3D_EXPORT double f3d_options_parse_double(const char* str);
 
@@ -325,7 +329,8 @@ extern "C"
    * @brief Parse a string as a string (returns a copy).
    *
    * @param str String to parse.
-   * @return Parsed string. Caller must free with f3d_options_free_string().
+   * @return Parsed string. Caller must free with f3d_options_free_string(). NULL if the option
+   * cannot be parsed.
    */
   F3D_EXPORT const char* f3d_options_parse_string(const char* str);
 
@@ -334,7 +339,7 @@ extern "C"
    *
    * @param str String to parse.
    * @param values Pre-allocated array to store the double values.
-   * @param count Pointer to store the number of values retrieved.
+   * @param count Pointer to store the number of values retrieved. 0 if the option cannot be parsed.
    */
   F3D_EXPORT void f3d_options_parse_double_vector(const char* str, double* values, size_t* count);
 
@@ -343,7 +348,7 @@ extern "C"
    *
    * @param str String to parse.
    * @param values Pre-allocated array to store the integer values.
-   * @param count Pointer to store the number of values retrieved.
+   * @param count Pointer to store the number of values retrieved. 0 if the option cannot be parsed.
    */
   F3D_EXPORT void f3d_options_parse_int_vector(const char* str, int* values, size_t* count);
 

--- a/c/utils_c_api.cxx
+++ b/c/utils_c_api.cxx
@@ -1,5 +1,7 @@
 #include "utils_c_api.h"
+#include "log.h"
 #include "utils.h"
+
 #include <cstring>
 #include <filesystem>
 #include <string>
@@ -50,21 +52,32 @@ char** f3d_utils_tokenize(const char* str, int keep_comments, size_t* out_count)
     return nullptr;
   }
 
-  std::vector<std::string> vec = f3d::utils::tokenize(str, keep_comments != 0);
-
-  size_t n = vec.size();
-  char** out = new char*[n];
-  for (size_t i = 0; i < n; ++i)
+  try
   {
-    out[i] = f3d_utils_strdup(vec[i]);
-  }
+    std::vector<std::string> vec = f3d::utils::tokenize(str, keep_comments != 0);
 
-  if (out_count)
+    size_t n = vec.size();
+    char** out = new char*[n];
+    for (size_t i = 0; i < n; ++i)
+    {
+      out[i] = f3d_utils_strdup(vec[i]);
+    }
+    if (out_count)
+    {
+      *out_count = n;
+    }
+
+    return out;
+  }
+  catch (f3d::utils::tokenize_exception& ex)
   {
-    *out_count = n;
+    f3d::log::error(ex.what());
+    if (out_count)
+    {
+      *out_count = 0;
+    }
+    return nullptr;
   }
-
-  return out;
 }
 
 //----------------------------------------------------------------------------
@@ -85,8 +98,16 @@ char* f3d_utils_collapse_path(const char* path, const char* base_directory)
 //----------------------------------------------------------------------------
 char* f3d_utils_glob_to_regex(const char* glob, char path_separator)
 {
-  std::string regex = f3d::utils::globToRegex(glob, path_separator);
-  return f3d_utils_strdup(regex);
+  try
+  {
+    std::string regex = f3d::utils::globToRegex(glob, path_separator);
+    return f3d_utils_strdup(regex);
+  }
+  catch (const f3d::utils::glob_exception& ex)
+  {
+    f3d::log::error(ex.what());
+    return nullptr;
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/c/utils_c_api.h
+++ b/c/utils_c_api.h
@@ -37,8 +37,8 @@ extern "C"
    *
    * @param str Input string to tokenize.
    * @param keep_comments Non-zero to keep comments, zero to treat '#' as a normal character.
-   * @param out_count Pointer to receive the number of tokens.
-   * @return Array of C strings.
+   * @param out_count Pointer to receive the number of tokens. Set to 0 if `str` is ill-formed.
+   * @return Array of C strings. NULL if `str` is malformed.
    */
   F3D_EXPORT char** f3d_utils_tokenize(const char* str, int keep_comments, size_t* out_count);
 
@@ -71,7 +71,7 @@ extern "C"
    *
    * @param glob Glob expression.
    * @param path_separator Path separator character.
-   * @return Regular expression string.
+   * @return Regular expression string. NULL if `glob` is ill-formed.
    */
   F3D_EXPORT char* f3d_utils_glob_to_regex(const char* glob, char path_separator);
 

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -83,6 +83,8 @@ public:
   /**
    * Remove all existing commands and add all default commands,
    * see COMMANDS.md for details.
+   *
+   * Throw an interactor::invalid_args_exception if the arguments provided are wrong, or missing.
    */
   virtual interactor& initCommands() = 0;
 

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -83,8 +83,6 @@ public:
   /**
    * Remove all existing commands and add all default commands,
    * see COMMANDS.md for details.
-   *
-   * Throw an interactor::invalid_args_exception if the arguments provided are wrong, or missing.
    */
   virtual interactor& initCommands() = 0;
 

--- a/library/public/options.h.in
+++ b/library/public/options.h.in
@@ -126,23 +126,23 @@ public:
     std::string_view option) const;
 
   /**
-   *  Returns true if the option is optional else returns false.
+   * Returns true if the option is optional else returns false.
    *
-   *  Throws an options::inexistent_exception if option does not exist.
+   * Throws an options::inexistent_exception if option does not exist.
    */
   [[nodiscard]] bool isOptional(std::string_view option) const;
 
   /**
-   *  Resets the option to default value.
+   * Resets the option to default value.
    *
-   *  Throws an options::inexistent_exception if option does not exist.
+   * Throws an options::inexistent_exception if option does not exist.
    */
   options& reset(std::string_view name);
 
   /**
-   *  Unset the option if it is optional else throws options::incompatible_exception.
+   * Unset the option if it is optional else throws options::incompatible_exception.
    *
-   *  Throws an options::inexistent_exception if option does not exist.
+   * Throws an options::inexistent_exception if option does not exist.
    */
   options& removeValue(std::string_view name);
 

--- a/library/public/options.h.in
+++ b/library/public/options.h.in
@@ -143,6 +143,7 @@ public:
    * Unset the option if it is optional else throws options::incompatible_exception.
    *
    * Throws an options::inexistent_exception if option does not exist.
+   * Throws an options::incompatible_exception if option is not an optional.
    */
   options& removeValue(std::string_view name);
 


### PR DESCRIPTION
### Describe your changes
As explained in the issue, some C bindings are not handling exceptions explicitly thrown by the library. This PR addresses this. I'm only catching specific exceptions based on this [comment](https://github.com/f3d-app/f3d/pull/2980#discussion_r3009305842).

### Issue ticket number and link if any

Implements https://github.com/f3d-app/f3d/issues/2763.

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
