### PR TITLE
Properly forward C++ exceptions through the Java bindings

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -12,6 +12,7 @@ set(F3D_JAVA_SOURCES
   Camera.java
   Context.java
   Engine.java
+  F3DException.java
   Image.java
   Interactor.java
   Log.java

--- a/java/Context.java
+++ b/java/Context.java
@@ -2,6 +2,16 @@ package app.f3d.F3D;
 
 public class Context {
 
+    /** Thrown when a shared library required for a context cannot be loaded. */
+    public static class LoadingException extends F3DException {
+        public LoadingException(String message) { super(message); }
+    }
+
+    /** Thrown when a required symbol cannot be resolved from a shared library. */
+    public static class SymbolException extends F3DException {
+        public SymbolException(String message) { super(message); }
+    }
+
     // Used to load the 'f3d' library on application startup.
     static {
         System.loadLibrary("f3d-java");

--- a/java/Engine.java
+++ b/java/Engine.java
@@ -62,6 +62,26 @@ public class Engine implements AutoCloseable {
         }
     }
 
+    /** Thrown when a window-based operation is called on an engine with no window. */
+    public static class NoWindowException extends F3DException {
+        public NoWindowException(String message) { super(message); }
+    }
+
+    /** Thrown when {@link #getInteractor()} is called on an engine with no interactor. */
+    public static class NoInteractorException extends F3DException {
+        public NoInteractorException(String message) { super(message); }
+    }
+
+    /** Thrown when a plugin cannot be loaded. */
+    public static class PluginException extends F3DException {
+        public PluginException(String message) { super(message); }
+    }
+
+    /** Thrown when the cache path cannot be set or used. */
+    public static class CacheException extends F3DException {
+        public CacheException(String message) { super(message); }
+    }
+
     // Used to load the 'f3d' library on application startup.
     static {
         System.loadLibrary("f3d-java");

--- a/java/F3DContextBindings.cxx
+++ b/java/F3DContextBindings.cxx
@@ -16,29 +16,89 @@ struct f3d_java_context
 
 extern "C"
 {
-  JNIEXPORT jlong JAVA_BIND(Context, glx)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Context, glx)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d_java_context(f3d::context::glx()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d_java_context(f3d::context::glx()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Context, wgl)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Context, wgl)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d_java_context(f3d::context::wgl()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d_java_context(f3d::context::wgl()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Context, cocoa)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Context, cocoa)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d_java_context(f3d::context::cocoa()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d_java_context(f3d::context::cocoa()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Context, egl)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Context, egl)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d_java_context(f3d::context::egl()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d_java_context(f3d::context::egl()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Context, osmesa)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Context, osmesa)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d_java_context(f3d::context::osmesa()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d_java_context(f3d::context::osmesa()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    return 0;
   }
 
   JNIEXPORT jlong JAVA_BIND(Context, getSymbol)(JNIEnv* env, jclass, jstring lib, jstring func)
@@ -46,12 +106,26 @@ extern "C"
     const char* libStr = env->GetStringUTFChars(lib, nullptr);
     const char* funcStr = env->GetStringUTFChars(func, nullptr);
 
-    f3d_java_context* ctx = new f3d_java_context(f3d::context::getSymbol(libStr, funcStr));
-
-    env->ReleaseStringUTFChars(lib, libStr);
-    env->ReleaseStringUTFChars(func, funcStr);
-
-    return reinterpret_cast<jlong>(ctx);
+    try
+    {
+      f3d_java_context* ctx = new f3d_java_context(f3d::context::getSymbol(libStr, funcStr));
+      env->ReleaseStringUTFChars(lib, libStr);
+      env->ReleaseStringUTFChars(func, funcStr);
+      return reinterpret_cast<jlong>(ctx);
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      env->ReleaseStringUTFChars(lib, libStr);
+      env->ReleaseStringUTFChars(func, funcStr);
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      env->ReleaseStringUTFChars(lib, libStr);
+      env->ReleaseStringUTFChars(func, funcStr);
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    return 0;
   }
 
   JNIEXPORT void JAVA_BIND(Context, delete)(JNIEnv*, jclass, jlong contextHandle)

--- a/java/F3DContextBindings.cxx
+++ b/java/F3DContextBindings.cxx
@@ -106,26 +106,23 @@ extern "C"
     const char* libStr = env->GetStringUTFChars(lib, nullptr);
     const char* funcStr = env->GetStringUTFChars(func, nullptr);
 
+    jlong result = 0;
     try
     {
-      f3d_java_context* ctx = new f3d_java_context(f3d::context::getSymbol(libStr, funcStr));
-      env->ReleaseStringUTFChars(lib, libStr);
-      env->ReleaseStringUTFChars(func, funcStr);
-      return reinterpret_cast<jlong>(ctx);
+      result =
+        reinterpret_cast<jlong>(new f3d_java_context(f3d::context::getSymbol(libStr, funcStr)));
     }
     catch (const f3d::context::loading_exception& e)
     {
-      env->ReleaseStringUTFChars(lib, libStr);
-      env->ReleaseStringUTFChars(func, funcStr);
       F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
     }
     catch (const f3d::context::symbol_exception& e)
     {
-      env->ReleaseStringUTFChars(lib, libStr);
-      env->ReleaseStringUTFChars(func, funcStr);
       F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
     }
-    return 0;
+    env->ReleaseStringUTFChars(lib, libStr);
+    env->ReleaseStringUTFChars(func, funcStr);
+    return result;
   }
 
   JNIEXPORT void JAVA_BIND(Context, delete)(JNIEnv*, jclass, jlong contextHandle)

--- a/java/F3DEngineBindings.cxx
+++ b/java/F3DEngineBindings.cxx
@@ -327,9 +327,7 @@ extern "C"
     }
     catch (const f3d::engine::plugin_exception& e)
     {
-      env->ReleaseStringUTFChars(str, plugin);
       F3DThrowJavaException(env, "app/f3d/F3D/Engine$PluginException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(str, plugin);
   }
@@ -348,9 +346,7 @@ extern "C"
     }
     catch (const f3d::engine::cache_exception& e)
     {
-      env->ReleaseStringUTFChars(path, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(path, str);
   }
@@ -602,10 +598,7 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, nameStr);
-      env->ReleaseStringUTFChars(value, valueStr);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
 
     env->ReleaseStringUTFChars(name, nameStr);

--- a/java/F3DEngineBindings.cxx
+++ b/java/F3DEngineBindings.cxx
@@ -9,34 +9,146 @@
 
 extern "C"
 {
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreate)(JNIEnv*, jclass, jboolean offscreen)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreate)(JNIEnv* env, jclass, jboolean offscreen)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::create(offscreen)));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::create(offscreen)));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateNone)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateNone)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createNone()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createNone()));
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateGLX)(JNIEnv*, jclass, jboolean offscreen)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateGLX)(JNIEnv* env, jclass, jboolean offscreen)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createGLX(offscreen)));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createGLX(offscreen)));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateWGL)(JNIEnv*, jclass, jboolean offscreen)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateWGL)(JNIEnv* env, jclass, jboolean offscreen)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createWGL(offscreen)));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createWGL(offscreen)));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateEGL)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateEGL)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createEGL()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createEGL()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateOSMesa)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateOSMesa)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createOSMesa()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createOSMesa()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
   JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternal)(
@@ -61,32 +173,144 @@ extern "C"
       return reinterpret_cast<f3d::context::fptr>(addr);
     };
 
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternal(func)));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternal(func)));
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternalGLX)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternalGLX)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternalGLX()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternalGLX()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternalWGL)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternalWGL)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternalWGL()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternalWGL()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternalCOCOA)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternalCOCOA)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternalCOCOA()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternalCOCOA()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternalEGL)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternalEGL)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternalEGL()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternalEGL()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
-  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternalOSMesa)(JNIEnv*, jclass)
+  JNIEXPORT jlong JAVA_BIND(Engine, nativeCreateExternalOSMesa)(JNIEnv* env, jclass)
   {
-    return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternalOSMesa()));
+    try
+    {
+      return reinterpret_cast<jlong>(new f3d::engine(f3d::engine::createExternalOSMesa()));
+    }
+    catch (const f3d::context::loading_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$LoadingException", e.what());
+    }
+    catch (const f3d::context::symbol_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
+    }
+    catch (const f3d::engine::no_window_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoWindowException", e.what());
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+    }
+    return 0;
   }
 
   JNIEXPORT void JAVA_BIND(Engine, nativeDestroy)(JNIEnv*, jclass, jlong ptr)
