### PR TITLE
Fix opacity map from command

### DIFF
--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -482,6 +482,7 @@ f3d_test(NAME TestCommandScriptSetCameraBottom SCRIPT DATA dragon.vtu) # set_cam
 f3d_test(NAME TestCommandScriptSetCameraLeft SCRIPT DATA dragon.vtu) # set_camera left
 f3d_test(NAME TestCommandScriptCycleCameraIndex SCRIPT DATA Cameras.gltf) # cycle scene.camera.index;cycle scene.camera.index;reload_current_file_group
 f3d_test(NAME TestCommandScriptIncreaseDecreaseCameraIndex SCRIPT DATA Cameras.gltf) # increase scene.camera.index;increase scene.camera.index;increase.camera.index;decrease.camera.index;reload_current_file_group
+f3d_test(NAME TestCommandScriptOpacityMap SCRIPT DATA vase_4comp.vti ARGS -v) # set model.scivis.opacity_map 0,0.03,1,1
 
 ## Tests to increase coverage
 # Output option test

--- a/testing/baselines/TestCommandScriptOpacityMap.png
+++ b/testing/baselines/TestCommandScriptOpacityMap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eccfb7494e3f785dddeecc557ce5bb1e333ecc88e8b04096d7a3cb3a9ac225ee
+size 17080

--- a/testing/scripts/TestCommandScriptOpacityMap.txt
+++ b/testing/scripts/TestCommandScriptOpacityMap.txt
@@ -1,0 +1,1 @@
+set model.scivis.opacity_map 0,0.03,1,1

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -3066,6 +3066,7 @@ void vtkF3DRenderer::SetOpacityMap(const std::vector<double>& opacityMap)
 
     this->OpacityTransferFunctionConfigured = false;
     this->VolumePropsAndMappersConfigured = false;
+    this->ColoringConfigured = false;
   }
 }
 


### PR DESCRIPTION
### Describe your changes

Fixing an issue when typing `set model.scivis.opacity_map xx` in the console (or from libf3d options) wasn't updated right away.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
