### PR TITLE
Add color option for normal glyphs attributes

### DIFF
--- a/application/F3DOptionsTools.h
+++ b/application/F3DOptionsTools.h
@@ -129,6 +129,7 @@ static inline const std::map<std::string_view, std::string_view> LibOptionsNames
   { "metallic", "model.material.metallic" },
   { "normal-glyphs", "model.normal_glyphs.enable" },
   { "normal-glyphs-scale", "model.normal_glyphs.scale" },
+  { "normal-glyphs-color", "model.normal_glyphs.color" },
   { "normal-scale", "model.normal.scale" },
   { "notifications", "ui.notifications.enable" },
   { "opacity", "model.color.opacity" },

--- a/application/testing/tests.documentation.cmake
+++ b/application/testing/tests.documentation.cmake
@@ -191,6 +191,9 @@ f3d_test_doc(NAME TestDocNormalGlyphsOn DATA DamagedHelmet.glb REF_IMAGE normal_
 f3d_test_doc(NAME TestDocNormalGlyphsScale03 DATA DamagedHelmet.glb REF_IMAGE normal_glyphs_scale_0.3.png ROTATE ARGS --normal-glyphs --normal-glyphs-scale=.3 -f)
 f3d_test_doc(NAME TestDocNormalGlyphsScale07 DATA DamagedHelmet.glb REF_IMAGE normal_glyphs_scale_0.7.png ROTATE ARGS --normal-glyphs --normal-glyphs-scale=.7 -f)
 
+## --normal-glyphs-color
+f3d_test_doc(NAME TestDocNormalGlyphsColorRed DATA DamagedHelmet.glb REF_IMAGE normal_glyphs_red.png ROTATE ARGS --normal-glyphs --normal-glyphs-scale=.3 --normal-glyphs-color=red -f)
+
 ## --point-sprites
 ### OFF: damaged_helmet_baseline.png
 f3d_test_doc(NAME TestDocPointSpritesSphere DATA DamagedHelmet.glb REF_IMAGE point_sprites_sphere.png ROTATE ARGS --point-sprites=sphere --point-sprites-size=5)

--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -144,7 +144,6 @@ f3d_test(NAME TestNormalGlyphsScale DATA suzanne.obj ARGS --normal-glyphs --norm
 f3d_test(NAME TestNormalGlyphsColor DATA suzanne.obj ARGS --normal-glyphs --normal-glyphs-color=1,0,0)
 f3d_test(NAME TestNormalGlyphsNoNormalsAvailable DATA cow.vtp ARGS --normal-glyphs NO_BASELINE REGEXP "does not contain any normals")
 
-
 ## Textures
 f3d_test(NAME TestTextureNormal DATA WaterBottle.glb ARGS --texture-normal=${F3D_SOURCE_DIR}/testing/data/normal.png --normal-scale=0.1)
 f3d_test(NAME TestTextureMaterial DATA WaterBottle.glb ARGS --texture-material=${F3D_SOURCE_DIR}/testing/data/red_mod.jpg --roughness=1 --metallic=1)

--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -141,6 +141,7 @@ f3d_test(NAME TestVolumeColoringArray DATA waveletArrays.vti ARGS -vb --coloring
 f3d_test(NAME TestNormalGlyphsPerspectiveEnable DATA suzanne.obj ARGS --normal-glyphs)
 f3d_test(NAME TestNormalGlyphsOrthographicEnable DATA suzanne.obj ARGS --normal-glyphs --camera-orthographic)
 f3d_test(NAME TestNormalGlyphsScale DATA suzanne.obj ARGS --normal-glyphs --normal-glyphs-scale=0.1)
+f3d_test(NAME TestNormalGlyphsColor DATA suzanne.obj ARGS --normal-glyphs --normal-glyphs-color=1,0,0)
 f3d_test(NAME TestNormalGlyphsNoNormalsAvailable DATA cow.vtp ARGS --normal-glyphs NO_BASELINE REGEXP "does not contain any normals")
 
 ## Textures

--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -144,6 +144,7 @@ f3d_test(NAME TestNormalGlyphsScale DATA suzanne.obj ARGS --normal-glyphs --norm
 f3d_test(NAME TestNormalGlyphsColor DATA suzanne.obj ARGS --normal-glyphs --normal-glyphs-color=1,0,0)
 f3d_test(NAME TestNormalGlyphsNoNormalsAvailable DATA cow.vtp ARGS --normal-glyphs NO_BASELINE REGEXP "does not contain any normals")
 
+
 ## Textures
 f3d_test(NAME TestTextureNormal DATA WaterBottle.glb ARGS --texture-normal=${F3D_SOURCE_DIR}/testing/data/normal.png --normal-scale=0.1)
 f3d_test(NAME TestTextureMaterial DATA WaterBottle.glb ARGS --texture-material=${F3D_SOURCE_DIR}/testing/data/red_mod.jpg --roughness=1 --metallic=1)

--- a/doc/libf3d/03-OPTIONS.md
+++ b/doc/libf3d/03-OPTIONS.md
@@ -152,13 +152,19 @@ CLI: `--texture-material`.
 
 Render vertex normals as arrows on top of the geometry.
 
+CLI: `--normal-glyphs`.
+
 ### `model.normal_glyphs.scale` (_ratio_, default: `1.0`, range domain: `[0, 10]`, increment: `0.1`)
 
 Scales the normal glyphs
 
+CLI: `--normal-glyphs-scale`.
+
 ### `model.normal_glyphs.color` (_color_, optional)
 
 Color of the normal glyphs.
+
+CLI: `--normal-glyphs-color`.
 
 ### `model.normal.scale` (_double_, optional, range domain: `[0, 3]`, increment: `0.1`)
 

--- a/doc/libf3d/03-OPTIONS.md
+++ b/doc/libf3d/03-OPTIONS.md
@@ -156,6 +156,10 @@ Render vertex normals as arrows on top of the geometry.
 
 Scales the normal glyphs
 
+### `model.normal_glyphs.color` (_color_, optional)
+
+Color of the normal glyphs.
+
 ### `model.normal.scale` (_double_, optional, range domain: `[0, 3]`, increment: `0.1`)
 
 Normal scale affects the strength of the normal deviation from the normal texture. Model-specified by default.

--- a/doc/user/03-OPTIONS.md
+++ b/doc/user/03-OPTIONS.md
@@ -362,6 +362,10 @@ Display arrows that show vertex normals.
 
 Adjusts the scales of normal glyphs.
 
+### `--normal-glyphs-color` (_color_, optional)
+
+Set the color of normal glyphs.
+
 #### compare
 
 | 0.3                                       | 0.7                                       |

--- a/doc/user/03-OPTIONS.md
+++ b/doc/user/03-OPTIONS.md
@@ -362,15 +362,21 @@ Display arrows that show vertex normals.
 
 Adjusts the scales of normal glyphs.
 
+#### compare
+
+| 0.3                                       | 0.7                                       |
+| ----------------------------------------- | ----------------------------------------- |
+| ![](./images/normal_glyphs_scale_0.3.png) | ![](./images/normal_glyphs_scale_0.7.png) |
+
 ### `--normal-glyphs-color` (_color_, optional)
 
 Set the color of normal glyphs.
 
 #### compare
 
-| 0.3                                       | 0.7                                       |
-| ----------------------------------------- | ----------------------------------------- |
-| ![](./images/normal_glyphs_scale_0.3.png) | ![](./images/normal_glyphs_scale_0.7.png) |
+| Default                            | Red                                 |
+| ---------------------------------- | ----------------------------------- |
+| ![](./images/normal_glyphs_on.png) | ![](./images/normal_glyphs_red.png) |
 
 ### `-o`, `--point-sprites=<none|sphere|gaussian|circle|stddev|bound|cross>` (_string_, default: `none`, implicit: `sphere`)
 

--- a/doc/user/images/normal_glyphs_red.png
+++ b/doc/user/images/normal_glyphs_red.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aeed3fcde33df43cf30bc86d28a7cfd04df2aff6704c9a23d38936fc7a1fa0e1
+size 252862

--- a/library/options.json
+++ b/library/options.json
@@ -543,7 +543,7 @@
         }
       },
       "color": {
-        "type": "color",
+        "type": "color"
         // "default_value": "1.0, 1.0, 1.0"
       }
     },

--- a/library/options.json
+++ b/library/options.json
@@ -543,7 +543,8 @@
         }
       },
       "color": {
-        "type": "color"
+        "type": "color",
+        "default_value": "1.0, 1.0, 1.0"
       }
     },
     "volume": {

--- a/library/options.json
+++ b/library/options.json
@@ -544,7 +544,7 @@
       },
       "color": {
         "type": "color",
-        "default_value": "1.0, 1.0, 1.0"
+        // "default_value": "1.0, 1.0, 1.0"
       }
     },
     "volume": {

--- a/library/options.json
+++ b/library/options.json
@@ -544,7 +544,7 @@
       },
       "color": {
         "type": "color",
-        "default_value":"0.0, 0.0, 0.0"
+        "default_value": "0.0, 0.0, 0.0"
       }
     },
     "volume": {

--- a/library/options.json
+++ b/library/options.json
@@ -541,6 +541,10 @@
           "max": "10.0",
           "increment": "0.1"
         }
