### PR TITLE
Fix grid axes with SSAA

### DIFF
--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -107,6 +107,7 @@ endif()
 if(VTK_VERSION VERSION_GREATER_EQUAL 9.4.20250513)
   f3d_test(NAME TestAxesGridEnable DATA suzanne.ply ARGS --axes-grid THRESHOLD 0.08) # Threshold required for MacOS due to line rendering differences
   f3d_test(NAME TestAxesGridEnableNonCenteredData DATA cow.vtp ARGS --axes-grid)
+  f3d_test(NAME TestAxesGridEnableSSAA DATA cow.vtp ARGS --axes-grid --anti-aliasing=ssaa)
   f3d_test(NAME TestCommandScriptAxesGridAnimation SCRIPT DATA BoxAnimated.gltf ARGS --axes-grid --camera-zoom-factor=0.2)
 endif()
 

--- a/testing/baselines/TestAxesGridEnableSSAA.png
+++ b/testing/baselines/TestAxesGridEnableSSAA.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15f9fe48ae0809c43b2b970734c0c278b888f23d412a989f3b3dc274f361543a
+size 35378

--- a/vtkext/private/module/vtkF3DOpenGLGridMapper.cxx
+++ b/vtkext/private/module/vtkF3DOpenGLGridMapper.cxx
@@ -183,11 +183,11 @@ void vtkF3DOpenGLGridMapper::SetMapperShaderParameters(
   float scaling = 1.f;
 
   const vtkF3DRenderer* renderer = vtkF3DRenderer::SafeDownCast(ren);
-  if (renderer && renderer->GetAntiAliasingMode() == vtkF3DRenderer::AntiAliasingMode::SSAA)
+  if (renderer)
   {
     // The grid line width and reflection sampling need to be scaled up by the SSAA factor
     // to keep a consistent appearance.
-    scaling = std::sqrt(5.f);
+    scaling = renderer->GetScreenSpaceScaling();
   }
 
   const float offset2d[2] = {

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -976,11 +976,17 @@ void vtkF3DRenderer::ConfigureGridAxesUsingCurrentActors()
 
       double a, b, c, x, y, z;
       bbox.GetBounds(a, b, c, x, y, z);
-      GridAxesActor->SetGridBounds(a, b, c, x, y, z);
+      this->GridAxesActor->SetGridBounds(a, b, c, x, y, z);
 
-      GridAxesActor->SetXTitle("X Axis");
-      GridAxesActor->SetYTitle("Y Axis");
-      GridAxesActor->SetZTitle("Z Axis");
+      this->GridAxesActor->SetXTitle("X Axis");
+      this->GridAxesActor->SetYTitle("Y Axis");
+      this->GridAxesActor->SetZTitle("Z Axis");
+
+      vtkNew<vtkProperty> property;
+      // scaling must be applied to line width to keep it constant in screen space
+      // the scaling is applied on both side of lines, which is why we multiply by 2
+      property->SetLineWidth(1.0 + 2.0 * (this->GetScreenSpaceScaling() - 1.0));
+      this->GridAxesActor->SetProperty(property);
 
       this->GridAxesConfigured = true;
     }
@@ -1745,6 +1751,7 @@ void vtkF3DRenderer::SetAntiAliasingMode(AntiAliasingMode mode)
     this->AntiAliasingModeEnabled = mode;
     this->RenderPassesConfigured = false;
     this->CheatSheetConfigured = false;
+    this->GridAxesConfigured = false;
   }
 }
 
@@ -3713,4 +3720,10 @@ void vtkF3DRenderer::AddNotification(
 vtkMatrix4x4* vtkF3DRenderer::GetGridMatrix() const
 {
   return this->GridActor->GetMatrix();
+}
+
+//----------------------------------------------------------------------------
+double vtkF3DRenderer::GetScreenSpaceScaling() const
+{
+  return this->AntiAliasingModeEnabled == vtkF3DRenderer::AntiAliasingMode::SSAA ? std::sqrt(5.0) : 1.0;
 }

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -3725,5 +3725,6 @@ vtkMatrix4x4* vtkF3DRenderer::GetGridMatrix() const
 //----------------------------------------------------------------------------
 double vtkF3DRenderer::GetScreenSpaceScaling() const
 {
-  return this->AntiAliasingModeEnabled == vtkF3DRenderer::AntiAliasingMode::SSAA ? std::sqrt(5.0) : 1.0;
+  return this->AntiAliasingModeEnabled == vtkF3DRenderer::AntiAliasingMode::SSAA ? std::sqrt(5.0)
+                                                                                 : 1.0;
 }

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -560,6 +560,8 @@ public:
 
   /**
    * Get screen-space scaling
+   * The value returned can be used to scale screen space methods like line width
+   * to keep a consistent size on screen when using SSAA anti-aliasing.
    */
   double GetScreenSpaceScaling() const;
 

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -558,6 +558,11 @@ public:
    */
   vtkMatrix4x4* GetGridMatrix() const;
 
+  /**
+   * Get screen-space scaling
+   */
+  double GetScreenSpaceScaling() const;
+
 private:
   vtkF3DRenderer();
   ~vtkF3DRenderer() override;


### PR DESCRIPTION
### Describe your changes

When using SSAA, the axes grid lines were pretty much invisible.
A screen space scaling factor can be retrieved from the renderer to adapt the width.

### Issue ticket number and link if any

Related: https://github.com/f3d-app/f3d/issues/2255

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
