### PR TITLE
WASM: Allow custom canvas ID and multiple contexts

### DIFF
--- a/doc/libf3d/04-LANGUAGE_BINDINGS.md
+++ b/doc/libf3d/04-LANGUAGE_BINDINGS.md
@@ -99,7 +99,6 @@ const settings = {
     // make it look nice
     options.setAsString("render.effect.antialiasing.mode", "fxaa");
     options.toggle("render.effect.tone_mapping");
-    options.toggle("render.effect.ambient_occlusion");
     options.toggle("render.hdri.ambient");
 
     // display widgets
@@ -110,17 +109,11 @@ const settings = {
 
 f3d(settings)
   .then(async (Module) => {
-    // write a 3D file located on the server to the internal filesystem
-    const modelFile = await fetch("/assets/example.obj").then((b) =>
-      b.arrayBuffer(),
-    );
-    Module.FS.writeFile("example.obj", new Uint8Array(modelFile));
-
     // automatically load all supported file format readers
     Module.Engine.autoloadPlugins();
 
-    // create an engine
-    Module.engineInstance = Module.Engine.create();
+    // create an engine (specify canvas ID)
+    Module.engineInstance = Module.Engine.create("#canvas");
 
     Module.setupOptions(Module.engineInstance.getOptions());
 
@@ -130,8 +123,15 @@ f3d(settings)
       .getWindow()
       .setSize(Module.canvas.clientWidth, scale * Module.canvas.clientHeight);
 
-    const scene = Module.engineInstance.getScene();
-    scene.add("/example.obj");
+    // download file and add stream
+    const response = await fetch("https://f3d.app/data/DamagedHelmet.glb");
+    const arrayBuffer = await response.arrayBuffer();
+    const scene = engine.getScene();
+    try {
+      scene.addBuffer(new Uint8Array(arrayBuffer));
+    } catch (e) {
+      console.error("Unsupported file");
+    }
 
     // do a first render and start the interactor
     Module.engineInstance.getWindow().render();

--- a/library/private/window_impl.h
+++ b/library/private/window_impl.h
@@ -36,7 +36,7 @@ public:
    * and store option ref for later usage
    */
   window_impl(const options& options, const std::optional<Type>& type, bool offscreen,
-    const context::function& getProcAddress);
+    const context::function& getProcAddress, std::string_view id = "");
   /**
    * Default destructor
    */

--- a/library/public/engine.h
+++ b/library/public/engine.h
@@ -109,6 +109,14 @@ public:
   [[nodiscard]] static engine createOSMesa();
 
   /**
+   * Create an engine with a webassembly window.
+   * The canvas element can be selected using the `canvasSelector` parameter.
+   *
+   * Throws a engine::no_window_exception if not using WebAssembly.
+   */
+  [[nodiscard]] static engine createWasm(std::string_view canvasSelector = "#canvas");
+
+  /**
    * Create an engine with an external window.
    * A context to retrieve OpenGL symbols is required.
    * Here's an example if a GLFW window is used:
@@ -380,8 +388,8 @@ private:
    * Engine constructor. This is a private method.
    * The user must rely on factories to create the engine instance.
    */
-  engine(
-    const std::optional<window::Type>& windowType, bool offscreen, const context::function& loader);
+  engine(const std::optional<window::Type>& windowType, bool offscreen,
+    const context::function& loader, std::string_view id = "");
 };
 }
 

--- a/library/src/engine.cxx
+++ b/library/src/engine.cxx
@@ -13,6 +13,10 @@
 
 #include <vtkVersion.h>
 
+#ifdef __EMSCRIPTEN__
+#include <vtkWebAssemblyRenderWindowInteractor.h>
+#endif
+
 #include <vtksys/DynamicLoader.hxx>
 #include <vtksys/SystemTools.hxx>
 
@@ -45,8 +49,8 @@ public:
 };
 
 //----------------------------------------------------------------------------