+      },
+      "color": {
+        "type": "color",
+        "default_value":"0.0, 0.0, 0.0"
       }
     },
     "volume": {

--- a/library/options.json
+++ b/library/options.json
@@ -543,8 +543,7 @@
         }
       },
       "color": {
-        "type": "color",
-        "default_value": "0.0, 0.0, 0.0"
+        "type": "color"
       }
     },
     "volume": {

--- a/library/options.json
+++ b/library/options.json
@@ -543,8 +543,7 @@
         }
       },
       "color": {
-        "type": "color",
-        "default_value": "1.0, 1.0, 1.0"
+        "type": "color"
       }
     },
     "volume": {

--- a/library/options.json
+++ b/library/options.json
@@ -543,8 +543,8 @@
         }
       },
       "color": {
-        "type": "color"
-        // "default_value": "1.0, 1.0, 1.0"
+        "type": "color",
+        "default_value": "1.0, 1.0, 1.0"
       }
     },
     "volume": {

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -418,6 +418,7 @@ void window_impl::UpdateDynamicOptions()
 
   renderer->SetUseNormalGlyphs(opt.model.normal_glyphs.enable);
   renderer->SetNormalGlyphScaleMultiplier(opt.model.normal_glyphs.scale);
+  renderer->SetNormalGlyphColor(opt.model.normal_glyphs.color);
 
   // XXX: model.point_sprites.type only has an effect on geometry scene
   // but we set it here for practical reasons

--- a/resources/cli-options.json
+++ b/resources/cli-options.json
@@ -332,6 +332,11 @@
           "longName": "normal-glyphs-scale",
           "helpText": "Scale normal glyphs",
           "valueHelper": "<ratio>"
+        },
+        {
+          "longName": "normal-glyphs-color",
+          "helpText": "Color of normal glyphs",
+          "valueHelper": "<R,G,B>"
         }
       ]
     },