@@ -97,7 +321,16 @@ extern "C"
   JNIEXPORT void JAVA_BIND(Engine, loadPlugin)(JNIEnv* env, jclass, jstring str)
   {
     const char* plugin = env->GetStringUTFChars(str, nullptr);
-    f3d::engine::loadPlugin(plugin);
+    try
+    {
+      f3d::engine::loadPlugin(plugin);
+    }
+    catch (const f3d::engine::plugin_exception& e)
+    {
+      env->ReleaseStringUTFChars(str, plugin);
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$PluginException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(str, plugin);
   }
 
@@ -109,7 +342,16 @@ extern "C"
   JNIEXPORT void JAVA_BIND(Engine, setCachePath)(JNIEnv* env, jobject self, jstring path)
   {
     const char* str = env->GetStringUTFChars(path, nullptr);
-    GetEngine(env, self)->setCachePath(fs::path(str));
+    try
+    {
+      GetEngine(env, self)->setCachePath(fs::path(str));
+    }
+    catch (const f3d::engine::cache_exception& e)
+    {
+      env->ReleaseStringUTFChars(path, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(path, str);
   }
 
@@ -241,12 +483,20 @@ extern "C"
 
   JNIEXPORT jobject JAVA_BIND(Engine, getInteractor)(JNIEnv* env, jobject self)
   {
-    f3d::interactor& interactor = GetEngine(env, self)->getInteractor();
+    try
+    {
+      f3d::interactor& interactor = GetEngine(env, self)->getInteractor();
 
-    jclass interactorClass = env->FindClass("app/f3d/F3D/Interactor");
-    jmethodID constructor = env->GetMethodID(interactorClass, "<init>", "(J)V");
+      jclass interactorClass = env->FindClass("app/f3d/F3D/Interactor");
+      jmethodID constructor = env->GetMethodID(interactorClass, "<init>", "(J)V");
 
-    return env->NewObject(interactorClass, constructor, reinterpret_cast<jlong>(&interactor));
+      return env->NewObject(interactorClass, constructor, reinterpret_cast<jlong>(&interactor));
+    }
+    catch (const f3d::engine::no_interactor_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Engine$NoInteractorException", e.what());
+    }
+    return nullptr;
   }
 
   JNIEXPORT jobject JAVA_BIND(Engine, getPluginsList)(JNIEnv* env, jclass, jstring path)
@@ -354,9 +604,7 @@ extern "C"
     {
       env->ReleaseStringUTFChars(name, nameStr);
       env->ReleaseStringUTFChars(value, valueStr);
-
-      jclass exceptionClass = env->FindClass("java/lang/IllegalArgumentException");
-      env->ThrowNew(exceptionClass, e.what());
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
       return;
     }
 

--- a/java/F3DEngineBindings.cxx
+++ b/java/F3DEngineBindings.cxx
@@ -384,37 +384,34 @@ extern "C"
     JNIEnv* env, jclass, jstring content)
   {
     const char* str = env->GetStringUTFChars(content, nullptr);
+    jlong ptr = 0;
     try
     {
-      jlong ptr =
-        reinterpret_cast<jlong>(new f3d::engine::state(f3d::engine::state::fromString(str)));
-      env->ReleaseStringUTFChars(content, str);
-      return ptr;
+      ptr = reinterpret_cast<jlong>(new f3d::engine::state(f3d::engine::state::fromString(str)));
     }
     catch (const f3d::engine::statefile_exception& e)
     {
-      env->ReleaseStringUTFChars(content, str);
       env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
-      return 0;
     }
+    env->ReleaseStringUTFChars(content, str);
+    return ptr;
   }
 
   JNIEXPORT jlong JAVA_SCOPED_BIND(Engine, State, nativeFromFile)(JNIEnv* env, jclass, jstring path)
   {
     const char* str = env->GetStringUTFChars(path, nullptr);
+    jlong ptr = 0;
     try
     {
-      jlong ptr = reinterpret_cast<jlong>(
+      ptr = reinterpret_cast<jlong>(
         new f3d::engine::state(f3d::engine::state::fromFile(fs::path(str))));
-      env->ReleaseStringUTFChars(path, str);
-      return ptr;
     }
     catch (const f3d::engine::statefile_exception& e)
     {
-      env->ReleaseStringUTFChars(path, str);
       env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
-      return 0;
     }
+    env->ReleaseStringUTFChars(path, str);
+    return ptr;
   }
 
   JNIEXPORT jlong JAVA_SCOPED_BIND(Engine, State, nativeFromClipboard)(JNIEnv* env, jclass)
@@ -444,9 +441,7 @@ extern "C"
     }
     catch (const f3d::engine::statefile_exception& e)
     {
-      env->ReleaseStringUTFChars(path, str);
       env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
-      return;
     }
     env->ReleaseStringUTFChars(path, str);
   }

--- a/java/F3DException.java
+++ b/java/F3DException.java
@@ -1,0 +1,20 @@
+package app.f3d.F3D;
+
+/**
+ * Base class for all F3D Java exceptions.
+ * Mirrors the f3d::exception C++ hierarchy, allowing callers to
+ * catch any F3D error with a single catch block:
+ *
+ * <pre>{@code
+ * try {
+ *   engine.getScene().add("file.stl");
+ * } catch (F3DException e) {
+ *   // handles any f3d error
+ * }
+ * }</pre>
+ */
+public class F3DException extends RuntimeException {
+    public F3DException(String message) {
+        super(message);
+    }
+}

--- a/java/F3DImageBindings.cxx
+++ b/java/F3DImageBindings.cxx
@@ -265,18 +265,19 @@ extern "C"
     f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
 
     const char* keyStr = env->GetStringUTFChars(key, nullptr);
+    std::string value;
     try
     {
-      std::string value = img->getMetadata(keyStr);
-      env->ReleaseStringUTFChars(key, keyStr);
-      return env->NewStringUTF(value.c_str());
+      value = img->getMetadata(keyStr);
     }
     catch (const f3d::image::metadata_exception& e)
     {
-      env->ReleaseStringUTFChars(key, keyStr);
       F3DThrowJavaException(env, "app/f3d/F3D/Image$MetadataException", e.what());
+      env->ReleaseStringUTFChars(key, keyStr);
+      return nullptr;
     }
-    return nullptr;
+    env->ReleaseStringUTFChars(key, keyStr);
+    return env->NewStringUTF(value.c_str());
   }
 
   JNIEXPORT jobject JAVA_BIND(Image, allMetadata)(JNIEnv* env, jobject self)

--- a/java/F3DImageBindings.cxx
+++ b/java/F3DImageBindings.cxx
@@ -192,9 +192,7 @@ extern "C"
     }
     catch (const f3d::image::write_exception& e)
     {
-      env->ReleaseStringUTFChars(filePath, path);
       F3DThrowJavaException(env, "app/f3d/F3D/Image$WriteException", e.what());
-      return nullptr;
     }
 
     env->ReleaseStringUTFChars(filePath, path);

--- a/java/F3DImageBindings.cxx
+++ b/java/F3DImageBindings.cxx
@@ -14,9 +14,18 @@ extern "C"
   JNIEXPORT jlong JAVA_BIND(Image, nativeCreateFromFile)(JNIEnv* env, jclass, jstring filePath)
   {
     const char* path = env->GetStringUTFChars(filePath, nullptr);
-    f3d::image* img = new f3d::image(path);
-    env->ReleaseStringUTFChars(filePath, path);
-    return reinterpret_cast<jlong>(img);
+    try
+    {
+      f3d::image* img = new f3d::image(path);
+      env->ReleaseStringUTFChars(filePath, path);
+      return reinterpret_cast<jlong>(img);
+    }
+    catch (const f3d::image::read_exception& e)
+    {
+      env->ReleaseStringUTFChars(filePath, path);
+      F3DThrowJavaException(env, "app/f3d/F3D/Image$ReadException", e.what());
+    }
+    return 0;
   }
 
   JNIEXPORT jlong JAVA_BIND(Image, nativeCreate)(
@@ -177,7 +186,16 @@ extern "C"
     jint formatOrdinal = env->CallIntMethod(format, ordinalMethod);
 
     f3d::image::SaveFormat saveFormat = static_cast<f3d::image::SaveFormat>(formatOrdinal);
-    img->save(path, saveFormat);
+    try
+    {
+      img->save(path, saveFormat);
+    }
+    catch (const f3d::image::write_exception& e)
+    {
+      env->ReleaseStringUTFChars(filePath, path);
+      F3DThrowJavaException(env, "app/f3d/F3D/Image$WriteException", e.what());
+      return nullptr;
+    }
 
     env->ReleaseStringUTFChars(filePath, path);
     return self;
@@ -195,12 +213,20 @@ extern "C"
     jint formatOrdinal = env->CallIntMethod(format, ordinalMethod);
 
     f3d::image::SaveFormat saveFormat = static_cast<f3d::image::SaveFormat>(formatOrdinal);
-    std::vector<unsigned char> buffer = img->saveBuffer(saveFormat);
+    try
+    {
+      std::vector<unsigned char> buffer = img->saveBuffer(saveFormat);
 
-    jbyteArray result = env->NewByteArray(buffer.size());
-    env->SetByteArrayRegion(result, 0, buffer.size(), reinterpret_cast<jbyte*>(buffer.data()));
+      jbyteArray result = env->NewByteArray(buffer.size());
+      env->SetByteArrayRegion(result, 0, buffer.size(), reinterpret_cast<jbyte*>(buffer.data()));
 
-    return result;
+      return result;
+    }
+    catch (const f3d::image::write_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Image$WriteException", e.what());
+    }
+    return nullptr;
   }
 
   JNIEXPORT jstring JAVA_BIND(Image, toTerminalText)(JNIEnv* env, jobject self)
@@ -241,10 +267,18 @@ extern "C"
     f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
 
     const char* keyStr = env->GetStringUTFChars(key, nullptr);
-    std::string value = img->getMetadata(keyStr);
-    env->ReleaseStringUTFChars(key, keyStr);
-
-    return env->NewStringUTF(value.c_str());
+    try
+    {
+      std::string value = img->getMetadata(keyStr);
+      env->ReleaseStringUTFChars(key, keyStr);
+      return env->NewStringUTF(value.c_str());
+    }
+    catch (const f3d::image::metadata_exception& e)
+    {
+      env->ReleaseStringUTFChars(key, keyStr);
+      F3DThrowJavaException(env, "app/f3d/F3D/Image$MetadataException", e.what());
+    }
+    return nullptr;
   }
 
   JNIEXPORT jobject JAVA_BIND(Image, allMetadata)(JNIEnv* env, jobject self)

