### PR TITLE
WASM: Add 3 examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -151,6 +151,17 @@ npm install f3d --tag rc
 npm run start
 ```
 
+- Test examples manually (Docker required)
+
+```bash
+cd examples/libf3d/web
+npm run install
+npm run dev --workspace simple-ui
+npm run dev --workspace volume-rendering
+npm run dev --workspace multiple-instances
+npm run dev --workspace gaussian-splatting
+```
+
 Once a release cycle:
 
 - Check that completions are still working with `fish` and `zsh` when tab is pressed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "npm"
-    directory: "/examples/libf3d/web/"
+    directory: "/examples/libf3d/web/*/"
     labels:
       - "source:wasm"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,7 +601,7 @@ jobs:
 
       - name: Build F3D web app with npm F3D package
         working-directory: ${{github.workspace}}/source/examples/libf3d/web
-        run: npm run build
+        run: npm run build --workspaces
 
       - name: Retrieve f3d package
         uses: actions/download-artifact@v8
@@ -612,8 +612,8 @@ jobs:
       # Override with the locally built package
       - name: Install f3d package
         working-directory: ${{github.workspace}}/source/examples/libf3d/web
-        run: npm install f3d-*.tgz
+        run: npm install f3d-*.tgz --workspaces
 
       - name: Build F3D web app with package just built from branch
         working-directory: ${{github.workspace}}/source/examples/libf3d/web
-        run: npm run build
+        run: npm run build --workspaces

--- a/examples/libf3d/web/README.md
+++ b/examples/libf3d/web/README.md
@@ -1,0 +1,31 @@
+# Web examples
+
+In order to run the examples, F3D must be built locally, which is done automatically but requires Docker installed on your computer.
+
+## Specific example
+
+It's possible to run one specific example by navigating to its folder (e.g. `examples/libf3d/web/simple-ui`) and install dependencies by running:
+
+```bash
+npm install
+```
+
+Once dependencies are installed (can take a while because F3D is compiled), the example can be launched by running:
+
+```bash
+npm run dev
+```
+
+## All examples
+
+It's possible to install dependencies once by running the following command from `examples/libf3d/web`:
+
+```bash
+npm install
+```
+
+Then it's possible to select the example to launch. In order to run `simple-ui`, the following command must be run:
+
+```bash
+npm run dev --workspace simple-ui
+```

--- a/examples/libf3d/web/gaussian-splatting/index.html
+++ b/examples/libf3d/web/gaussian-splatting/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Volume rendering demo</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+
+      .page-header {
+        padding: 18px 24px;
+        text-align: center;
+      }
+      .page-header h1 {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 600;
+      }
+
+      .container {
+        box-sizing: border-box;
+        display: flex;
+        gap: 16px;
+        height: calc(100vh - 72px);
+        max-height: 720px;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 16px;
+        align-items: stretch;
+      }
+
+      .card {
+        background: MintCream;
+        border-radius: 10px;
+        border: 1px solid #888;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .viewer {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+        image-rendering: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Gaussian Splatting demo</h1>
+    </header>
+
+    <div class="container" id="main">
+      <div class="card viewer">
+        <canvas id="canvas"></canvas>
+      </div>
+    </div>
+
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/examples/libf3d/web/gaussian-splatting/package.json
+++ b/examples/libf3d/web/gaussian-splatting/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "f3d-example-gaussian-splatting",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^8.1.2"
+  },
+  "dependencies": {
+    "f3d": "file:../../../.."
+  }
+}

--- a/examples/libf3d/web/gaussian-splatting/src/main.js
+++ b/examples/libf3d/web/gaussian-splatting/src/main.js
@@ -1,0 +1,44 @@
+import f3d from "f3d";
+
+f3d({})
+  .then(async (Module) => {
+    // automatically load all supported file format readers
+    Module.Engine.autoloadPlugins();
+
+    const engine = Module.Engine.create();
+
+    // background must be set to black for proper blending with transparent canvas
+    engine.getOptions().setAsString("render.background.color", "black");
+    engine.getOptions().setAsString("scene.up_direction", "-y");
+    engine.getOptions().toggle("model.scivis.enable");
+    engine.getOptions().setAsString("model.scivis.component", "-2");
+    engine.getOptions().setAsString("model.point_sprites.type", "gaussian");
+    engine.getOptions().setAsString("model.point_sprites.size", "1.0");
+    engine.getOptions().toggle("model.point_sprites.absolute_size");
+    engine
+      .getOptions()
+      .setAsString("render.effect.blending.mode", "stochastic");
+    engine.getOptions().setAsString("render.effect.antialiasing.mode", "taa");
+
+    // setup the window size based on the canvas size
+    const canvas = document.getElementById("canvas");
+    const scale = window.devicePixelRatio;
+    engine
+      .getWindow()
+      .setSize(scale * canvas.clientWidth, scale * canvas.clientHeight);
+
+    // read file and display it
+    const response = await fetch(`https://f3d.app/data/cluster_fly.spz`);
+    const arrayBuffer = await response.arrayBuffer();
+    const scene = engine.getScene();
+    try {
+      scene.addBuffer(new Uint8Array(arrayBuffer));
+    } catch (e) {
+      console.error("Unsupported file");
+    }
+
+    // do a first render and start the interactor
+    engine.getWindow().render();
+    engine.getInteractor().start();
+  })
+  .catch((error) => console.error("Internal exception: " + error));