--- a/resources/cli-options.json
+++ b/resources/cli-options.json
@@ -336,7 +336,7 @@
         {
           "longName": "normal-glyphs-color",
           "helpText": "Color of normal glyphs",
-          "valueHelper": "<R,G,B>"
+          "valueHelper": "<color>"
         }
       ]
     },

--- a/testing/baselines/TestNormalGlyphsColor.png
+++ b/testing/baselines/TestNormalGlyphsColor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce8cd2633de65009a3b7d33f5e25a92070ecb94a1818cda3c0832784137167f8
+size 44560

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2913,17 +2913,14 @@ void vtkF3DRenderer::ConfigureNormalGlyphs()
     }
 
     this->UpdateNormalGlyphsScale();
-    if (this->NormalGlyphColor.has_value())
-    {
-      assert(this->NormalGlyphColor->size() == 3);
-      const double* normalGlyphColor = this->NormalGlyphColor->data();
-      double linearColor[3];
-      linearColor[0] = std::pow(normalGlyphColor[0], 2.2);
-      linearColor[1] = std::pow(normalGlyphColor[1], 2.2);
-      linearColor[2] = std::pow(normalGlyphColor[2], 2.2);
-      normalGlyph.GlyphMapper->ScalarVisibilityOff();
-      normalGlyph.Actor->GetProperty()->SetColor(linearColor);
-    }
+    assert(this->NormalGlyphColor.size() == 3);
+    const double* normalGlyphColor = this->NormalGlyphColor.data();
+    double linearColor[3];
+    linearColor[0] = std::pow(normalGlyphColor[0], 2.2);
+    linearColor[1] = std::pow(normalGlyphColor[1], 2.2);
+    linearColor[2] = std::pow(normalGlyphColor[2], 2.2);
+    normalGlyph.GlyphMapper->ScalarVisibilityOff();
+    normalGlyph.Actor->GetProperty()->SetColor(linearColor);
     normalGlyph.Actor->SetVisibility(normalGlyphsVisible);
   }
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1728,7 +1728,7 @@ void vtkF3DRenderer::SetNormalGlyphScaleMultiplier(double multiplier)
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRenderer::SetNormalGlyphColor(const std::optional<std::vector<double>>& color)
+void vtkF3DRenderer::SetNormalGlyphColor(const std::vector<double>& color)
 {
   if (this->NormalGlyphColor != color)
   {

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2913,14 +2913,17 @@ void vtkF3DRenderer::ConfigureNormalGlyphs()
     }
 
     this->UpdateNormalGlyphsScale();
-    assert(this->NormalGlyphColor.size() == 3);
-    const double* normalGlyphColor = this->NormalGlyphColor.data();
-    double linearColor[3];
-    linearColor[0] = std::pow(normalGlyphColor[0], 2.2);
-    linearColor[1] = std::pow(normalGlyphColor[1], 2.2);
-    linearColor[2] = std::pow(normalGlyphColor[2], 2.2);
-    normalGlyph.GlyphMapper->ScalarVisibilityOff();
-    normalGlyph.Actor->GetProperty()->SetColor(linearColor);
+    if (this->NormalGlyphColor.has_value())
+    {
+      assert(this->NormalGlyphColor->size() == 3);
+      const double* normalGlyphColor = this->NormalGlyphColor->data();
+      double linearColor[3];
+      linearColor[0] = std::pow(normalGlyphColor[0], 2.2);
+      linearColor[1] = std::pow(normalGlyphColor[1], 2.2);
+      linearColor[2] = std::pow(normalGlyphColor[2], 2.2);
+      normalGlyph.GlyphMapper->ScalarVisibilityOff();
+      normalGlyph.Actor->GetProperty()->SetColor(linearColor);
+    }
     normalGlyph.Actor->SetVisibility(normalGlyphsVisible);
   }
 

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1728,7 +1728,7 @@ void vtkF3DRenderer::SetNormalGlyphScaleMultiplier(double multiplier)
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DRenderer::SetNormalGlyphColor(const std::vector<double>& color)
+void vtkF3DRenderer::SetNormalGlyphColor(const std::optional<std::vector<double>>& color)
 {
   if (this->NormalGlyphColor != color)
   {

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2916,12 +2916,13 @@ void vtkF3DRenderer::ConfigureNormalGlyphs()
     if (this->NormalGlyphColor.has_value())
     {
       assert(this->NormalGlyphColor->size() == 3);
+      const double* normalGlyphColor = this->NormalGlyphColor->data();
+      double linearColor[3];
+      linearColor[0] = std::pow(normalGlyphColor[0], 2.2);
+      linearColor[1] = std::pow(normalGlyphColor[1], 2.2);
+      linearColor[2] = std::pow(normalGlyphColor[2], 2.2);
       normalGlyph.GlyphMapper->ScalarVisibilityOff();
-      normalGlyph.Actor->GetProperty()->SetColor(this->NormalGlyphColor->data());
-    }
-    else
-    {
-      normalGlyph.GlyphMapper->ScalarVisibilityOn();
+      normalGlyph.Actor->GetProperty()->SetColor(linearColor);
     }
     normalGlyph.Actor->SetVisibility(normalGlyphsVisible);
   }

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1728,6 +1728,16 @@ void vtkF3DRenderer::SetNormalGlyphScaleMultiplier(double multiplier)
 }
 
 //----------------------------------------------------------------------------