--- a/java/F3DImageBindings.cxx
+++ b/java/F3DImageBindings.cxx
@@ -14,18 +14,17 @@ extern "C"
   JNIEXPORT jlong JAVA_BIND(Image, nativeCreateFromFile)(JNIEnv* env, jclass, jstring filePath)
   {
     const char* path = env->GetStringUTFChars(filePath, nullptr);
+    jlong result = 0;
     try
     {
-      f3d::image* img = new f3d::image(path);
-      env->ReleaseStringUTFChars(filePath, path);
-      return reinterpret_cast<jlong>(img);
+      result = reinterpret_cast<jlong>(new f3d::image(path));
     }
     catch (const f3d::image::read_exception& e)
     {
-      env->ReleaseStringUTFChars(filePath, path);
       F3DThrowJavaException(env, "app/f3d/F3D/Image$ReadException", e.what());
     }
-    return 0;
+    env->ReleaseStringUTFChars(filePath, path);
+    return result;
   }
 
   JNIEXPORT jlong JAVA_BIND(Image, nativeCreate)(
@@ -273,11 +272,9 @@ extern "C"
     catch (const f3d::image::metadata_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Image$MetadataException", e.what());
-      env->ReleaseStringUTFChars(key, keyStr);
-      return nullptr;
     }
     env->ReleaseStringUTFChars(key, keyStr);
-    return env->NewStringUTF(value.c_str());
+    return env->ExceptionCheck() ? nullptr : env->NewStringUTF(value.c_str());
   }
 
   JNIEXPORT jobject JAVA_BIND(Image, allMetadata)(JNIEnv* env, jobject self)

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -168,7 +168,15 @@ extern "C"
       g_jvm->DetachCurrentThread();
     };
 
-    GetInteractor(env, self).addCommand(actionCpp, cppCallback);
+    try
+    {
+      GetInteractor(env, self).addCommand(actionCpp, cppCallback);
+    }
+    catch (const f3d::interactor::already_exists_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Interactor$AlreadyExistsException", e.what());
+      return nullptr;
+    }
     return self;
   }
 
@@ -198,9 +206,23 @@ extern "C"
     JNIEnv* env, jobject self, jstring command, jboolean keepComments)
   {
     const char* commandStr = env->GetStringUTFChars(command, nullptr);
-    bool result = GetInteractor(env, self).triggerCommand(commandStr, keepComments);
-    env->ReleaseStringUTFChars(command, commandStr);
-    return result;
+    try
+    {
+      bool result = GetInteractor(env, self).triggerCommand(commandStr, keepComments);
+      env->ReleaseStringUTFChars(command, commandStr);
+      return result;
+    }
+    catch (const f3d::interactor::command_runtime_exception& e)
+    {
+      env->ReleaseStringUTFChars(command, commandStr);
+      F3DThrowJavaException(env, "app/f3d/F3D/Interactor$CommandRuntimeException", e.what());
+    }
+    catch (const f3d::interactor::invalid_args_exception& e)
+    {
+      env->ReleaseStringUTFChars(command, commandStr);
+      F3DThrowJavaException(env, "app/f3d/F3D/Interactor$InvalidArgsException", e.what());
+    }
+    return false;
   }
 
   JNIEXPORT jobject JAVA_BIND(Interactor, initBindings)(JNIEnv* env, jobject self)
@@ -254,8 +276,16 @@ extern "C"
         break;
     }
 
-    GetInteractor(env, self).addBinding(
-      nativeBind, commandsVec, groupCpp, nullptr, nativeType, notify);
+    try
+    {
+      GetInteractor(env, self).addBinding(
+        nativeBind, commandsVec, groupCpp, nullptr, nativeType, notify);
+    }
+    catch (const f3d::interactor::already_exists_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Interactor$AlreadyExistsException", e.what());
+      return nullptr;
+    }
     return self;
   }
 
@@ -294,15 +324,31 @@ extern "C"
         break;
     }
 
-    GetInteractor(env, self).addBinding(
-      nativeBind, commandCpp, groupCpp, nullptr, nativeType, notify);
+    try
+    {
+      GetInteractor(env, self).addBinding(
+        nativeBind, commandCpp, groupCpp, nullptr, nativeType, notify);
+    }
+    catch (const f3d::interactor::already_exists_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Interactor$AlreadyExistsException", e.what());
+      return nullptr;
+    }
     return self;
   }
 
   JNIEXPORT jobject JAVA_BIND(Interactor, removeBinding)(JNIEnv* env, jobject self, jobject bind)
   {
     f3d::interaction_bind_t nativeBind = JavaBindToNative(env, bind);
-    GetInteractor(env, self).removeBinding(nativeBind);
+    try
+    {
+      GetInteractor(env, self).removeBinding(nativeBind);
+    }
+    catch (const f3d::interactor::does_not_exists_exception& e)
+    {
+      F3DThrowJavaException(env, "app/f3d/F3D/Interactor$DoesNotExistException", e.what());
+      return nullptr;
+    }
     return self;
   }
 

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -175,7 +175,6 @@ extern "C"
     catch (const f3d::interactor::already_exists_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Interactor$AlreadyExistsException", e.what());
-      return nullptr;
     }
     return self;
   }
@@ -284,7 +283,6 @@ extern "C"
     catch (const f3d::interactor::already_exists_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Interactor$AlreadyExistsException", e.what());
-      return nullptr;
     }
     return self;
   }
@@ -332,7 +330,6 @@ extern "C"
     catch (const f3d::interactor::already_exists_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Interactor$AlreadyExistsException", e.what());
-      return nullptr;
     }
     return self;
   }
@@ -347,7 +344,6 @@ extern "C"
     catch (const f3d::interactor::does_not_exists_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Interactor$DoesNotExistException", e.what());
-      return nullptr;
     }
     return self;
   }

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -205,23 +205,21 @@ extern "C"
     JNIEnv* env, jobject self, jstring command, jboolean keepComments)
   {
     const char* commandStr = env->GetStringUTFChars(command, nullptr);
+    bool result = false;
     try
     {
-      bool result = GetInteractor(env, self).triggerCommand(commandStr, keepComments);
-      env->ReleaseStringUTFChars(command, commandStr);
-      return result;
+      result = GetInteractor(env, self).triggerCommand(commandStr, keepComments);
     }
     catch (const f3d::interactor::command_runtime_exception& e)
     {
-      env->ReleaseStringUTFChars(command, commandStr);
       F3DThrowJavaException(env, "app/f3d/F3D/Interactor$CommandRuntimeException", e.what());
     }
     catch (const f3d::interactor::invalid_args_exception& e)
     {
-      env->ReleaseStringUTFChars(command, commandStr);
       F3DThrowJavaException(env, "app/f3d/F3D/Interactor$InvalidArgsException", e.what());
     }
-    return false;
+    env->ReleaseStringUTFChars(command, commandStr);
+    return result;
   }
 
   JNIEXPORT jobject JAVA_BIND(Interactor, initBindings)(JNIEnv* env, jobject self)

--- a/java/F3DJavaBindings.h
+++ b/java/F3DJavaBindings.h
@@ -17,6 +17,25 @@
 
 namespace fs = std::filesystem;
 