-engine::engine(
-  const std::optional<window::Type>& windowType, bool offscreen, const context::function& loader)
+engine::engine(const std::optional<window::Type>& windowType, bool offscreen,
+  const context::function& loader, std::string_view id)
   : Internals(new engine::internals)
 {
   // Ensure all lib initialization is done (once)
@@ -87,8 +91,8 @@ engine::engine(
 
   this->Internals->Options = std::make_unique<options>();
 
-  this->Internals->Window =
-    std::make_unique<detail::window_impl>(*this->Internals->Options, windowType, offscreen, loader);
+  this->Internals->Window = std::make_unique<detail::window_impl>(
+    *this->Internals->Options, windowType, offscreen, loader, id);
 
   if (!cachePath.empty())
   {
@@ -105,6 +109,18 @@ engine::engine(
     this->Internals->Interactor = std::make_unique<detail::interactor_impl>(
       *this->Internals->Options, *this->Internals->Window, *this->Internals->Scene);
   }
+
+#ifdef __EMSCRIPTEN__
+  // Set canvas selector for wasm window
+  if (windowType == window::Type::WASM)
+  {
+    vtkRenderWindowInteractor* interactor =
+      this->Internals->Window->GetRenderWindow()->GetInteractor();
+    vtkWebAssemblyRenderWindowInteractor* wasmInteractor =
+      vtkWebAssemblyRenderWindowInteractor::SafeDownCast(interactor);
+    wasmInteractor->SetCanvasSelector(id.empty() ? "#canvas" : id.data());
+  }
+#endif
 }
 
 //----------------------------------------------------------------------------
@@ -182,6 +198,15 @@ engine engine::createExternalEGL()
 engine engine::createExternalOSMesa()
 {
   return { window::Type::EXTERNAL, false, context::osmesa() };
+}
+
+//----------------------------------------------------------------------------
+engine engine::createWasm(std::string_view canvasSelector)
+{
+#ifndef __EMSCRIPTEN__
+  throw engine::no_window_exception("Cannot create a WebAssembly window on this platform");
+#endif
+  return { window::Type::WASM, false, nullptr, canvasSelector };
 }
 
 //----------------------------------------------------------------------------

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -28,6 +28,10 @@
 #include <vtkVersion.h>
 #include <vtkWindowToImageFilter.h>
 
+#ifdef __EMSCRIPTEN__
+#include <vtkWebAssemblyOpenGLRenderWindow.h>
+#endif
+
 #ifdef VTK_USE_X
 #include <vtkF3DGLXRenderWindow.h>
 #endif
@@ -120,7 +124,7 @@ public:
 
 //----------------------------------------------------------------------------
 window_impl::window_impl(const options& options, const std::optional<Type>& type, bool offscreen,
-  const context::function& getProcAddress)
+  const context::function& getProcAddress, [[maybe_unused]] std::string_view id)
   : Internals(std::make_unique<window_impl::internals>(options))
 {
   this->Internals->GetProcAddress = getProcAddress;
@@ -158,6 +162,14 @@ window_impl::window_impl(const options& options, const std::optional<Type>& type
     this->Internals->RenWin = vtkSmartPointer<vtkF3DWGLRenderWindow>::New();
 #else
     assert(false); // Unreachable
+#endif
+  }
+  else if (type == Type::WASM)
+  {
+#ifdef __EMSCRIPTEN__
+    auto wasmRenWin = vtkSmartPointer<vtkWebAssemblyOpenGLRenderWindow>::New();
+    wasmRenWin->SetCanvasSelector(id.empty() ? "#canvas" : id.data());
+    this->Internals->RenWin = wasmRenWin;
 #endif
   }
   else if (!type.has_value())

--- a/library/testing/TestSDKEngineExceptions.cxx
+++ b/library/testing/TestSDKEngineExceptions.cxx
@@ -25,6 +25,9 @@ int TestSDKEngineExceptions([[maybe_unused]] int argc, [[maybe_unused]] char* ar
   test.expect<f3d::engine::no_window_exception>(
     "create empty external context", []() { std::ignore = f3d::engine::createExternal(nullptr); });
 
+  test.expect<f3d::engine::no_window_exception>(
+    "create wasm context", []() { std::ignore = f3d::engine::createWasm(); });
+
   {
     f3d::engine eng = f3d::engine::createNone();
     test.expect<f3d::engine::no_window_exception>(

--- a/testing/baselines/TestWasmCustomCanvas.png
+++ b/testing/baselines/TestWasmCustomCanvas.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a95089ab2e20b71e475a7104a2f8dca49e4fe09a1ad1ade895e377742bca29d
+size 2856

--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -473,7 +473,10 @@ EMSCRIPTEN_BINDINGS(f3d)
 
   emscripten::class_<f3d::engine>("Engine")
     .class_function(
-      "create", +[]() { return f3d::engine::create(); },
+      "create", +[](std::string canvas) { return f3d::engine::createWasm(canvas); },
+      emscripten::return_value_policy::take_ownership())
+    .class_function(
+      "create", +[]() { return f3d::engine::createWasm(); },
       emscripten::return_value_policy::take_ownership())
     .function(
       "setCachePath", +[](f3d::engine& engine, const std::string& path) -> f3d::engine&

--- a/webassembly/testing/CMakeLists.txt
+++ b/webassembly/testing/CMakeLists.txt
@@ -19,12 +19,13 @@ endif()
 # Add all the ADD_TEST for each test
 foreach(test_name ${f3djsTests_list})
 
+  # Set TEST_JS_MODULE and TEST_CANVAS_ID used in configure_file
   set(TEST_JS_MODULE "${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.js")
+  set(TEST_CANVAS_ID "canvas")
 
+  # test_custom_canvas needs a different TEST_CANVAS_ID
   if (${test_name} STREQUAL "test_custom_canvas")
     set(TEST_CANVAS_ID "custom_id")
-  else()
-    set(TEST_CANVAS_ID "canvas")
   endif()
 
   configure_file(

--- a/webassembly/testing/CMakeLists.txt
+++ b/webassembly/testing/CMakeLists.txt
@@ -7,6 +7,7 @@ set(f3djsTests_list
   "test_render"
   "test_scene"
   "test_splats"
+  "test_custom_canvas"
 )
 
 find_program(CHROMIUM_EXECUTABLE chromium)
@@ -19,6 +20,13 @@ endif()
 foreach(test_name ${f3djsTests_list})
 
   set(TEST_JS_MODULE "${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.js")
+
+  if (${test_name} STREQUAL "test_custom_canvas")
+    set(TEST_CANVAS_ID "custom_id")
+  else()
+    set(TEST_CANVAS_ID "canvas")
+  endif()
+
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/test.html.in"
     "${CMAKE_CURRENT_BINARY_DIR}/${test_name}.html"

--- a/webassembly/testing/test.html.in
+++ b/webassembly/testing/test.html.in
@@ -15,7 +15,7 @@
 
   <body>
     <div id="main">
-      <canvas id="canvas"></canvas>
+      <canvas id="@TEST_CANVAS_ID@"></canvas>
     </div>
     <script src="@TEST_JS_MODULE@" type="module"></script>
   </body>

--- a/webassembly/testing/test_custom_canvas.js
+++ b/webassembly/testing/test_custom_canvas.js
@@ -1,0 +1,25 @@
+import utils from "./utils.js";
+
+const settings = {
+  runBefore: (Module) => {
+    const options = Module.engineInstance.getOptions();
+
+    // background must be set to black for proper blending with transparent canvas
+    options.setAsString("render.background.color", "#000000");
+
+    // setup coloring
+    options.toggle("model.scivis.enable");
+    options.setAsString("model.scivis.array_name", "Colors");
+    options.setAsString("model.scivis.component", "-2");
+    options.toggle("model.scivis.cells");
+
+    // default to +Z
+    options.setAsString("scene.up_direction", "+Z");
+  },
+  canvasId: "custom_id",
+};
+
+utils.runRenderTest(settings, {
+  data: "f3d.vtp",
+  baseline: "TestWasmCustomCanvas.png",
+});

--- a/webassembly/testing/utils.js
+++ b/webassembly/testing/utils.js
@@ -41,8 +41,12 @@ const utils = {
   },
 
   copyLocalFileToWasmFS: async (Module, localPath, wasmPath) => {
-    const data = await fetch(localPath).then((b) => b.arrayBuffer());
-    Module.FS.writeFile(wasmPath, new Uint8Array(data));
+    try {
+      const data = await fetch(localPath).then((b) => b.arrayBuffer());
+      Module.FS.writeFile(wasmPath, new Uint8Array(data));
+    } catch (error) {
+      console.error("Fail to copy file " + localPath);
+    }
   },
 
   runBasicTest: (settings) => {
@@ -59,7 +63,7 @@ const utils = {
   },
 
   runRenderTest: (settings, args) => {
-    settings.canvas = document.getElementById("canvas");
+    settings.canvas = document.getElementById(settings.canvasId || "canvas");
 
     f3d(settings)
       .then(async (Module) => {
@@ -81,7 +85,11 @@ const utils = {
 
         Module.Log.setVerboseLevel(Module.LogVerboseLevel.DEBUG, false);
 
-        Module.engineInstance = Module.Engine.create();
+        if (settings.canvasId !== undefined) {
+          Module.engineInstance = Module.Engine.create(`#${settings.canvasId}`);
+        } else {
+          Module.engineInstance = Module.Engine.create();
+        }
 
         // setup the window size based on the canvas size
         const scale = window.devicePixelRatio;
@@ -122,16 +130,21 @@ const utils = {
 
         // compare images
         const result = Module.engineInstance.getWindow().renderToImage(true);
-        const baseline = new Module.Image("/baseline.png");
-        const ssim = result.compare(baseline);
 
-        if (ssim <= 0.05) {
-          console.log("Passed with SSIM = " + ssim);
-        } else {
-          console.log("F3D_ERROR: Comparison failed with SSIM " + ssim);
+        try {
+          const baseline = new Module.Image("/baseline.png");
+          const ssim = result.compare(baseline);
 
-          utils.printImageBase64(Module, result);
+          if (ssim <= 0.05) {
+            console.log("Passed with SSIM = " + ssim);
+          } else {
+            console.log("F3D_ERROR: Comparison failed with SSIM " + ssim);
+          }
+        } catch (error) {
+          console.error("F3D_ERROR: Cannot read baseline image");
         }
+
+        utils.printImageBase64(Module, result);
 
         window.close();
       })


### PR DESCRIPTION
### Describe your changes

- Allow custom canvas ID
- Multiple engine are possible now within the same web page
- Improve test utility to detect when a baseline doesn't exist

### Issue ticket number and link if any

Fixes #3227 

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