--- a/examples/libf3d/web/gaussian-splatting/vite.config.js
+++ b/examples/libf3d/web/gaussian-splatting/vite.config.js
@@ -1,6 +1,9 @@
 import { defineConfig } from "vite";
+import { createRequire } from "module";
 import fs from "fs";
 import path from "path";
+
+const _require = createRequire(import.meta.url);
 
 // Custom middleware to serve wasm files with the correct MIME type
 // See https://stackoverflow.com/questions/78095780/web-assembly-wasm-errors-in-a-vite-vue-app-using-realm-web-sdk
@@ -11,8 +14,7 @@ const wasmMiddleware = () => {
       server.middlewares.use((req, res, next) => {
         if (req.url && req.url.endsWith(".wasm")) {
           const wasmPath = path.join(
-            __dirname,
-            "node_modules/f3d/dist",
+            path.dirname(_require.resolve("f3d")),
             path.basename(req.url),
           );
           const wasmFile = fs.readFileSync(wasmPath);

--- a/examples/libf3d/web/multiple-instances/index.html
+++ b/examples/libf3d/web/multiple-instances/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Multiple instance demo</title>
+    <style>
+      /* Reset page spacing and base styles */
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+
+      .page-header {
+        padding: 18px 24px;
+        text-align: center;
+      }
+      .page-header h1 {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 600;
+      }
+
+      /* Layout: two cards side-by-side with a small gap and padding */
+      .container {
+        box-sizing: border-box;
+        display: flex;
+        gap: 16px;
+        height: calc(100vh - 72px);
+        padding: 16px;
+        align-items: center;
+        justify-content: center;
+      }
+
+      /* Card wrapper for a canvas + label */
+      .card {
+        position: relative;
+        flex: 0 0 50%;
+        min-width: 0;
+        max-width: 720px;
+        width: 50%;
+        background: #121212;
+        border-radius: 10px;
+        border: 1px solid rgba(16, 24, 40, 0.06);
+        box-shadow: 0 6px 18px rgba(16, 24, 40, 0.06);
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        height: 70vh;
+        max-height: 640px;
+      }
+
+      /* Canvas fills remaining card space */
+      .card canvas {
+        width: 100%;
+        height: 100%;
+      }
+
+      /* Keep rendering crisp (JS should also set drawing buffer size) */
+      canvas:where(#canvas1, #canvas2) {
+        image-rendering: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Multiple instance demo</h1>
+    </header>
+
+    <div class="container" id="main">
+      <div class="card">
+        <canvas id="canvas1"></canvas>
+      </div>
+      <div class="card">
+        <canvas id="canvas2"></canvas>
+      </div>
+    </div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/examples/libf3d/web/multiple-instances/package.json
+++ b/examples/libf3d/web/multiple-instances/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "f3d-example-multiple-instances",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^8.1.2"
+  }
+}

--- a/examples/libf3d/web/multiple-instances/src/main.js
+++ b/examples/libf3d/web/multiple-instances/src/main.js
@@ -1,0 +1,54 @@
+import f3d from "f3d";
+
+f3d({})
+  .then(async (Module) => {
+    Module.Log.setVerboseLevel(Module.LogVerboseLevel.QUIET, false);
+    Module.Log.forward((level, message) => {
+      if (level === Module.LogVerboseLevel.ERROR) console.error(message);
+      else if (level === Module.LogVerboseLevel.WARN) console.warn(message);
+      else if (level === Module.LogVerboseLevel.INFO) console.info(message);
+    });
+
+    // automatically load all supported file format readers
+    Module.Engine.autoloadPlugins();
+
+    for (const { id, file } of [
+      { id: "canvas1", file: "DamagedHelmet.glb" },
+      { id: "canvas2", file: "202.vtp" },
+    ]) {
+      const engine = Module.Engine.create("#" + id);
+
+      // background must be set to black for proper blending with transparent canvas
+      engine.getOptions().setAsString("render.background.color", "#000000");
+
+      // make it look nice
+      engine
+        .getOptions()
+        .setAsString("render.effect.antialiasing.mode", "fxaa");
+      engine.getOptions().toggle("render.effect.tone_mapping");
+      engine.getOptions().toggle("render.effect.ambient_occlusion");
+      engine.getOptions().toggle("render.hdri.ambient");
+
+      // setup the window size based on the canvas size
+      const canvas = document.getElementById(id);
+      const scale = window.devicePixelRatio;
+      engine
+        .getWindow()
+        .setSize(scale * canvas.clientWidth, scale * canvas.clientHeight);
+
+      // read https://f3d.app/data/{file} and display it
+      const response = await fetch(`https://f3d.app/data/${file}`);
+      const arrayBuffer = await response.arrayBuffer();
+      const scene = engine.getScene();
+      try {
+        scene.addBuffer(new Uint8Array(arrayBuffer));
+      } catch (e) {
+        console.error("Unsupported file");
+      }
+
+      // do a first render and start the interactor
+      engine.getWindow().render();
+      engine.getInteractor().start();
+    }
+  })
+  .catch((error) => console.error("Internal exception: " + error));

--- a/examples/libf3d/web/multiple-instances/vite.config.js
+++ b/examples/libf3d/web/multiple-instances/vite.config.js
@@ -1,0 +1,34 @@
+import { defineConfig } from "vite";
+import { createRequire } from "module";
+import fs from "fs";
+import path from "path";
+
+const _require = createRequire(import.meta.url);
+
+// Custom middleware to serve wasm files with the correct MIME type
+// See https://stackoverflow.com/questions/78095780/web-assembly-wasm-errors-in-a-vite-vue-app-using-realm-web-sdk
+const wasmMiddleware = () => {
+  return {
+    name: "wasm-middleware",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url && req.url.endsWith(".wasm")) {
+          const wasmPath = path.join(
+            path.dirname(_require.resolve("f3d")),
+            path.basename(req.url),
+          );
+          const wasmFile = fs.readFileSync(wasmPath);
+          res.setHeader("Content-Type", "application/wasm");
+          res.end(wasmFile);
+          return;
+        }
+        next();
+      });
+    },
+  };
+};
+
+export default defineConfig({
+  plugins: [wasmMiddleware()],
+  base: "./",
+});

