### PR TITLE
TestWatch: give more time to update

### DIFF
--- a/application/testing/test_watch.ps1
+++ b/application/testing/test_watch.ps1
@@ -16,13 +16,13 @@ Remove-Item $reloaded_data
 $log = "$tmp_dir/output.log"
 $id = (Start-Process -FilePath $f3d_cmd -ArgumentList "--watch --verbose $reloaded_data" -RedirectStandardOutput $log -PassThru).Id
 
-Start-Sleep -Seconds 1
+Start-Sleep -Seconds 3
 Copy-Item $hires_data -Destination $reloaded_data
-Start-Sleep -Seconds 1
+Start-Sleep -Seconds 3
 Copy-Item $invalid_data -Destination $reloaded_data
-Start-Sleep -Seconds 1
+Start-Sleep -Seconds 3
 Copy-Item $lowres_data -Destination $reloaded_data
-Start-Sleep -Seconds 1
+Start-Sleep -Seconds 3
 
 $str = Select-String $log -Pattern "Number of points: 634"
 if ($str -ne $null) {

--- a/application/testing/test_watch.sh
+++ b/application/testing/test_watch.sh
@@ -26,12 +26,12 @@ function cleanup()
 }
 trap "cleanup" EXIT
 
-sleep 1
+sleep 3
 cp $hires_data $reloaded_data
-sleep 1
+sleep 3
 cp $invalid_data $reloaded_data
-sleep 1
+sleep 3
 cp $lowres_data $reloaded_data
-sleep 1
+sleep 3
 
 grep -q "Number of points: 634" $log


### PR DESCRIPTION
### Describe your changes

TestWatch is flaky on coverage or sanitizer jobs, give it more time.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