+void vtkF3DRenderer::SetNormalGlyphColor(const std::optional<std::vector<double>>& color)
+{
+  if (this->NormalGlyphColor != color)
+  {
+    this->NormalGlyphColor = color;
+    this->NormalGlyphsConfigured = false;
+  }
+}
+
+//----------------------------------------------------------------------------
 void vtkF3DRenderer::SetUseSSAOPass(bool use)
 {
   if (this->UseSSAOPass != use)
@@ -2903,6 +2913,16 @@ void vtkF3DRenderer::ConfigureNormalGlyphs()
     }
 
     this->UpdateNormalGlyphsScale();
+    if (this->NormalGlyphColor.has_value())
+    {
+      assert(this->NormalGlyphColor->size() == 3);
+      normalGlyph.GlyphMapper->ScalarVisibilityOff();
+      normalGlyph.Actor->GetProperty()->SetColor(this->NormalGlyphColor->data());
+    }
+    else
+    {
+      normalGlyph.GlyphMapper->ScalarVisibilityOn();
+    }
     normalGlyph.Actor->SetVisibility(normalGlyphsVisible);
   }
 

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -361,6 +361,11 @@ public:
   void SetNormalGlyphScaleMultiplier(double multiplier);
 
   /**
+   * Sets the color of the normal glyphs
+   */
+  void SetNormalGlyphColor(const std::optional<std::vector<double>>& color);
+
+  /**
    * Set the visibility of the point sprites actor.
    * It will only be shown if raytracing and volume are not enabled
    */
