### PR TITLE
Fix CI

### DIFF
--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -136,7 +136,7 @@ runs:
         runner.os == 'Linux' &&
         inputs.optdeps_label == 'optdeps'
       shell: bash
-      run: echo "LD_LIBRARY_PATH=$(pwd)/dependencies/install/lib" >> $GITHUB_ENV
+      run: echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/dependencies/install/lib" >> $GITHUB_ENV
 
     # Works around for https://github.com/actions/runner-images/issues/10055
     - name: Remove conflicting libraries for Java bindings on Windows

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -131,6 +131,13 @@ runs:
       shell: bash
       run: echo "DYLD_LIBRARY_PATH=$(pwd)/dependencies/install/lib" >> $GITHUB_ENV
 
+    - name: Set LD_LIBRARY_PATH on Linux for OSMesa dynamic loading
+      if: |
+        runner.os == 'Linux' &&
+        inputs.optdeps_label == 'optdeps'
+      shell: bash
+      run: echo "LD_LIBRARY_PATH=$(pwd)/dependencies/install/lib" >> $GITHUB_ENV
+
     # Works around for https://github.com/actions/runner-images/issues/10055
     - name: Remove conflicting libraries for Java bindings on Windows
       if: runner.os == 'Windows'

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -203,7 +203,7 @@ runs:
         -DF3D_TESTING_ENABLE_ILLUSTRATION_TESTS=${{ (runner.os == 'Linux' && inputs.vtk_version == 'commit' && inputs.build_type == 'standard') && 'ON' || 'OFF' }}
         -DF3D_TESTING_ENABLE_GLX_TESTS=${{ (runner.os == 'Linux' && inputs.rendering_backend == 'auto') && 'ON' || 'OFF' }}
         -DF3D_TESTING_ENABLE_LONG_TIMEOUT_TESTS=${{ (runner.os == 'Linux' || runner.os == 'Windows') && 'ON' || 'OFF' }}
-        -DF3D_TESTING_ENABLE_OSMESA_TESTS=ON
+        -DF3D_TESTING_ENABLE_OSMESA_TESTS=${{ inputs.optdeps_label == 'optdeps' && 'ON' || 'OFF' }}
         -DF3D_TESTING_DISABLE_CATCH_ALL=ON
         -DF3D_TESTING_FORCE_RENDERING_BACKEND=${{ inputs.rendering_backend }}
         -DF3D_WINDOWS_BUILD_CONSOLE_APPLICATION=ON

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -93,7 +93,7 @@ runs:
       run: |
         python -m pip install pytest==9.0.3
         python -m pip install pybind11_stubgen
-        python -m pip install numpy==2.2.6
+        python -m pip install "numpy>=2.2.6"
 
     - name: Extract java version
       id: java_ver

--- a/.github/actions/mesa-install-dep/action.yml
+++ b/.github/actions/mesa-install-dep/action.yml
@@ -67,11 +67,6 @@ runs:
       shell: bash
       run: choco install winflexbison3 --no-progress -y
 
-    - name: Install Flex/Bison (Linux)
-      if: steps.cache-mesa.outputs.cache-hit != 'true' && runner.os == 'Linux'
-      shell: bash
-      run: apt-get install -y bison byacc flex pkg-config ninja-build libzstd-dev
-
     - name: Checkout mesa
       if: steps.cache-mesa.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/actions/mesa-install-dep/action.yml
+++ b/.github/actions/mesa-install-dep/action.yml
@@ -42,7 +42,7 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: dependencies/mesa_install
-        key: mesa-${{steps.mesa_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-9
+        key: mesa-${{steps.mesa_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-10
 
     - name: Setup MSVC (Windows)
       if: steps.cache-mesa.outputs.cache-hit != 'true' && runner.os == 'Windows'
@@ -93,6 +93,7 @@ runs:
         meson setup mesa_build mesa
         --prefix=$(pwd)/mesa_install
         --buildtype=release
+        --libdir=lib
         -Db_ndebug=true
         -Dosmesa=true
         -Dcpp_rtti=false

--- a/.github/actions/mesa-install-dep/action.yml
+++ b/.github/actions/mesa-install-dep/action.yml
@@ -42,7 +42,7 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: dependencies/mesa_install
-        key: mesa-${{steps.mesa_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-8
+        key: mesa-${{steps.mesa_ver.outputs.extract}}-${{runner.os}}-${{inputs.cpu}}-${{steps.global_idx.outputs.extract}}-9
 
     - name: Setup MSVC (Windows)
       if: steps.cache-mesa.outputs.cache-hit != 'true' && runner.os == 'Windows'

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -52,7 +52,7 @@ runs:
         python -m pip install pytest==9.0.3
         python -m pip install pyopengltk==0.0.4
         python -m pip install PySide6==6.11.1
-        python -m pip install numpy==2.2.6
+        python -m pip install "numpy>=2.2.6"
 
     - name: Set PATH windows
       if: runner.os == 'Windows'

--- a/webassembly/testing/CMakeLists.txt
+++ b/webassembly/testing/CMakeLists.txt
@@ -27,10 +27,12 @@ foreach(test_name ${f3djsTests_list})
   add_test(NAME libf3d_bindings_js::${test_name}
     COMMAND ${CHROMIUM_EXECUTABLE}
       --disable-application-cache
+      --disable-dev-shm-usage
       --disable-extensions
+      --disable-gpu
       --disable-notifications
       --disable-restore-session-state
-      --disable-gpu
+      --disable-setuid-sandbox
       --enable-unsafe-swiftshader
       --new-window
       --no-default-browser-check

--- a/webassembly/testing/CMakeLists.txt
+++ b/webassembly/testing/CMakeLists.txt
@@ -27,12 +27,10 @@ foreach(test_name ${f3djsTests_list})
   add_test(NAME libf3d_bindings_js::${test_name}
     COMMAND ${CHROMIUM_EXECUTABLE}
       --disable-application-cache
-      --disable-dev-shm-usage
       --disable-extensions
-      --disable-gpu
       --disable-notifications
       --disable-restore-session-state
-      --disable-setuid-sandbox
+      --disable-gpu
       --enable-unsafe-swiftshader
       --new-window
       --no-default-browser-check


### PR DESCRIPTION
### Describe your changes

- Remove Linux package installation already present in the docker image
- Add `LD_LIBRARY_PATH` in order to find OSMesa
- Install OSMesa in `lib` instead of `lib/x86_64-linux-gnu` on Linux
- Allow more recent versions of numpy because 2.2.6 is not supported by Python 3.14

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