--- a/examples/libf3d/web/package-lock.json
+++ b/examples/libf3d/web/package-lock.json
@@ -1,27 +1,44 @@
 {
-  "name": "f3d-example",
+  "name": "f3d-examples-web",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "f3d-example",
+      "name": "f3d-examples-web",
       "version": "0.0.0",
+      "workspaces": [
+        "gaussian-splatting",
+        "multiple-instances",
+        "simple-ui",
+        "volume-rendering"
+      ],
       "dependencies": {
-        "bulma": "^1.0.4",
-        "bulma-switch": "^2.0.4",
         "f3d": "file:../../.."
-      },
-      "devDependencies": {
-        "vite": "^8.1.3"
       }
     },
     "../../..": {
-      "name": "f3d",
       "version": "3.5.0",
       "license": "BSD-3-Clause",
       "funding": {
         "url": "https://f3d.app/thanks/"
+      }
+    },
+    "gaussian-splatting": {
+      "name": "f3d-example-gaussian-splatting",
+      "version": "0.0.0",
+      "dependencies": {
+        "f3d": "file:../../../.."
+      },
+      "devDependencies": {
+        "vite": "^8.1.2"
+      }
+    },
+    "multiple-instances": {
+      "name": "f3d-example-multiple-instances",
+      "version": "0.0.0",
+      "devDependencies": {
+        "vite": "^8.1.2"
       }
     },
     "node_modules/@emnapi/core": {
@@ -78,9 +95,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -88,9 +105,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
-      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -105,9 +122,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
-      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -122,9 +139,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
-      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -139,9 +156,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
-      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -156,9 +173,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
-      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -173,9 +190,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
-      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
@@ -193,9 +210,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
-      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
@@ -213,9 +230,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
-      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
@@ -233,9 +250,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
-      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
@@ -253,9 +270,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
-      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
@@ -273,9 +290,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
-      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
@@ -293,9 +310,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
-      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -310,9 +327,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
-      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
       ],