@@ -887,6 +892,7 @@ private:
   bool ScalarBarVisible = false;
   bool UseNormalGlyphs = false;
   double NormalGlyphScaleMultiplier = 1.0;
+  std::optional<std::vector<double>> NormalGlyphColor;
   bool UsePointSprites = false;
   bool UseVolume = false;
   bool UseInverseOpacityFunction = false;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -363,7 +363,7 @@ public:
   /**
    * Sets the color of the normal glyphs
    */
-  void SetNormalGlyphColor(const std::vector<double>& color);
+  void SetNormalGlyphColor(const std::optional<std::vector<double>>& color);
 
   /**
    * Set the visibility of the point sprites actor.
@@ -892,7 +892,7 @@ private:
   bool ScalarBarVisible = false;
   bool UseNormalGlyphs = false;
   double NormalGlyphScaleMultiplier = 1.0;
-  std::vector<double> NormalGlyphColor;
+  std::optional<std::vector<double>> NormalGlyphColor;
   bool UsePointSprites = false;
   bool UseVolume = false;
   bool UseInverseOpacityFunction = false;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -363,7 +363,7 @@ public:
   /**
    * Sets the color of the normal glyphs
    */
-  void SetNormalGlyphColor(const std::optional<std::vector<double>>& color);
+  void SetNormalGlyphColor(const std::vector<double>& color);
 
   /**
    * Set the visibility of the point sprites actor.
@@ -892,7 +892,7 @@ private:
   bool ScalarBarVisible = false;
   bool UseNormalGlyphs = false;
   double NormalGlyphScaleMultiplier = 1.0;
-  std::optional<std::vector<double>> NormalGlyphColor;
+  std::vector<double> NormalGlyphColor;
   bool UsePointSprites = false;
   bool UseVolume = false;
   bool UseInverseOpacityFunction = false;


### PR DESCRIPTION
### Describe your changes
Adds the color option for normal glyphs with tests and image 
part of https://github.com/f3d-app/f3d/issues/3120

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
