### PR TITLE
Assimp color space fix

### DIFF
--- a/plugins/assimp/module/vtkF3DAssimpImporter.cxx
+++ b/plugins/assimp/module/vtkF3DAssimpImporter.cxx
@@ -342,22 +342,24 @@ public:
       property->SetOpacity(opacity);
     }
 
+    auto toSRGB = [](float c) { return std::pow(c, 1.0 / 2.2); };
+
     aiColor4D diffuse;
     if (material->Get(AI_MATKEY_COLOR_DIFFUSE, diffuse) == aiReturn_SUCCESS)
     {
-      property->SetColor(diffuse.r, diffuse.g, diffuse.b);
+      property->SetColor(toSRGB(diffuse.r), toSRGB(diffuse.g), toSRGB(diffuse.b));
     }
 
     aiColor4D specular;
     if (material->Get(AI_MATKEY_COLOR_SPECULAR, specular) == aiReturn_SUCCESS)
     {
-      property->SetSpecularColor(specular.r, specular.g, specular.b);
+      property->SetSpecularColor(toSRGB(specular.r), toSRGB(specular.g), toSRGB(specular.b));
     }
 
     aiColor4D ambient;
     if (material->Get(AI_MATKEY_COLOR_AMBIENT, ambient) == aiReturn_SUCCESS)
     {
-      property->SetAmbientColor(ambient.r, ambient.g, ambient.b);
+      property->SetAmbientColor(toSRGB(ambient.r), toSRGB(ambient.g), toSRGB(ambient.b));
     }
 
     aiString texDiffuse;

--- a/testing/baselines/Test3MF.png
+++ b/testing/baselines/Test3MF.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffb8cefd22c12dfc0d9f591b90c93ca02abaf821ae38b4a626e9a67b3d44099f
-size 8623
+oid sha256:8b3de3965da3411d545da77c3f67d4f71b1390f898c94adddb4c44232ccbdb06
+size 8715

--- a/testing/baselines/TestDefaultConfigFileAssimpFBX.png
+++ b/testing/baselines/TestDefaultConfigFileAssimpFBX.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:abfcd333db0600d66e7741324ed27431ff72d9f3a5b4879dcccb69dc4fbfbc58
-size 47354
+oid sha256:d7f603fc3350c084d3b7c361befbc83db3a62fb6479a4904c00a5895d06b0188
+size 48895

--- a/testing/baselines/TestDefaultConfigFileAssimpOFF.png
+++ b/testing/baselines/TestDefaultConfigFileAssimpOFF.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76fa1c17f70b322086ba058bb50189f8e9ea4ba114308ad3715aa02459405d8f
-size 45717
+oid sha256:b7a4a7ea9710d571dc5561fab5760f3f0a3c8c0d54f17ab989b56cc026bc7cac
+size 46618

--- a/testing/baselines/TestFBX.png
+++ b/testing/baselines/TestFBX.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d643dade6452ca137c6b269c11dd0b9a9fb444a11e8f03b27ca5a3b514ce89ba
-size 4080
+oid sha256:581f9623ab0b8a1df8492cd77342aec992ebbe95a69e8b9e45df1732ad0b9b47
+size 2775

--- a/testing/baselines/TestOFF.png
+++ b/testing/baselines/TestOFF.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:247b8246a5889e5f72c294e4002f15dc384d27a2b1edca474cc4524bf8d6c4ad
-size 5610
+oid sha256:1576cdc36e594ff937fb42b161553a466919bf24223306467a60f61b53e7eb4a
+size 5741

--- a/testing/baselines/TestPiped3MF.png
+++ b/testing/baselines/TestPiped3MF.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffb8cefd22c12dfc0d9f591b90c93ca02abaf821ae38b4a626e9a67b3d44099f
-size 8623
+oid sha256:8b3de3965da3411d545da77c3f67d4f71b1390f898c94adddb4c44232ccbdb06
+size 8715

--- a/testing/baselines/TestPipedFBX.png
+++ b/testing/baselines/TestPipedFBX.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d643dade6452ca137c6b269c11dd0b9a9fb444a11e8f03b27ca5a3b514ce89ba
-size 4080
+oid sha256:581f9623ab0b8a1df8492cd77342aec992ebbe95a69e8b9e45df1732ad0b9b47
+size 2775

--- a/testing/baselines/TestPipedOFF.png
+++ b/testing/baselines/TestPipedOFF.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:247b8246a5889e5f72c294e4002f15dc384d27a2b1edca474cc4524bf8d6c4ad
-size 5610
+oid sha256:1576cdc36e594ff937fb42b161553a466919bf24223306467a60f61b53e7eb4a
+size 5741

--- a/testing/baselines/TestPipedX.png
+++ b/testing/baselines/TestPipedX.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48c7600d0a92547e09470456f7889e0c3cfdc98cbfd022c9da1ac4294599d89e
-size 4871
+oid sha256:f9788911a130b76040e8d1c9c17fd8dafb3e64b1595ea0239df6858709d6ba79
+size 4629

--- a/testing/baselines/TestThumbnailConfigFileAssimpFBX.png
+++ b/testing/baselines/TestThumbnailConfigFileAssimpFBX.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3953ec26bdb8c20600653336d8a4a1fcdd2ed7cf3ae2d130d787e6b3ead1aae4
-size 15959
+oid sha256:aa722ab9a26c0d27c11fdb15b33880fd950535b079d33df5599252e2bda0f22e
+size 13570

--- a/testing/baselines/TestThumbnailConfigFileAssimpOFF.png
+++ b/testing/baselines/TestThumbnailConfigFileAssimpOFF.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:551e11f4c44b392821b125494840ec6158e721de6cfe56ff08811918da78a7b0
-size 12390
+oid sha256:f0171db4a251177419c85b86cac1ccd03b2a5b2573154f27a1bf759bbd24d4b7
+size 11532

--- a/testing/baselines/TestX.png
+++ b/testing/baselines/TestX.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48c7600d0a92547e09470456f7889e0c3cfdc98cbfd022c9da1ac4294599d89e
-size 4871
+oid sha256:f9788911a130b76040e8d1c9c17fd8dafb3e64b1595ea0239df6858709d6ba79
+size 4629


### PR DESCRIPTION
### Describe your changes

It looks like Assimp return colors in linear color space, so we should convert them in sRGB.

### Issue ticket number and link if any

Fix #1459 

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
