### PR TITLE
Use dispatch to preheat caches

### DIFF
--- a/.github/workflows/build-cache-preheating.yml
+++ b/.github/workflows/build-cache-preheating.yml
@@ -15,7 +15,7 @@ jobs:
   # Trigger a cache preheating workflow
   #----------------------------------------------------------------------------
   build_cache_preheating:
-    name: Build docker images
+    name: Build cache preheating
     if: contains(github.event.pull_request.labels.*.name, 'ci:cache')
     runs-on: ubuntu-latest
     steps:
@@ -28,12 +28,11 @@ jobs:
           github_token: ${{ secrets.F3D_CACHE_CI_DISPATCH }}
           workflow_file_name: cache-preheating.yml
           wait_interval: 60
-          client_payload: '{"repo": "${{github.event.pull_request.head.repo.full_name}}"}'
+          client_payload: '{"repo": "${{github.event.pull_request.head.repo.full_name}}", "branch": "${{github.event.pull_request.head.ref}}"}'
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
 
       - uses: marocchino/sticky-pull-request-comment@v3.0.4
-        if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1'}}
         with:
           message: Caches have been generated/checked

--- a/.github/workflows/build-cache-preheating.yml
+++ b/.github/workflows/build-cache-preheating.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           owner: f3d-app
           repo: f3d
+          ref: master
           github_token: ${{ secrets.F3D_CACHE_CI_DISPATCH }}
           workflow_file_name: cache-preheating.yml
           wait_interval: 60

--- a/.github/workflows/build-cache-preheating.yml
+++ b/.github/workflows/build-cache-preheating.yml
@@ -1,0 +1,39 @@
+name: Build cache preheating
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - master
+      - release
+    paths-ignore:
+      - "doc/**"
+      - "_config.yml"
+
+jobs:
+  #----------------------------------------------------------------------------
+  # Trigger a cache preheating workflow
+  #----------------------------------------------------------------------------
+  build_cache_preheating:
+    name: Build docker images
+    if: contains(github.event.pull_request.labels.*.name, 'ci:cache')
+    runs-on: ubuntu-latest
+    steps:
+      # This require a F3D_CACHE_CI_DISPATCH secret contain a PAT with read and write admin access
+      - name: Trigger docker images build
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: f3d-app
+          repo: f3d
+          github_token: ${{ secrets.F3D_CACHE_CI_DISPATCH }}
+          workflow_file_name: cache-preheating.yml
+          wait_interval: 60
+          client_payload: '{"repo": "${{github.event.pull_request.head.repo.full_name}}, "branch": "${{github.event.pull_request.head.ref}}"}'
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+
+      - uses: marocchino/sticky-pull-request-comment@v3.0.4
+        if: ${{env.F3D_DOCKER_IMAGE_AVAILABLE == '1'}}
+        with:
+          message: Caches have been generated/checked

--- a/.github/workflows/build-cache-preheating.yml
+++ b/.github/workflows/build-cache-preheating.yml
@@ -28,7 +28,7 @@ jobs:
           github_token: ${{ secrets.F3D_CACHE_CI_DISPATCH }}
           workflow_file_name: cache-preheating.yml
           wait_interval: 60
-          client_payload: '{"repo": "${{github.event.pull_request.head.repo.full_name}}, "branch": "${{github.event.pull_request.head.ref}}"}'
+          client_payload: '{"repo": "${{github.event.pull_request.head.repo.full_name}}"}'
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true

--- a/.github/workflows/build-cache-preheating.yml
+++ b/.github/workflows/build-cache-preheating.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Trigger docker images build
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
-          owner: mwestphal
+          owner: f3d-app
           repo: f3d
           ref: master
           github_token: ${{ secrets.F3D_CACHE_CI_DISPATCH }}

--- a/.github/workflows/build-cache-preheating.yml
+++ b/.github/workflows/build-cache-preheating.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Trigger docker images build
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
-          owner: f3d-app
+          owner: mwestphal
           repo: f3d
           ref: master
           github_token: ${{ secrets.F3D_CACHE_CI_DISPATCH }}

--- a/.github/workflows/cache-preheating.yml
+++ b/.github/workflows/cache-preheating.yml
@@ -1,14 +1,14 @@
 name: Cache preheating
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
-    branches:
-      - master
-      - release
-    paths-ignore:
-      - "doc/**"
-      - "_config.yml"
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository to build caches from'
+        required: true
+      branch:
+        description: 'Branch of repository to build caches from'
+        required: true
 
 jobs:
   #----------------------------------------------------------------------------
@@ -16,7 +16,6 @@ jobs:
   #----------------------------------------------------------------------------
   cache_preheating_dependencies:
     name: Preheat dependency caches
-    if: contains(github.event.pull_request.labels.*.name, 'ci:cache')
     strategy:
       fail-fast: false
       matrix:
@@ -36,9 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          allow-unsafe-pr-checkout: true
+          ref:  ${{ github.event.inputs.branch }}
+          repository:  ${{ github.event.inputs.repo }}
           path: "source"
           fetch-depth: 1
           lfs: false
@@ -56,16 +54,14 @@ jobs:
   recover_vtk_matrix:
     name: Recover VTK matrix
     runs-on: ubuntu-24.04
-    if: contains(github.event.pull_request.labels.*.name, 'ci:cache')
     outputs:
       vtk_matrix: ${{steps.vtk_matrix.outputs.extract}}
 
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          allow-unsafe-pr-checkout: true
+          ref:  ${{ github.event.inputs.branch }}
+          repository:  ${{ github.event.inputs.repo }}
           path: "source"
           fetch-depth: 1
           lfs: false
@@ -112,9 +108,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          allow-unsafe-pr-checkout: true
+          ref:  ${{ github.event.inputs.branch }}
+          repository:  ${{ github.event.inputs.repo }}
           path: "source"
           fetch-depth: 1
           lfs: false


### PR DESCRIPTION
### Describe your changes

Due to reduced authorization on the GITHUB_TOKEN in pull_request_target workflows, now use a dispatch workflow with a PAT to preheat caches.

See in action here: https://github.com/mwestphal/f3d/pull/62/checks

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