@@ -329,9 +346,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
-      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -346,9 +363,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
-      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -382,11 +399,434 @@
     },
     "node_modules/bulma": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-1.0.4.tgz",
+      "integrity": "sha512-Ffb6YGXDiZYX3cqvSbHWqQ8+LkX6tVoTcZuVB3lm93sbAVXlO0D6QlOTMnV6g18gILpAXqkG2z9hf9z4hCjz2g==",
       "license": "MIT"
     },
     "node_modules/bulma-switch": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/bulma-switch/-/bulma-switch-2.0.4.tgz",
+      "integrity": "sha512-kMu4H0Pr0VjvfsnT6viRDCgptUq0Rvy7y7PX6q+IHg1xUynsjszPjhAdal5ysAlCG5HNO+5YXxeiu92qYGQolw==",
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -400,6 +840,22 @@
     },
     "node_modules/f3d": {
       "resolved": "../../..",
+      "link": true
+    },
+    "node_modules/f3d-example-gaussian-splatting": {
+      "resolved": "gaussian-splatting",
+      "link": true
+    },
+    "node_modules/f3d-example-multiple-instances": {
+      "resolved": "multiple-instances",
+      "link": true
+    },
+    "node_modules/f3d-example-simple-ui": {
+      "resolved": "simple-ui",
+      "link": true
+    },
+    "node_modules/f3d-example-volume-rendering": {
+      "resolved": "volume-rendering",
       "link": true
     },
     "node_modules/fdir": {
@@ -433,6 +889,27 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lightningcss": {
@@ -578,6 +1055,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -599,6 +1079,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -620,6 +1103,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -641,6 +1127,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -723,9 +1212,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -764,14 +1253,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
-      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.137.0",
+        "@oxc-project/types": "=0.138.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -781,22 +1276,34 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.3",
-        "@rolldown/binding-darwin-arm64": "1.1.3",
-        "@rolldown/binding-darwin-x64": "1.1.3",
-        "@rolldown/binding-freebsd-x64": "1.1.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
-        "@rolldown/binding-linux-arm64-musl": "1.1.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
-        "@rolldown/binding-linux-x64-gnu": "1.1.3",
-        "@rolldown/binding-linux-x64-musl": "1.1.3",
-        "@rolldown/binding-openharmony-arm64": "1.1.3",
-        "@rolldown/binding-wasm32-wasi": "1.1.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
-        "@rolldown/binding-win32-x64-msvc": "1.1.3"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -909,6 +1416,30 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "simple-ui": {
+      "name": "f3d-example-simple-ui",
+      "version": "0.0.0",
+      "dependencies": {
+        "bulma": "^1.0.4",
+        "bulma-switch": "^2.0.4",
+        "f3d": "file:../../../.."
+      },
+      "devDependencies": {
+        "vite": "^8.1.2"
+      }
+    },
+    "volume-rendering": {
+      "name": "f3d-example-volume-rendering",
+      "version": "0.0.0",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "d3-scale-chromatic": "^3.1.0",
+        "f3d": "file:../../../.."
+      },
+      "devDependencies": {
+        "vite": "^8.1.2"
       }
     }
   }

