### PR TITLE
Fixes related to splats and wasm

### DIFF
--- a/vtkext/private/module/glsl/vtkF3DPointSplatVS.glsl
+++ b/vtkext/private/module/glsl/vtkF3DPointSplatVS.glsl
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 uniform float scaleFactor;
-uniform int cameraParallel;
+uniform mediump int cameraParallel;
 
 // low-pass filtering matrix
 // stored as a vector since it's a 2x2 symmetric matrix

--- a/vtkext/private/module/vtkF3DPointSplatMapper.cxx
+++ b/vtkext/private/module/vtkF3DPointSplatMapper.cxx
@@ -30,6 +30,7 @@
 #include <vtk_glad.h>
 
 #include <algorithm>
+#include <numeric>
 #include <sstream>
 #include <vector>
 
@@ -386,12 +387,14 @@ void vtkF3DSplatMapperHelper::SortSplatsCPU(vtkRenderer* ren)
 
   int numVerts = this->VBOs->GetNumberOfTuples("vertexMC");
 
-  this->CPUSortedIndices.resize(static_cast<size_t>(numVerts));
+  if (numVerts != static_cast<int>(this->CPUSortedIndices.size()))
+  {
+    this->CPUSortedIndices.resize(static_cast<size_t>(numVerts));
+    this->CPUDepths.resize(static_cast<size_t>(numVerts));
 
-  this->Primitives[PrimitivePoints].IBO->Download(
-    this->CPUSortedIndices.data(), static_cast<size_t>(numVerts));
+    std::iota(this->CPUSortedIndices.begin(), this->CPUSortedIndices.end(), 0);
+  }
 
-  this->CPUDepths.resize(static_cast<size_t>(numVerts));
   // compute depth for each splat
   vtkPolyData* poly = this->CurrentInput;
 
@@ -521,7 +524,7 @@ void vtkF3DSplatMapperHelper::ReplaceShaderColor(
     {
       vtkShaderProgram::Substitute(VSSource, "//VTK::Color::Dec",
         "//VTK::Color::Dec\n\n"
-        "uniform sampler2DArray sphericalHarmonics;\n"
+        "uniform mediump sampler2DArray sphericalHarmonics;\n"
         "uniform vec3 cameraDirection;\n"
         "vec3 decode(ivec3 texelIndex)\n"
         "{\n"

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -2761,7 +2761,8 @@ void vtkF3DRenderer::ConfigurePointSprites()
     return;
   }
 
-  if (!this->PointSpritesUseInstancing && !vtkShader::IsComputeShaderSupported())
+  if (this->GetBlendingMode() == vtkF3DRenderer::BlendingMode::SORT &&
+    !vtkShader::IsComputeShaderSupported())
   {
     F3DLog::Print(F3DLog::Severity::Warning,
       "Compute shaders are not supported, gaussians are not sorted, resulting in blending "


### PR DESCRIPTION
### Describe your changes

- Add missing GLES precision which can result in warnings in some browsers
- Improve performance of `sort_cpu` by reusing the CPU buffer instead of download it
- Do not warn if blending mode is not `sort` and compute shader is not supported

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