+/**
+ * Throw a Java exception of the given class name with the given message.
+ * Call this from a catch block, then immediately return from the JNI function
+ * so that the pending Java exception is delivered to the caller.
+ *
+ * className uses JNI slash-notation, e.g.
+ *   "app/f3d/F3D/Engine$NoInteractorException"
+ *   "java/lang/RuntimeException"
+ */
+inline void F3DThrowJavaException(JNIEnv* env, const char* className, const char* msg)
+{
+  jclass cls = env->FindClass(className);
+  if (cls)
+  {
+    env->ThrowNew(cls, msg);
+    env->DeleteLocalRef(cls);
+  }
+}
+
 // Helper function to get the f3d::engine pointer from a Java object
 inline f3d::engine* GetEngine(JNIEnv* env, jobject self)
 {

--- a/java/F3DOptionsBindings.cxx
+++ b/java/F3DOptionsBindings.cxx
@@ -6,6 +6,7 @@
 
 #include <cassert>
 #include <stdexcept>
+#include <variant>
 
 namespace
 {
@@ -21,14 +22,44 @@ extern "C"
     JNIEnv* env, jobject self, jstring name, jboolean value)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    GetOptionsFromEngine(env, self).set(str, static_cast<bool>(value));
+    try
+    {
+      GetOptionsFromEngine(env, self).set(str, static_cast<bool>(value));
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
+    catch (const f3d::options::incompatible_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, setAsInt)(JNIEnv* env, jobject self, jstring name, jint value)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    GetOptionsFromEngine(env, self).set(str, static_cast<int>(value));
+    try
+    {
+      GetOptionsFromEngine(env, self).set(str, static_cast<int>(value));
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
+    catch (const f3d::options::incompatible_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
@@ -36,7 +67,22 @@ extern "C"
     JNIEnv* env, jobject self, jstring name, jdouble value)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    GetOptionsFromEngine(env, self).set(str, static_cast<double>(value));
+    try
+    {
+      GetOptionsFromEngine(env, self).set(str, static_cast<double>(value));
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
+    catch (const f3d::options::incompatible_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
@@ -45,7 +91,24 @@ extern "C"
   {
     const char* nameStr = env->GetStringUTFChars(name, nullptr);
     const char* valueStr = env->GetStringUTFChars(value, nullptr);
-    GetOptionsFromEngine(env, self).set(nameStr, std::string(valueStr));
+    try
+    {
+      GetOptionsFromEngine(env, self).set(nameStr, std::string(valueStr));
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, nameStr);
+      env->ReleaseStringUTFChars(value, valueStr);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
+    catch (const f3d::options::incompatible_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, nameStr);
+      env->ReleaseStringUTFChars(value, valueStr);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, nameStr);
     env->ReleaseStringUTFChars(value, valueStr);
   }
@@ -56,11 +119,25 @@ extern "C"
     const char* str = env->GetStringUTFChars(name, nullptr);
     jsize len = env->GetArrayLength(values);
     double* arr = env->GetDoubleArrayElements(values, nullptr);
-
     std::vector<double> vec(arr, arr + len);
-    GetOptionsFromEngine(env, self).set(str, vec);
-
     env->ReleaseDoubleArrayElements(values, arr, 0);
+
+    try
+    {
+      GetOptionsFromEngine(env, self).set(str, vec);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
+    catch (const f3d::options::incompatible_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
@@ -70,53 +147,157 @@ extern "C"
     const char* str = env->GetStringUTFChars(name, nullptr);
     jsize len = env->GetArrayLength(values);
     int* arr = env->GetIntArrayElements(values, nullptr);
-
     std::vector<int> vec(arr, arr + len);
-    GetOptionsFromEngine(env, self).set(str, vec);
-
     env->ReleaseIntArrayElements(values, arr, 0);
+
+    try
+    {
+      GetOptionsFromEngine(env, self).set(str, vec);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
+    catch (const f3d::options::incompatible_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT jboolean JAVA_BIND(Options, getAsBool)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    bool value = std::get<bool>(GetOptionsFromEngine(env, self).get(str));
-    env->ReleaseStringUTFChars(name, str);
-    return value;
+    try
+    {
+      bool value = std::get<bool>(GetOptionsFromEngine(env, self).get(str));
+      env->ReleaseStringUTFChars(name, str);
+      return value;
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    catch (const f3d::options::no_value_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
+    }
+    catch (const std::bad_variant_access& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+    }
+    return false;
   }
 
   JNIEXPORT jint JAVA_BIND(Options, getAsInt)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    int value = std::get<int>(GetOptionsFromEngine(env, self).get(str));
-    env->ReleaseStringUTFChars(name, str);
-    return value;
+    try
+    {
+      int value = std::get<int>(GetOptionsFromEngine(env, self).get(str));
+      env->ReleaseStringUTFChars(name, str);
+      return value;
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    catch (const f3d::options::no_value_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
+    }
+    catch (const std::bad_variant_access& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+    }
+    return 0;
   }
 
   JNIEXPORT jdouble JAVA_BIND(Options, getAsDouble)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    double value = std::get<double>(GetOptionsFromEngine(env, self).get(str));
-    env->ReleaseStringUTFChars(name, str);
-    return value;
+    try
+    {
+      double value = std::get<double>(GetOptionsFromEngine(env, self).get(str));
+      env->ReleaseStringUTFChars(name, str);
+      return value;
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    catch (const f3d::options::no_value_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
+    }
+    catch (const std::bad_variant_access& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+    }
+    return 0.0;
   }
 
   JNIEXPORT jstring JAVA_BIND(Options, getAsString)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    std::string value = std::get<std::string>(GetOptionsFromEngine(env, self).get(str));
-    env->ReleaseStringUTFChars(name, str);
-    return env->NewStringUTF(value.c_str());
+    try
+    {
+      std::string value = std::get<std::string>(GetOptionsFromEngine(env, self).get(str));
+      env->ReleaseStringUTFChars(name, str);
+      return env->NewStringUTF(value.c_str());
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    catch (const f3d::options::no_value_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
+    }
+    catch (const std::bad_variant_access& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+    }
+    return nullptr;
   }
 
   JNIEXPORT jstring JAVA_BIND(Options, getAsStringRepresentation)(
     JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    std::string value = GetOptionsFromEngine(env, self).getAsString(str);
-    env->ReleaseStringUTFChars(name, str);
-    return env->NewStringUTF(value.c_str());
+    try
+    {
+      std::string value = GetOptionsFromEngine(env, self).getAsString(str);
+      env->ReleaseStringUTFChars(name, str);
+      return env->NewStringUTF(value.c_str());
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    catch (const f3d::options::no_value_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
+    }
+    return nullptr;
   }
 
   JNIEXPORT void JAVA_BIND(Options, setAsStringRepresentation)(
@@ -124,7 +305,24 @@ extern "C"
   {
     const char* nameStr = env->GetStringUTFChars(name, nullptr);
     const char* valueStr = env->GetStringUTFChars(str, nullptr);
-    GetOptionsFromEngine(env, self).setAsString(nameStr, valueStr);
+    try
+    {
+      GetOptionsFromEngine(env, self).setAsString(nameStr, valueStr);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, nameStr);
+      env->ReleaseStringUTFChars(str, valueStr);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
+    catch (const f3d::options::parsing_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, nameStr);
+      env->ReleaseStringUTFChars(str, valueStr);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$ParsingException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, nameStr);
     env->ReleaseStringUTFChars(str, valueStr);
   }
@@ -133,30 +331,83 @@ extern "C"
     JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    std::vector<double> vec =
-      std::get<std::vector<double>>(GetOptionsFromEngine(env, self).get(str));
-    env->ReleaseStringUTFChars(name, str);
+    try
+    {
+      std::vector<double> vec =
+        std::get<std::vector<double>>(GetOptionsFromEngine(env, self).get(str));
+      env->ReleaseStringUTFChars(name, str);
 
-    jdoubleArray result = env->NewDoubleArray(vec.size());
-    env->SetDoubleArrayRegion(result, 0, vec.size(), vec.data());
-    return result;
+      jdoubleArray result = env->NewDoubleArray(vec.size());
+      env->SetDoubleArrayRegion(result, 0, vec.size(), vec.data());
+      return result;
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    catch (const f3d::options::no_value_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
+    }
+    catch (const std::bad_variant_access& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+    }
+    return nullptr;
   }
 
   JNIEXPORT jintArray JAVA_BIND(Options, getAsIntVector)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    std::vector<int> vec = std::get<std::vector<int>>(GetOptionsFromEngine(env, self).get(str));
-    env->ReleaseStringUTFChars(name, str);
+    try
+    {
+      std::vector<int> vec = std::get<std::vector<int>>(GetOptionsFromEngine(env, self).get(str));
+      env->ReleaseStringUTFChars(name, str);
 
-    jintArray result = env->NewIntArray(vec.size());
-    env->SetIntArrayRegion(result, 0, vec.size(), vec.data());
-    return result;
+      jintArray result = env->NewIntArray(vec.size());
+      env->SetIntArrayRegion(result, 0, vec.size(), vec.data());
+      return result;
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    catch (const f3d::options::no_value_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
+    }
+    catch (const std::bad_variant_access& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+    }
+    return nullptr;
   }
 
   JNIEXPORT void JAVA_BIND(Options, toggle)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    GetOptionsFromEngine(env, self).toggle(str);
+    try
+    {
+      GetOptionsFromEngine(env, self).toggle(str);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
+    catch (const f3d::options::incompatible_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
@@ -168,18 +419,36 @@ extern "C"
     jlong otherPtr = env->GetLongField(other, fid);
 
     const char* str = env->GetStringUTFChars(name, nullptr);
-    bool result = GetOptionsFromEngine(env, self).isSame(
-      reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str);
-    env->ReleaseStringUTFChars(name, str);
-    return result;
+    try
+    {
+      bool result = GetOptionsFromEngine(env, self).isSame(
+        reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str);
+      env->ReleaseStringUTFChars(name, str);
+      return result;
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    return false;
   }
 
   JNIEXPORT jboolean JAVA_BIND(Options, hasValue)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    bool result = GetOptionsFromEngine(env, self).hasValue(str);
-    env->ReleaseStringUTFChars(name, str);
-    return result;
+    try
+    {
+      bool result = GetOptionsFromEngine(env, self).hasValue(str);
+      env->ReleaseStringUTFChars(name, str);
+      return result;
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    return false;
   }
 
   JNIEXPORT void JAVA_BIND(Options, copy)(JNIEnv* env, jobject self, jobject other, jstring name)
@@ -189,8 +458,17 @@ extern "C"
     jlong otherPtr = env->GetLongField(other, fid);
 
     const char* str = env->GetStringUTFChars(name, nullptr);
-    GetOptionsFromEngine(env, self).copy(
-      reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str);
+    try
+    {
+      GetOptionsFromEngine(env, self).copy(
+        reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
@@ -226,119 +504,194 @@ extern "C"
   JNIEXPORT jboolean JAVA_BIND(Options, isOptional)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    bool result = GetOptionsFromEngine(env, self).isOptional(str);
-    env->ReleaseStringUTFChars(name, str);
-    return result;
+    try
+    {
+      bool result = GetOptionsFromEngine(env, self).isOptional(str);
+      env->ReleaseStringUTFChars(name, str);
+      return result;
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    return false;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getType)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    f3d::options::option_type type = GetOptionsFromEngine(env, self).getType(str);
-    env->ReleaseStringUTFChars(name, str);
-
-    const char* enumName = nullptr;
-    switch (type)
+    try
     {
-      case f3d::options::option_type::BOOL:
-        enumName = "BOOL";
-        break;
-      case f3d::options::option_type::INT:
-        enumName = "INT";
-        break;
-      case f3d::options::option_type::DOUBLE:
-        enumName = "DOUBLE";
-        break;
-      case f3d::options::option_type::RATIO:
-        enumName = "RATIO";
-        break;
-      case f3d::options::option_type::STRING:
-        enumName = "STRING";
-        break;
-      case f3d::options::option_type::PATH:
-        enumName = "PATH";
-        break;
-      case f3d::options::option_type::COLOR:
-        enumName = "COLOR";
-        break;
-      case f3d::options::option_type::DIRECTION:
-        enumName = "DIRECTION";
-        break;
-      case f3d::options::option_type::COLORMAP:
-        enumName = "COLORMAP";
-        break;
-      case f3d::options::option_type::TRANSFORM2D:
-        enumName = "TRANSFORM2D";
-        break;
-      case f3d::options::option_type::DOUBLE_VECTOR:
-        enumName = "DOUBLE_VECTOR";
-        break;
-      case f3d::options::option_type::INT_VECTOR:
-        enumName = "INT_VECTOR";
-        break;
-      default:
-        // Unreachable
-        assert(false);
-    }
+      f3d::options::option_type type = GetOptionsFromEngine(env, self).getType(str);
+      env->ReleaseStringUTFChars(name, str);
 
-    jclass typeClass = env->FindClass("app/f3d/F3D/Options$OptionType");
-    jfieldID fid = env->GetStaticFieldID(typeClass, enumName, "Lapp/f3d/F3D/Options$OptionType;");
-    return env->GetStaticObjectField(typeClass, fid);
+      const char* enumName = nullptr;
+      switch (type)
+      {
+        case f3d::options::option_type::BOOL:
+          enumName = "BOOL";
+          break;
+        case f3d::options::option_type::INT:
+          enumName = "INT";
+          break;
+        case f3d::options::option_type::DOUBLE:
+          enumName = "DOUBLE";
+          break;
+        case f3d::options::option_type::RATIO:
+          enumName = "RATIO";
+          break;
+        case f3d::options::option_type::STRING:
+          enumName = "STRING";
+          break;
+        case f3d::options::option_type::PATH:
+          enumName = "PATH";
+          break;
+        case f3d::options::option_type::COLOR:
+          enumName = "COLOR";
+          break;
+        case f3d::options::option_type::DIRECTION:
+          enumName = "DIRECTION";
+          break;
+        case f3d::options::option_type::COLORMAP:
+          enumName = "COLORMAP";
+          break;
+        case f3d::options::option_type::TRANSFORM2D:
+          enumName = "TRANSFORM2D";
+          break;
+        case f3d::options::option_type::DOUBLE_VECTOR:
+          enumName = "DOUBLE_VECTOR";
+          break;
+        case f3d::options::option_type::INT_VECTOR:
+          enumName = "INT_VECTOR";
+          break;
+        default:
+          // Unreachable
+          assert(false);
+      }
+
+      jclass typeClass = env->FindClass("app/f3d/F3D/Options$OptionType");
+      jfieldID fid = env->GetStaticFieldID(typeClass, enumName, "Lapp/f3d/F3D/Options$OptionType;");
+      return env->GetStaticObjectField(typeClass, fid);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    return nullptr;
   }
 
   JNIEXPORT void JAVA_BIND(Options, reset)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    GetOptionsFromEngine(env, self).reset(str);
+    try
+    {
+      GetOptionsFromEngine(env, self).reset(str);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, removeValue)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    GetOptionsFromEngine(env, self).removeValue(str);
+    try
+    {
+      GetOptionsFromEngine(env, self).removeValue(str);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
+    catch (const f3d::options::incompatible_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT jboolean JAVA_BIND(Options, hasDomain)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    bool result = GetOptionsFromEngine(env, self).hasDomain(str);
-    env->ReleaseStringUTFChars(name, str);
-    return result;
+    try
+    {
+      bool result = GetOptionsFromEngine(env, self).hasDomain(str);
+      env->ReleaseStringUTFChars(name, str);
+      return result;
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    return false;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getDomainStyle)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    f3d::options::domain_style ds = GetOptionsFromEngine(env, self).getDomainStyle(str);
-    env->ReleaseStringUTFChars(name, str);
-
-    jclass enumClass = env->FindClass("app/f3d/F3D/Options$DomainStyle");
-    jfieldID fieldID;
-
-    switch (ds)
+    try
     {
-      case f3d::options::domain_style::RANGE:
-        fieldID = env->GetStaticFieldID(enumClass, "RANGE", "Lapp/f3d/F3D/Options$DomainStyle;");
-        break;
-      case f3d::options::domain_style::ENUM:
-        fieldID = env->GetStaticFieldID(enumClass, "ENUM", "Lapp/f3d/F3D/Options$DomainStyle;");
-        break;
-      default:
-      case f3d::options::domain_style::INDEX:
-        fieldID = env->GetStaticFieldID(enumClass, "INDEX", "Lapp/f3d/F3D/Options$DomainStyle;");
-        break;
+      f3d::options::domain_style ds = GetOptionsFromEngine(env, self).getDomainStyle(str);
+      env->ReleaseStringUTFChars(name, str);
+
+      jclass enumClass = env->FindClass("app/f3d/F3D/Options$DomainStyle");
+      jfieldID fieldID;
+
+      switch (ds)
+      {
+        case f3d::options::domain_style::RANGE:
+          fieldID = env->GetStaticFieldID(enumClass, "RANGE", "Lapp/f3d/F3D/Options$DomainStyle;");
+          break;
+        case f3d::options::domain_style::ENUM:
+          fieldID = env->GetStaticFieldID(enumClass, "ENUM", "Lapp/f3d/F3D/Options$DomainStyle;");
+          break;
+        default:
+        case f3d::options::domain_style::INDEX:
+          fieldID = env->GetStaticFieldID(enumClass, "INDEX", "Lapp/f3d/F3D/Options$DomainStyle;");
+          break;
+      }
+      return env->GetStaticObjectField(enumClass, fieldID);
     }
-    return env->GetStaticObjectField(enumClass, fieldID);
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    return nullptr;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getEnumDomain)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    jobject enumeration = CreateStringList(env, GetOptionsFromEngine(env, self).getEnumDomain(str));
-    env->ReleaseStringUTFChars(name, str);
-    return enumeration;
+    try
+    {
+      jobject enumeration =
+        CreateStringList(env, GetOptionsFromEngine(env, self).getEnumDomain(str));
+      env->ReleaseStringUTFChars(name, str);
+      return enumeration;
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+    }
+    catch (const f3d::options::incompatible_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
+    }
+    return nullptr;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getRangeDomainAsDouble)(
@@ -416,21 +769,48 @@ extern "C"
   JNIEXPORT void JAVA_BIND(Options, increase)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    GetOptionsFromEngine(env, self).increase(str);
+    try
+    {
+      GetOptionsFromEngine(env, self).increase(str);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, decrease)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    GetOptionsFromEngine(env, self).decrease(str);
+    try
+    {
+      GetOptionsFromEngine(env, self).decrease(str);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, cycle)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
-    GetOptionsFromEngine(env, self).cycle(str);
+    try
+    {
+      GetOptionsFromEngine(env, self).cycle(str);
+    }
+    catch (const f3d::options::inexistent_exception& e)
+    {
+      env->ReleaseStringUTFChars(name, str);
+      F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
+      return;
+    }
     env->ReleaseStringUTFChars(name, str);
   }
 }

--- a/java/F3DOptionsBindings.cxx
+++ b/java/F3DOptionsBindings.cxx
@@ -28,15 +28,11 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     catch (const f3d::options::incompatible_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -50,15 +46,11 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     catch (const f3d::options::incompatible_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -73,15 +65,11 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     catch (const f3d::options::incompatible_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -97,17 +85,11 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, nameStr);
-      env->ReleaseStringUTFChars(value, valueStr);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     catch (const f3d::options::incompatible_exception& e)
     {
-      env->ReleaseStringUTFChars(name, nameStr);
-      env->ReleaseStringUTFChars(value, valueStr);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, nameStr);
     env->ReleaseStringUTFChars(value, valueStr);
@@ -128,15 +110,11 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     catch (const f3d::options::incompatible_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -156,15 +134,11 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     catch (const f3d::options::incompatible_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -311,17 +285,11 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, nameStr);
-      env->ReleaseStringUTFChars(str, valueStr);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     catch (const f3d::options::parsing_exception& e)
     {
-      env->ReleaseStringUTFChars(name, nameStr);
-      env->ReleaseStringUTFChars(str, valueStr);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$ParsingException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, nameStr);
     env->ReleaseStringUTFChars(str, valueStr);
@@ -398,15 +366,11 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     catch (const f3d::options::incompatible_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -465,9 +429,7 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -591,9 +553,7 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -607,15 +567,11 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     catch (const f3d::options::incompatible_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -775,9 +731,7 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -791,9 +745,7 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }
@@ -807,9 +759,7 @@ extern "C"
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
-      return;
     }
     env->ReleaseStringUTFChars(name, str);
   }

--- a/java/F3DOptionsBindings.cxx
+++ b/java/F3DOptionsBindings.cxx
@@ -146,132 +146,118 @@ extern "C"
   JNIEXPORT jboolean JAVA_BIND(Options, getAsBool)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    bool value = false;
     try
     {
-      bool value = std::get<bool>(GetOptionsFromEngine(env, self).get(str));
-      env->ReleaseStringUTFChars(name, str);
-      return value;
+      value = std::get<bool>(GetOptionsFromEngine(env, self).get(str));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
     catch (const f3d::options::no_value_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
     }
     catch (const std::bad_variant_access& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    return false;
+    env->ReleaseStringUTFChars(name, str);
+    return value;
   }
 
   JNIEXPORT jint JAVA_BIND(Options, getAsInt)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    int value = 0;
     try
     {
-      int value = std::get<int>(GetOptionsFromEngine(env, self).get(str));
-      env->ReleaseStringUTFChars(name, str);
-      return value;
+      value = std::get<int>(GetOptionsFromEngine(env, self).get(str));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
     catch (const f3d::options::no_value_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
     }
     catch (const std::bad_variant_access& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    return 0;
+    env->ReleaseStringUTFChars(name, str);
+    return value;
   }
 
   JNIEXPORT jdouble JAVA_BIND(Options, getAsDouble)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    double value = 0.0;
     try
     {
-      double value = std::get<double>(GetOptionsFromEngine(env, self).get(str));
-      env->ReleaseStringUTFChars(name, str);
-      return value;
+      value = std::get<double>(GetOptionsFromEngine(env, self).get(str));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
     catch (const f3d::options::no_value_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
     }
     catch (const std::bad_variant_access& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    return 0.0;
+    env->ReleaseStringUTFChars(name, str);
+    return value;
   }
 
   JNIEXPORT jstring JAVA_BIND(Options, getAsString)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    std::string value;
     try
     {
-      std::string value = std::get<std::string>(GetOptionsFromEngine(env, self).get(str));
-      env->ReleaseStringUTFChars(name, str);
-      return env->NewStringUTF(value.c_str());
+      value = std::get<std::string>(GetOptionsFromEngine(env, self).get(str));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
     catch (const f3d::options::no_value_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
     }
     catch (const std::bad_variant_access& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    return nullptr;
+    env->ReleaseStringUTFChars(name, str);
+    return env->ExceptionCheck() ? nullptr : env->NewStringUTF(value.c_str());
   }
 
   JNIEXPORT jstring JAVA_BIND(Options, getAsStringRepresentation)(
     JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    std::string value;
     try
     {
-      std::string value = GetOptionsFromEngine(env, self).getAsString(str);
-      env->ReleaseStringUTFChars(name, str);
-      return env->NewStringUTF(value.c_str());
+      value = GetOptionsFromEngine(env, self).getAsString(str);
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
     catch (const f3d::options::no_value_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
     }
-    return nullptr;
+    env->ReleaseStringUTFChars(name, str);
+    return env->ExceptionCheck() ? nullptr : env->NewStringUTF(value.c_str());
   }
 
   JNIEXPORT void JAVA_BIND(Options, setAsStringRepresentation)(
@@ -299,62 +285,54 @@ extern "C"
     JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    jdoubleArray result = nullptr;
     try
     {
       std::vector<double> vec =
         std::get<std::vector<double>>(GetOptionsFromEngine(env, self).get(str));
-      env->ReleaseStringUTFChars(name, str);
-
-      jdoubleArray result = env->NewDoubleArray(vec.size());
+      result = env->NewDoubleArray(vec.size());
       env->SetDoubleArrayRegion(result, 0, vec.size(), vec.data());
-      return result;
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
     catch (const f3d::options::no_value_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
     }
     catch (const std::bad_variant_access& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    return nullptr;
+    env->ReleaseStringUTFChars(name, str);
+    return result;
   }
 
   JNIEXPORT jintArray JAVA_BIND(Options, getAsIntVector)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    jintArray result = nullptr;
     try
     {
       std::vector<int> vec = std::get<std::vector<int>>(GetOptionsFromEngine(env, self).get(str));
-      env->ReleaseStringUTFChars(name, str);
-
-      jintArray result = env->NewIntArray(vec.size());
+      result = env->NewIntArray(vec.size());
       env->SetIntArrayRegion(result, 0, vec.size(), vec.data());
-      return result;
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
     catch (const f3d::options::no_value_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
     }
     catch (const std::bad_variant_access& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    return nullptr;
+    env->ReleaseStringUTFChars(name, str);
+    return result;
   }
 
   JNIEXPORT void JAVA_BIND(Options, toggle)(JNIEnv* env, jobject self, jstring name)
@@ -383,36 +361,34 @@ extern "C"
     jlong otherPtr = env->GetLongField(other, fid);
 
     const char* str = env->GetStringUTFChars(name, nullptr);
+    bool result = false;
     try
     {
-      bool result = GetOptionsFromEngine(env, self).isSame(
+      result = GetOptionsFromEngine(env, self).isSame(
         reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str);
-      env->ReleaseStringUTFChars(name, str);
-      return result;
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    return false;
+    env->ReleaseStringUTFChars(name, str);
+    return result;
   }
 
   JNIEXPORT jboolean JAVA_BIND(Options, hasValue)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    bool result = false;
     try
     {
-      bool result = GetOptionsFromEngine(env, self).hasValue(str);
-      env->ReleaseStringUTFChars(name, str);
-      return result;
+      result = GetOptionsFromEngine(env, self).hasValue(str);
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    return false;
+    env->ReleaseStringUTFChars(name, str);
+    return result;
   }
 
   JNIEXPORT void JAVA_BIND(Options, copy)(JNIEnv* env, jobject self, jobject other, jstring name)
@@ -466,27 +442,26 @@ extern "C"
   JNIEXPORT jboolean JAVA_BIND(Options, isOptional)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    bool result = false;
     try
     {
-      bool result = GetOptionsFromEngine(env, self).isOptional(str);
-      env->ReleaseStringUTFChars(name, str);
-      return result;
+      result = GetOptionsFromEngine(env, self).isOptional(str);
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    return false;
+    env->ReleaseStringUTFChars(name, str);
+    return result;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getType)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    jobject result = nullptr;
     try
     {
       f3d::options::option_type type = GetOptionsFromEngine(env, self).getType(str);
-      env->ReleaseStringUTFChars(name, str);
 
       const char* enumName = nullptr;
       switch (type)
@@ -534,14 +509,14 @@ extern "C"
 
       jclass typeClass = env->FindClass("app/f3d/F3D/Options$OptionType");
       jfieldID fid = env->GetStaticFieldID(typeClass, enumName, "Lapp/f3d/F3D/Options$OptionType;");
-      return env->GetStaticObjectField(typeClass, fid);
+      result = env->GetStaticObjectField(typeClass, fid);
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    return nullptr;
+    env->ReleaseStringUTFChars(name, str);
+    return result;
   }
 
   JNIEXPORT void JAVA_BIND(Options, reset)(JNIEnv* env, jobject self, jstring name)
@@ -579,27 +554,26 @@ extern "C"
   JNIEXPORT jboolean JAVA_BIND(Options, hasDomain)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    bool result = false;
     try
     {
-      bool result = GetOptionsFromEngine(env, self).hasDomain(str);
-      env->ReleaseStringUTFChars(name, str);
-      return result;
+      result = GetOptionsFromEngine(env, self).hasDomain(str);
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    return false;
+    env->ReleaseStringUTFChars(name, str);
+    return result;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getDomainStyle)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    jobject result = nullptr;
     try
     {
       f3d::options::domain_style ds = GetOptionsFromEngine(env, self).getDomainStyle(str);
-      env->ReleaseStringUTFChars(name, str);
 
       jclass enumClass = env->FindClass("app/f3d/F3D/Options$DomainStyle");
       jfieldID fieldID;
@@ -617,37 +591,34 @@ extern "C"
           fieldID = env->GetStaticFieldID(enumClass, "INDEX", "Lapp/f3d/F3D/Options$DomainStyle;");
           break;
       }
-      return env->GetStaticObjectField(enumClass, fieldID);
+      result = env->GetStaticObjectField(enumClass, fieldID);
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    return nullptr;
+    env->ReleaseStringUTFChars(name, str);
+    return result;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getEnumDomain)(JNIEnv* env, jobject self, jstring name)
   {
     const char* str = env->GetStringUTFChars(name, nullptr);
+    jobject result = nullptr;
     try
     {
-      jobject enumeration =
-        CreateStringList(env, GetOptionsFromEngine(env, self).getEnumDomain(str));
-      env->ReleaseStringUTFChars(name, str);
-      return enumeration;
+      result = CreateStringList(env, GetOptionsFromEngine(env, self).getEnumDomain(str));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
     catch (const f3d::options::incompatible_exception& e)
     {
-      env->ReleaseStringUTFChars(name, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    return nullptr;
+    env->ReleaseStringUTFChars(name, str);
+    return result;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getRangeDomainAsDouble)(

--- a/java/F3DSceneBindings.cxx
+++ b/java/F3DSceneBindings.cxx
@@ -206,9 +206,7 @@ extern "C"
     }
     catch (const f3d::scene::load_failure_exception& e)
     {
-      env->ReleaseStringUTFChars(path, str);
       F3DThrowJavaException(env, "app/f3d/F3D/Scene$LoadFailureException", e.what());
-      return nullptr;
     }
     env->ReleaseStringUTFChars(path, str);
     return self;
@@ -229,7 +227,6 @@ extern "C"
     catch (const f3d::scene::load_failure_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Scene$LoadFailureException", e.what());
-      return nullptr;
     }
     return self;
   }
@@ -249,7 +246,6 @@ extern "C"
     catch (const f3d::scene::load_failure_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Scene$LoadFailureException", e.what());
-      return nullptr;
     }
     return self;
   }
@@ -271,7 +267,6 @@ extern "C"
     catch (const f3d::scene::load_failure_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Scene$LoadFailureException", e.what());
-      return nullptr;
     }
     env->ReleaseByteArrayElements(buffer, bufferData, 0);
     return self;
@@ -337,7 +332,6 @@ extern "C"
     catch (const f3d::scene::light_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Scene$LightException", e.what());
-      return nullptr;
     }
     return self;
   }
@@ -351,7 +345,6 @@ extern "C"
     catch (const f3d::scene::light_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Scene$LightException", e.what());
-      return nullptr;
     }
     return self;
   }

--- a/java/F3DSceneBindings.cxx
+++ b/java/F3DSceneBindings.cxx
@@ -204,11 +204,10 @@ extern "C"
     {
       GetEngine(env, self)->getScene().add(str);
     }
-    catch (const std::exception& e)
+    catch (const f3d::scene::load_failure_exception& e)
     {
       env->ReleaseStringUTFChars(path, str);
-      jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
-      env->ThrowNew(exceptionClass, e.what());
+      F3DThrowJavaException(env, "app/f3d/F3D/Scene$LoadFailureException", e.what());
       return nullptr;
     }
     env->ReleaseStringUTFChars(path, str);
@@ -227,10 +226,9 @@ extern "C"
     {
       GetEngine(env, self)->getScene().add(vec);
     }
-    catch (const std::exception& e)
+    catch (const f3d::scene::load_failure_exception& e)
     {
-      jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
-      env->ThrowNew(exceptionClass, e.what());
+      F3DThrowJavaException(env, "app/f3d/F3D/Scene$LoadFailureException", e.what());
       return nullptr;
     }
     return self;
@@ -248,10 +246,9 @@ extern "C"
     {
       GetEngine(env, self)->getScene().add(cppMesh);
     }
-    catch (const std::exception& e)
+    catch (const f3d::scene::load_failure_exception& e)
     {
-      jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
-      env->ThrowNew(exceptionClass, e.what());
+      F3DThrowJavaException(env, "app/f3d/F3D/Scene$LoadFailureException", e.what());
       return nullptr;
     }
     return self;
@@ -271,10 +268,9 @@ extern "C"
       GetEngine(env, self)->getScene().add(
         reinterpret_cast<std::byte*>(bufferData), static_cast<size_t>(bufferLen));
     }
-    catch (const std::exception& e)
+    catch (const f3d::scene::load_failure_exception& e)
     {
-      jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
-      env->ThrowNew(exceptionClass, e.what());
+      F3DThrowJavaException(env, "app/f3d/F3D/Scene$LoadFailureException", e.what());
       return nullptr;
     }
     env->ReleaseByteArrayElements(buffer, bufferData, 0);
@@ -299,10 +295,9 @@ extern "C"
     {
       return GetEngine(env, self)->getScene().addLight(cppLightState);
     }
-    catch (const std::exception& e)
+    catch (const f3d::scene::light_exception& e)
     {
-      jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
-      env->ThrowNew(exceptionClass, e.what());
+      F3DThrowJavaException(env, "app/f3d/F3D/Scene$LightException", e.what());
       return -1;
     }
   }
@@ -319,10 +314,9 @@ extern "C"
       f3d::light_state_t cppLightState = GetEngine(env, self)->getScene().getLight(index);
       return CppLightStateToJavaLightState(env, cppLightState);
     }
-    catch (const std::exception& e)
+    catch (const f3d::scene::light_exception& e)
     {
-      jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
-      env->ThrowNew(exceptionClass, e.what());
+      F3DThrowJavaException(env, "app/f3d/F3D/Scene$LightException", e.what());
       return nullptr;
     }
   }
@@ -340,10 +334,9 @@ extern "C"
     {
       GetEngine(env, self)->getScene().updateLight(index, cppLightState);
     }
-    catch (const std::exception& e)
+    catch (const f3d::scene::light_exception& e)
     {
-      jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
-      env->ThrowNew(exceptionClass, e.what());
+      F3DThrowJavaException(env, "app/f3d/F3D/Scene$LightException", e.what());
       return nullptr;
     }
     return self;
@@ -355,10 +348,9 @@ extern "C"
     {
       GetEngine(env, self)->getScene().removeLight(index);
     }
-    catch (const std::exception& e)
+    catch (const f3d::scene::light_exception& e)
     {
-      jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
-      env->ThrowNew(exceptionClass, e.what());
+      F3DThrowJavaException(env, "app/f3d/F3D/Scene$LightException", e.what());
       return nullptr;
     }
     return self;

--- a/java/F3DUtilsBindings.cxx
+++ b/java/F3DUtilsBindings.cxx
@@ -33,20 +33,18 @@ extern "C"
     }
 
     const char* strChars = env->GetStringUTFChars(str, nullptr);
-
+    jobject result = nullptr;
     try
     {
-      std::vector<std::string> tokens = f3d::utils::tokenize(strChars, keepComments != 0);
-      env->ReleaseStringUTFChars(str, strChars);
-      return CreateStringList(env, tokens);
+      result = CreateStringList(env, f3d::utils::tokenize(strChars, keepComments != 0));
     }
     catch (const std::exception& e)
     {
-      env->ReleaseStringUTFChars(str, strChars);
       jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
       env->ThrowNew(exceptionClass, e.what());
-      return nullptr;
     }
+    env->ReleaseStringUTFChars(str, strChars);
+    return result;
   }
 
   JNIEXPORT jstring JAVA_BIND(Utils, collapsePath)(
@@ -82,20 +80,18 @@ extern "C"
     }
 
     const char* globChars = env->GetStringUTFChars(glob, nullptr);
-
+    std::string result;
     try
     {
-      std::string result = f3d::utils::globToRegex(globChars, static_cast<char>(pathSeparator));
-      env->ReleaseStringUTFChars(glob, globChars);
-      return env->NewStringUTF(result.c_str());
+      result = f3d::utils::globToRegex(globChars, static_cast<char>(pathSeparator));
     }
     catch (const std::exception& e)
     {
-      env->ReleaseStringUTFChars(glob, globChars);
       jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
       env->ThrowNew(exceptionClass, e.what());
-      return nullptr;
     }
+    env->ReleaseStringUTFChars(glob, globChars);
+    return env->ExceptionCheck() ? nullptr : env->NewStringUTF(result.c_str());
   }
 
   JNIEXPORT jstring JAVA_BIND(Utils, getEnv)(JNIEnv* env, jclass, jstring envVar)

--- a/java/Image.java
+++ b/java/Image.java
@@ -8,6 +8,21 @@ public class Image {
         System.loadLibrary("f3d-java");
     }
 
+    /** Thrown when an image file cannot be read (unsupported format, file not found, etc.). */
+    public static class ReadException extends F3DException {
+        public ReadException(String message) { super(message); }
+    }
+
+    /** Thrown when an image cannot be written/saved. */
+    public static class WriteException extends F3DException {
+        public WriteException(String message) { super(message); }
+    }
+
+    /** Thrown when a metadata key does not exist on the image. */
+    public static class MetadataException extends F3DException {
+        public MetadataException(String message) { super(message); }
+    }
+
     public enum SaveFormat {
         PNG,
         JPG,

--- a/java/Interactor.java
+++ b/java/Interactor.java
@@ -4,6 +4,26 @@ import java.util.List;
 
 public class Interactor {
 
+    /** Thrown when adding a command or binding that already exists. */
+    public static class AlreadyExistsException extends F3DException {
+        public AlreadyExistsException(String message) { super(message); }
+    }
+
+    /** Thrown when removing a command or binding that does not exist. */
+    public static class DoesNotExistException extends F3DException {
+        public DoesNotExistException(String message) { super(message); }
+    }
+
+    /** Thrown when a triggered command fails at runtime. */
+    public static class CommandRuntimeException extends F3DException {
+        public CommandRuntimeException(String message) { super(message); }
+    }
+
+    /** Thrown when a command is invoked with invalid arguments. */
+    public static class InvalidArgsException extends F3DException {
+        public InvalidArgsException(String message) { super(message); }
+    }
+
     private long mNativeAddress;
 
     public enum ModifierKeys {

--- a/java/Options.java
+++ b/java/Options.java
@@ -13,6 +13,26 @@ public class Options {
         mNativeAddress = nativeAddress;
     }
 
+    /** Thrown when the requested option name does not exist. */
+    public static class InexistentException extends F3DException {
+        public InexistentException(String message) { super(message); }
+    }
+
+    /** Thrown when an option's type is incompatible with the requested operation. */
+    public static class IncompatibleException extends F3DException {
+        public IncompatibleException(String message) { super(message); }
+    }
+
+    /** Thrown when a string representation cannot be parsed into the option's type. */
+    public static class ParsingException extends F3DException {
+        public ParsingException(String message) { super(message); }
+    }
+
+    /** Thrown when a get operation is called on an option with no value set. */
+    public static class NoValueException extends F3DException {
+        public NoValueException(String message) { super(message); }
+    }
+
     /**
      * Enumeration of supported domain style.
      */

--- a/java/Scene.java
+++ b/java/Scene.java
@@ -4,6 +4,16 @@ import java.util.List;
 
 public class Scene {
 
+    /** Thrown when a file or mesh cannot be loaded into the scene. */
+    public static class LoadFailureException extends F3DException {
+        public LoadFailureException(String message) { super(message); }
+    }
+
+    /** Thrown when a light operation fails (e.g. invalid index). */
+    public static class LightException extends F3DException {
+        public LightException(String message) { super(message); }
+    }
+
     public Scene(long nativeAddress) {
         mNativeAddress = nativeAddress;
     }

--- a/java/testing/TestEngine.java
+++ b/java/testing/TestEngine.java
@@ -58,10 +58,8 @@ public class TestEngine {
     // Engine.createNone() has no interactor; calling getInteractor() must throw
     // NoInteractorException and must NOT crash the JVM.
     boolean caughtNoInteractor = false;
-    try {
-      Engine noWinEngine = Engine.createNone();
+    try (Engine noWinEngine = Engine.createNone()) {
       noWinEngine.getInteractor();
-      noWinEngine.close();
     } catch (Engine.NoInteractorException e) {
       caughtNoInteractor = true;
     }

--- a/java/testing/TestEngine.java
+++ b/java/testing/TestEngine.java
@@ -53,6 +53,29 @@ public class TestEngine {
 
     engine.close();
 
+    // --- Exception handling tests ---
+
+    // Engine.createNone() has no interactor; calling getInteractor() must throw
+    // NoInteractorException and must NOT crash the JVM.
+    boolean caughtNoInteractor = false;
+    try {
+      Engine noWinEngine = Engine.createNone();
+      noWinEngine.getInteractor();
+      noWinEngine.close();
+    } catch (Engine.NoInteractorException e) {
+      caughtNoInteractor = true;
+    }
+    assert caughtNoInteractor : "Expected Engine.NoInteractorException was not thrown";
+
+    // Loading a nonexistent plugin must throw PluginException.
+    boolean caughtPlugin = false;
+    try {
+      Engine.loadPlugin("__nonexistent_plugin_f3d_test__");
+    } catch (Engine.PluginException e) {
+      caughtPlugin = true;
+    }
+    assert caughtPlugin : "Expected Engine.PluginException was not thrown";
+
     testStatefile(args);
   }
 

--- a/java/testing/TestEngine.java
+++ b/java/testing/TestEngine.java
@@ -57,22 +57,18 @@ public class TestEngine {
 
     // Engine.createNone() has no interactor; calling getInteractor() must throw
     // NoInteractorException and must NOT crash the JVM.
-    boolean caughtNoInteractor = false;
     try (Engine noWinEngine = Engine.createNone()) {
       noWinEngine.getInteractor();
+      throw new RuntimeException("Expected Engine.NoInteractorException was not thrown");
     } catch (Engine.NoInteractorException e) {
-      caughtNoInteractor = true;
     }
-    assert caughtNoInteractor : "Expected Engine.NoInteractorException was not thrown";
 
     // Loading a nonexistent plugin must throw PluginException.
-    boolean caughtPlugin = false;
     try {
       Engine.loadPlugin("__nonexistent_plugin_f3d_test__");
+      throw new RuntimeException("Expected Engine.PluginException was not thrown");
     } catch (Engine.PluginException e) {
-      caughtPlugin = true;
     }
-    assert caughtPlugin : "Expected Engine.PluginException was not thrown";
 
     testStatefile(args);
   }

--- a/java/testing/TestImage.java
+++ b/java/testing/TestImage.java
@@ -50,5 +50,27 @@ public class TestImage {
     img1.delete();
     img2.delete();
     img3.delete();
+
+    // --- Exception handling tests ---
+
+    // Reading a nonexistent image file must throw ReadException instead of crashing the JVM.
+    boolean caughtRead = false;
+    try {
+      new Image("/absolutely_nonexistent_image_f3d_test.png");
+    } catch (Image.ReadException e) {
+      caughtRead = true;
+    }
+    assert caughtRead : "Expected Image.ReadException was not thrown";
+
+    // Getting nonexistent metadata must throw MetadataException.
+    boolean caughtMetadata = false;
+    try {
+      Image tmpImg = new Image(300, 200, 3);
+      tmpImg.getMetadata("key_that_does_not_exist");
+      tmpImg.delete();
+    } catch (Image.MetadataException e) {
+      caughtMetadata = true;
+    }
+    assert caughtMetadata : "Expected Image.MetadataException was not thrown";
   }
 }

--- a/java/testing/TestImage.java
+++ b/java/testing/TestImage.java
@@ -64,12 +64,13 @@ public class TestImage {
 
     // Getting nonexistent metadata must throw MetadataException.
     boolean caughtMetadata = false;
+    Image tmpImg = new Image(300, 200, 3);
     try {
-      Image tmpImg = new Image(300, 200, 3);
       tmpImg.getMetadata("key_that_does_not_exist");
-      tmpImg.delete();
     } catch (Image.MetadataException e) {
       caughtMetadata = true;
+    } finally {
+      tmpImg.delete();
     }
     assert caughtMetadata : "Expected Image.MetadataException was not thrown";
   }

--- a/java/testing/TestImage.java
+++ b/java/testing/TestImage.java
@@ -54,24 +54,20 @@ public class TestImage {
     // --- Exception handling tests ---
 
     // Reading a nonexistent image file must throw ReadException instead of crashing the JVM.
-    boolean caughtRead = false;
     try {
       new Image("/absolutely_nonexistent_image_f3d_test.png");
+      throw new RuntimeException("Expected Image.ReadException was not thrown");
     } catch (Image.ReadException e) {
-      caughtRead = true;
     }
-    assert caughtRead : "Expected Image.ReadException was not thrown";
 
     // Getting nonexistent metadata must throw MetadataException.
-    boolean caughtMetadata = false;
     Image tmpImg = new Image(300, 200, 3);
     try {
       tmpImg.getMetadata("key_that_does_not_exist");
+      throw new RuntimeException("Expected Image.MetadataException was not thrown");
     } catch (Image.MetadataException e) {
-      caughtMetadata = true;
     } finally {
       tmpImg.delete();
     }
-    assert caughtMetadata : "Expected Image.MetadataException was not thrown";
   }
 }

--- a/java/testing/TestOptions.java
+++ b/java/testing/TestOptions.java
@@ -69,5 +69,30 @@ public class TestOptions {
     options.cycle("render.effect.blending.mode");
 
     engine.close();
+
+    // --- Exception handling tests ---
+    Engine exEngine = Engine.createNone();
+    Options exOptions = exEngine.getOptions();
+
+    // Setting a nonexistent option must throw InexistentException.
+    boolean caughtInexistent = false;
+    try {
+      exOptions.setAsBool("this.option.does.not.exist.at.all", true);
+    } catch (Options.InexistentException e) {
+      caughtInexistent = true;
+    }
+    assert caughtInexistent : "Expected Options.InexistentException was not thrown";
+
+    // Getting an option with wrong type must throw IncompatibleException.
+    boolean caughtIncompatible = false;
+    try {
+      // render.background.color is a double vector, not a bool
+      exOptions.getAsBool("render.background.color");
+    } catch (Options.IncompatibleException e) {
+      caughtIncompatible = true;
+    }
+    assert caughtIncompatible : "Expected Options.IncompatibleException was not thrown";
+
+    exEngine.close();
   }
 }

--- a/java/testing/TestOptions.java
+++ b/java/testing/TestOptions.java
@@ -75,23 +75,19 @@ public class TestOptions {
     Options exOptions = exEngine.getOptions();
 
     // Setting a nonexistent option must throw InexistentException.
-    boolean caughtInexistent = false;
     try {
       exOptions.setAsBool("this.option.does.not.exist.at.all", true);
+      throw new RuntimeException("Expected Options.InexistentException was not thrown");
     } catch (Options.InexistentException e) {
-      caughtInexistent = true;
     }
-    assert caughtInexistent : "Expected Options.InexistentException was not thrown";
 
     // Getting an option with wrong type must throw IncompatibleException.
-    boolean caughtIncompatible = false;
     try {
       // render.background.color is a double vector, not a bool
       exOptions.getAsBool("render.background.color");
+      throw new RuntimeException("Expected Options.IncompatibleException was not thrown");
     } catch (Options.IncompatibleException e) {
-      caughtIncompatible = true;
     }
-    assert caughtIncompatible : "Expected Options.IncompatibleException was not thrown";
 
     exEngine.close();
   }

--- a/java/testing/TestScene.java
+++ b/java/testing/TestScene.java
@@ -107,12 +107,10 @@ public class TestScene {
     // --- Exception handling tests ---
 
     // Adding a nonexistent file must throw LoadFailureException instead of crashing the JVM.
-    boolean caughtLoadFailure = false;
     try (Engine tmpEngine = Engine.createNone()) {
       tmpEngine.getScene().add("/absolutely_nonexistent_file_f3d_test.xyz");
+      throw new RuntimeException("Expected Scene.LoadFailureException was not thrown");
     } catch (Scene.LoadFailureException e) {
-      caughtLoadFailure = true;
     }
-    assert caughtLoadFailure : "Expected Scene.LoadFailureException was not thrown";
   }
 }

--- a/java/testing/TestScene.java
+++ b/java/testing/TestScene.java
@@ -103,5 +103,18 @@ public class TestScene {
     scene.removeAllLights();
 
     engine.close();
+
+    // --- Exception handling tests ---
+
+    // Adding a nonexistent file must throw LoadFailureException instead of crashing the JVM.
+    boolean caughtLoadFailure = false;
+    try {
+      Engine tmpEngine = Engine.createNone();
+      tmpEngine.getScene().add("/absolutely_nonexistent_file_f3d_test.xyz");
+      tmpEngine.close();
+    } catch (Scene.LoadFailureException e) {
+      caughtLoadFailure = true;
+    }
+    assert caughtLoadFailure : "Expected Scene.LoadFailureException was not thrown";
   }
 }

--- a/java/testing/TestScene.java
+++ b/java/testing/TestScene.java
@@ -108,10 +108,8 @@ public class TestScene {
 
     // Adding a nonexistent file must throw LoadFailureException instead of crashing the JVM.
     boolean caughtLoadFailure = false;
-    try {
-      Engine tmpEngine = Engine.createNone();
+    try (Engine tmpEngine = Engine.createNone()) {
       tmpEngine.getScene().add("/absolutely_nonexistent_file_f3d_test.xyz");
-      tmpEngine.close();
     } catch (Scene.LoadFailureException e) {
       caughtLoadFailure = true;
     }


### PR DESCRIPTION
### Describe your changes
The Java bindings did not properly handle C++ exceptions from libf3d. When a C++ exception crossed the JNI boundary, it could crash the JVM instead of being caught in Java.

Added a Java exception hierarchy that mirrors the C++ `f3d::exception` types and wraps JNI calls with `try/catch` blocks that forward those exceptions using `env->ThrowNew()`.

**Before:** calling something like `Engine.createNone().getInteractor()` could terminate the JVM with an uncaught C++ exception.

**After:** the same call throws a catchable Java exception such as `Engine.NoInteractorException`.

### Changes
- Add `F3DException` as the base Java exception class
- Add nested exception classes in `Engine`, `Scene`, `Options`, `Interactor`, `Image`, and `Context`
- Add `F3DThrowJavaException()` helper in `F3DJavaBindings.h`
- Forward exceptions in all relevant JNI binding files
- Add tests in `TestEngine`, `TestScene`, `TestOptions`, and `TestImage`

**Proper forwarding exceptions**
**Before:**
<img width="1155" height="234" alt="Screenshot 2026-07-03 at 19 12 36" src="https://github.com/user-attachments/assets/cbe54c5e-9735-4893-8363-9a0e9200231c" />
**After:**
<img width="1086" height="375" alt="Screenshot 2026-07-03 at 20 24 39" src="https://github.com/user-attachments/assets/91823721-67ca-4566-901d-282c6c8caac7" />

### Checklist for finalizing the PR
- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure
- [ ] I did not use AI to generate any of the content of that pull request
- [x] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.

AI was used for the following:
- To run test cases 
- To build
- To provide feedback for memory leaks (if found any)
- To provide feedback for security threats (if found any)
- Initial PR Description boilerplate
- JNI catch block boilerplate across the binding files

**Model**: Claude Sonnet 4.6 via Cursor (Ask Mode)

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.

###Issue Number
Fix: #3325