--- a/examples/libf3d/web/package.json
+++ b/examples/libf3d/web/package.json
@@ -1,19 +1,14 @@
 {
-  "name": "f3d-example",
+  "name": "f3d-examples-web",
   "private": true,
   "version": "0.0.0",
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
-  },
-  "devDependencies": {
-    "vite": "^8.1.3"
-  },
+  "workspaces": [
+    "gaussian-splatting",
+    "multiple-instances",
+    "simple-ui",
+    "volume-rendering"
+  ],
   "dependencies": {
-    "bulma": "^1.0.4",
-    "bulma-switch": "^2.0.4",
     "f3d": "file:../../.."
   }
 }

--- a/examples/libf3d/web/simple-ui/index.html
+++ b/examples/libf3d/web/simple-ui/index.html
@@ -80,16 +80,6 @@
             <p class="menu-label">Rendering</p>
             <div class="field">
               <input
-                id="fxaa"
-                type="checkbox"
-                name="fxaa"
-                class="switch is-rounded"
-                checked
-              />
-              <label for="fxaa">Anti-aliasing</label>
-            </div>
-            <div class="field">
-              <input
                 id="tone"
                 type="checkbox"
                 name="tone"

--- a/examples/libf3d/web/simple-ui/package.json
+++ b/examples/libf3d/web/simple-ui/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "f3d-example-simple-ui",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^8.1.2"
+  },
+  "dependencies": {
+    "bulma": "^1.0.4",
+    "bulma-switch": "^2.0.4",
+    "f3d": "file:../../../.."
+  }
+}

--- a/examples/libf3d/web/simple-ui/src/main.js
+++ b/examples/libf3d/web/simple-ui/src/main.js
@@ -69,7 +69,6 @@ f3d(settings)
     const idOptionMappings = [
       ["grid", "render.grid.enable"],
       ["axis", "ui.axis"],
-      ["fxaa", "render.effect.antialiasing.mode"],
       ["tone", "render.effect.tone_mapping"],
       ["ssao", "render.effect.ambient_occlusion"],
       ["ambient", "render.hdri.ambient"],
@@ -119,7 +118,7 @@ f3d(settings)
     document.querySelector("#z-up").addEventListener("click", (evt) => {
       Module.engineInstance
         .getOptions()
-        .set_as_string("scene.up_direction", "+Z");
+        .setAsString("scene.up_direction", "+Z");
       document.getElementById("z-up").classList.add("is-active");
       document.getElementById("y-up").classList.remove("is-active");
       openFile(document.getElementById("file-name").innerHTML);
@@ -128,7 +127,7 @@ f3d(settings)
     document.querySelector("#y-up").addEventListener("click", (evt) => {
       Module.engineInstance
         .getOptions()
-        .set_as_string("scene.up_direction", "+Y");
+        .setAsString("scene.up_direction", "+Y");
       document.getElementById("y-up").classList.add("is-active");
       document.getElementById("z-up").classList.remove("is-active");
       openFile(document.getElementById("file-name").innerHTML);

--- a/examples/libf3d/web/simple-ui/vite.config.js
+++ b/examples/libf3d/web/simple-ui/vite.config.js
@@ -1,0 +1,34 @@
+import { defineConfig } from "vite";
+import { createRequire } from "module";
+import fs from "fs";
+import path from "path";
+
+const _require = createRequire(import.meta.url);
+
+// Custom middleware to serve wasm files with the correct MIME type
+// See https://stackoverflow.com/questions/78095780/web-assembly-wasm-errors-in-a-vite-vue-app-using-realm-web-sdk
+const wasmMiddleware = () => {
+  return {
+    name: "wasm-middleware",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url && req.url.endsWith(".wasm")) {
+          const wasmPath = path.join(
+            path.dirname(_require.resolve("f3d")),
+            path.basename(req.url),
+          );
+          const wasmFile = fs.readFileSync(wasmPath);
+          res.setHeader("Content-Type", "application/wasm");
+          res.end(wasmFile);
+          return;
+        }
+        next();
+      });
+    },
+  };
+};
+
+export default defineConfig({
+  plugins: [wasmMiddleware()],
+  base: "./",
+});

--- a/examples/libf3d/web/volume-rendering/index.html
+++ b/examples/libf3d/web/volume-rendering/index.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Volume rendering demo</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+
+      .page-header {
+        padding: 18px 24px;
+        text-align: center;
+      }
+      .page-header h1 {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 600;
+      }
+
+      .container {
+        box-sizing: border-box;
+        display: flex;
+        gap: 16px;
+        height: calc(100vh - 72px);
+        max-height: 720px;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 16px;
+        align-items: stretch;
+      }
+
+      .card {
+        background: #121212;
+        border-radius: 10px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .viewer {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .viewer canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+        image-rendering: auto;
+      }
+
+      .controls {
+        width: 280px;
+        flex-shrink: 0;
+        padding: 20px;
+        overflow-y: auto;
+      }
+
+      .ui-section {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
+
+      label {
+        color: #888;
+        letter-spacing: 0.06em;
+      }
+
+      select {
+        width: 256px;
+        padding: 7px 10px;
+        border-radius: 4px;
+        border: 1px solid #888;
+        background: #1e1e1e;
+        color: #eee;
+        cursor: pointer;
+      }
+
+      #tfEditor {
+        width: 256px;
+        height: 96px;
+        border: 1px solid #888;
+        background: #1e1e1e;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Volume rendering demo</h1>
+    </header>
+
+    <div class="container" id="main">
+      <div class="card viewer">
+        <canvas id="canvas"></canvas>
+      </div>
+      <div class="card controls">
+        <div class="ui-section">
+          <label for="colormap">Colormap</label>
+          <select id="colormap">
+            <option>viridis</option>
+            <option>inferno</option>
+            <option>magma</option>
+            <option>plasma</option>
+            <option>cividis</option>
+            <option>turbo</option>
+            <option>warm</option>
+            <option>cool</option>
+            <option>spectral</option>
+            <option>rainbow</option>
+          </select>
+        </div>
+
+        <div class="ui-section">
+          <label>Transfer function</label>
+          <svg id="tfEditor"></svg>
+          <small style="color: #888">
+            Double-click to add point. Drag to move. Double-click point to
+            remove.
+          </small>
+        </div>
+      </div>
+    </div>
+
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/examples/libf3d/web/volume-rendering/package.json
+++ b/examples/libf3d/web/volume-rendering/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "f3d-example-volume-rendering",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^8.1.2"
+  },
+  "dependencies": {
+    "d3": "^7.9.0",
+    "d3-scale-chromatic": "^3.1.0",
+    "f3d": "file:../../../.."
+  }
+}

--- a/examples/libf3d/web/volume-rendering/src/main.js
+++ b/examples/libf3d/web/volume-rendering/src/main.js
@@ -1,0 +1,219 @@
+import * as d3 from "d3";
+import f3d from "f3d";
+
+function clamp(v) {
+  return Math.max(0, Math.min(1, v));
+}
+
+// Setup the transfer-function editor SVG
+const tfSvg = d3.select("#tfEditor");
+const tfWidth = 256,
+  tfHeight = 96;
+
+const tfX = d3.scaleLinear().domain([0, 1]).range([0, tfWidth]);
+const tfY = d3.scaleLinear().domain([0, 1]).range([tfHeight, 0]);
+const tfLine = d3
+  .line()
+  .x((d) => tfX(d.x))
+  .y((d) => tfY(d.y));
+
+// colormap background
+const tfDefs = tfSvg.append("defs");
+const tfGrad = tfDefs
+  .append("linearGradient")
+  .attr("id", "tf-cm-grad")
+  .attr("x1", "0%")
+  .attr("x2", "100%")
+  .attr("y1", "0%")
+  .attr("y2", "0%");
+const tfBg = tfSvg
+  .append("rect")
+  .attr("x", 0)
+  .attr("y", 0)
+  .attr("width", tfWidth)
+  .attr("height", tfHeight)
+  .attr("fill", "url(#tf-cm-grad)");
+
+const tfPath = tfSvg
+  .append("path")
+  .attr("fill", "none")
+  .attr("stroke", "#fff")
+  .attr("stroke-width", 2);
+const tfNodes = tfSvg.append("g");
+
+// colormap
+const colormapInterpolators = {
+  viridis: d3.interpolateViridis,
+  inferno: d3.interpolateInferno,
+  magma: d3.interpolateMagma,
+  plasma: d3.interpolatePlasma,
+  cividis: d3.interpolateCividis,
+  turbo: d3.interpolateTurbo,
+  warm: d3.interpolateWarm,
+  cool: d3.interpolateCool,
+  spectral: d3.interpolateSpectral,
+  rainbow: d3.interpolateRainbow,
+};
+
+// Generate F3D colormap string format: "val,#rrggbb,val,#rrggbb,..."
+function buildColormapString(name, nSamples = 32) {
+  const interp = colormapInterpolators[name];
+  if (!interp) return null;
+  return Array.from({ length: nSamples }, (_, i) => {
+    const t = i / (nSamples - 1);
+    return `${t},${d3.color(interp(t)).formatHex()}`;
+  }).join(",");
+}
+
+// Update colormap background gradient in the TF editor
+function updateTFBackground(name, nStops = 16) {
+  const interp = colormapInterpolators[name];
+  if (!interp) return;
+  tfGrad
+    .selectAll("stop")
+    .data(d3.range(nStops))
+    .join("stop")
+    .attr("offset", (i) => `${(i / (nStops - 1)) * 100}%`)
+    .attr("stop-color", (i) => interp(i / (nStops - 1)));
+}
+
+// Initial state of the transfer function editor
+let onTFChange = () => {};
+let currentColormap = "viridis";
+let tfPoints = [
+  { x: 0, y: 0 },
+  { x: 1, y: 1 },
+];
+
+function renderTF() {
+  tfPoints.sort((a, b) => a.x - b.x);
+  tfPath.attr("d", tfLine(tfPoints));
+
+  tfNodes
+    .selectAll("circle")
+    .data(tfPoints)
+    .join(
+      (enter) =>
+        enter
+          .append("circle")
+          .attr("r", 5)
+          .attr("fill", "#fff")
+          .attr("stroke", "#333")
+          .attr("cx", (d) => tfX(d.x))
+          .attr("cy", (d) => tfY(d.y))
+          .on("dblclick", (event, d) => {
+            // remove point
+            event.stopPropagation();
+            if (tfPoints.length <= 2) return;
+            tfPoints = tfPoints.filter((p) => p !== d);
+            renderTF();
+          })
+          .call(
+            d3
+              .drag()
+              .on("start", (e) => e.sourceEvent.stopPropagation())
+              .on("drag", (e, d) => {
+                const [mx, my] = d3.pointer(e, tfSvg.node());
+                d.x = clamp(tfX.invert(mx));
+                d.y = clamp(tfY.invert(my));
+                renderTF();
+              }),
+          ),
+      (update) =>
+        update.attr("cx", (d) => tfX(d.x)).attr("cy", (d) => tfY(d.y)),
+      (exit) => exit.remove(),
+    );
+
+  onTFChange();
+  updateTFBackground(currentColormap);
+}
+
+tfSvg.on("dblclick", (e) => {
+  // add point
+  const [mx, my] = d3.pointer(e, tfSvg.node());
+  tfPoints.push({ x: clamp(tfX.invert(mx)), y: clamp(tfY.invert(my)) });
+  renderTF();
+});
+
+renderTF();
+
+let onColormapChange = () => {};
+document
+  .getElementById("colormap")
+  .addEventListener("change", (e) => onColormapChange(e.target.value));
+
+f3d({})
+  .then(async (Module) => {
+    Module.Log.setVerboseLevel(Module.LogVerboseLevel.QUIET, false);
+    Module.Log.forward((level, message) => {
+      if (level === Module.LogVerboseLevel.ERROR) console.error(message);
+      else if (level === Module.LogVerboseLevel.WARN) console.warn(message);
+      else if (level === Module.LogVerboseLevel.INFO) console.info(message);
+    });
+
+    // automatically load all supported file format readers
+    Module.Engine.autoloadPlugins();
+
+    const engine = Module.Engine.create();
+
+    // background must be set to black for proper blending with transparent canvas
+    engine.getOptions().setAsString("render.background.color", "#000000");
+    engine.getOptions().setAsString("scene.up_direction", "+z");
+    engine.getOptions().toggle("model.volume.enable");
+    engine.getOptions().toggle("ui.scalar_bar");
+
+    // setup the window size based on the canvas size
+    const canvas = document.getElementById("canvas");
+    const scale = window.devicePixelRatio;
+    engine
+      .getWindow()
+      .setSize(scale * canvas.clientWidth, scale * canvas.clientHeight);
+
+    // read file and display it
+    const response = await fetch(`https://f3d.app/data/skull.vti`);
+    const arrayBuffer = await response.arrayBuffer();
+    const scene = engine.getScene();
+    try {
+      scene.addBuffer(new Uint8Array(arrayBuffer));
+    } catch (e) {
+      console.error("Unsupported file");
+    }
+
+    const options = engine.getOptions();
+
+    onTFChange = () => {
+      const sorted = tfPoints.sort((a, b) => a.x - b.x);
+
+      // update opacity_map
+      options.setAsString(
+        "model.scivis.opacity_map",
+        sorted.map((p) => `${p.x},${p.y}`).join(","),
+      );
+
+      // update range
+      options.setAsString(
+        "model.scivis.range",
+        `${255 * sorted[0].x},${255 * sorted[sorted.length - 1].x}`,
+      );
+      engine.getWindow().render();
+    };
+
+    onColormapChange = (name) => {
+      currentColormap = name;
+      const cm = buildColormapString(name);
+      if (cm) {
+        options.setAsString("model.scivis.colormap", cm);
+        updateTFBackground(name);
+        engine.getWindow().render();
+      }
+    };
+
+    // apply initial values
+    onTFChange();
+    onColormapChange(document.getElementById("colormap").value);
+
+    // do a first render and start the interactor
+    engine.getWindow().render();
+    engine.getInteractor().start();
+  })
+  .catch((error) => console.error("Internal exception: " + error));

--- a/examples/libf3d/web/volume-rendering/vite.config.js
+++ b/examples/libf3d/web/volume-rendering/vite.config.js
@@ -1,0 +1,34 @@
+import { defineConfig } from "vite";
+import { createRequire } from "module";
+import fs from "fs";
+import path from "path";
+
+const _require = createRequire(import.meta.url);
+
+// Custom middleware to serve wasm files with the correct MIME type
+// See https://stackoverflow.com/questions/78095780/web-assembly-wasm-errors-in-a-vite-vue-app-using-realm-web-sdk
+const wasmMiddleware = () => {
+  return {
+    name: "wasm-middleware",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url && req.url.endsWith(".wasm")) {
+          const wasmPath = path.join(
+            path.dirname(_require.resolve("f3d")),
+            path.basename(req.url),
+          );
+          const wasmFile = fs.readFileSync(wasmPath);
+          res.setHeader("Content-Type", "application/wasm");
+          res.end(wasmFile);
+          return;
+        }
+        next();
+      });
+    },
+  };
+};
+
+export default defineConfig({
+  plugins: [wasmMiddleware()],
+  base: "./",
+});


### PR DESCRIPTION
### Describe your changes

- Move web example to its own `simple-ui` folder
- Removed FXAA option in `simple-ui` and fix minor issues
- Add a new web example `multiple-instances` with two wasm windows (requires #3345)
- Add a new web example `volume-rendering` with colormap and opacity function widget
- Add a new web example `gaussian-splatting` with stochastic blending and TAA (requires #3346)

### Issue ticket number and link if any

Fixes https://github.com/f3d-app/f3d/issues/3049

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [ ] I did not use AI to generate any of the content of that pull request
- [x] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.

- Used VSCode Copilot autocompletion (Claude Sonnet 4.6)
- Used Claude Sonnet 4.6 to help generating CSS code in the new examples

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
