### PR TITLE
Fix depth precision on GLES

### DIFF
--- a/examples/libf3d/web/src/main.js
+++ b/examples/libf3d/web/src/main.js
@@ -141,6 +141,10 @@ f3d(settings)
       .getWindow()
       .setSize(scale * main.clientWidth, scale * main.clientHeight);
 
+    const response = await fetch(`https://f3d.app/data/f3d.vtp`);
+    const arrayBuffer = await response.arrayBuffer();
+    openFile("f3d.vtp", new Uint8Array(arrayBuffer));
+
     // do a first render and start the interactor
     Module.engineInstance.getWindow().render();
     Module.engineInstance.getInteractor().start();

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "_docker": "${F3D_DOCKER_CLIENT:-docker} run --rm -e CMAKE_BUILD_PARALLEL_LEVEL -v $(pwd):/src ghcr.io/f3d-app/f3d-wasm:${F3D_DOCKER_TIMESTAMP:-latest}",
     "clean": "npm run _docker -- rm -rf /src/dist /src/_wasm_build",
-    "build": "npm run _docker -- /src/webassembly/build.sh Release",
+    "build": "npm run _docker -- /src/webassembly/build.sh ${F3D_BUILD_TYPE:-Release}",
     "test": "npm run _docker -- ctest --test-dir /src/_wasm_build/webassembly --output-on-failure",
     "prepare": "npm run clean && npm run build"
   },

--- a/testing/baselines/TestWasmAnimation.png
+++ b/testing/baselines/TestWasmAnimation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e25f2e5f8d8aeb224781a8b773146a12e1e41f80f0812779853823effcf154ad
-size 35314
+oid sha256:81a9fe70dbe440beb51aa59b3c5cb8dc4f57f0742c63a1f84d76c37c1df4780b
+size 35160

--- a/testing/baselines/TestWasmDepth.png
+++ b/testing/baselines/TestWasmDepth.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:008902b23bdf5021bdae3a713e099e10b09a9443a16dce637925412838032f48
+size 5325

--- a/testing/baselines/TestWasmSplats.png
+++ b/testing/baselines/TestWasmSplats.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e1241e53f3369f898f3a0fba0a93a49744aa58c4e1a7d1ada01e91b8c5a0328
-size 156489
+oid sha256:96cef896580c00ce4c2c9f78a84aeb7262302be96f7a0c361ac42c83db85af6f
+size 156228

--- a/vtkext/private/module/vtkF3DDisplayDepthRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DDisplayDepthRenderPass.cxx
@@ -52,14 +52,14 @@ void vtkF3DDisplayDepthRenderPass::Render(const vtkRenderState* state)
     vtkShaderProgram::Substitute(depthDisplayingFS, "//VTK::FSQ::Decl",
       "uniform sampler2D texDepth;\n"
       "uniform bool useColorMap;\n"
-      "uniform sampler1D colorMapTexture;\n"
+      "uniform sampler2D colorMapTexture;\n"
       "//VTK::FSQ::Decl");
 
     vtkShaderProgram::Substitute(depthDisplayingFS, "//VTK::FSQ::Impl",
       "float depth = texture(texDepth, texCoord).r;\n"
       "if (useColorMap)\n"
       "{\n"
-      "  vec4 colorMapped = texture(colorMapTexture, depth);\n"
+      "  vec4 colorMapped = texture(colorMapTexture, vec2(depth, 0.5));\n"
       "  gl_FragData[0] = vec4(colorMapped.rgb, 1.0);\n"
       "  return;\n"
       "}\n"
@@ -127,7 +127,7 @@ void vtkF3DDisplayDepthRenderPass::InitializeResources(vtkOpenGLRenderWindow* re
   {
     this->ColorMapTexture = vtkSmartPointer<vtkTextureObject>::New();
     this->ColorMapTexture->SetContext(renWin);
-    this->ColorMapTexture->Allocate1D(256, 3, VTK_FLOAT);
+    this->ColorMapTexture->Allocate2D(256, 1, 3, VTK_FLOAT);
     this->ColorMapTexture->SetWrapS(vtkTextureObject::ClampToEdge);
     this->ColorMapTexture->SetWrapT(vtkTextureObject::ClampToEdge);
     this->ColorMapTexture->SetMinificationFilter(vtkTextureObject::Linear);
@@ -148,7 +148,7 @@ void vtkF3DDisplayDepthRenderPass::InitializeResources(vtkOpenGLRenderWindow* re
       std::array<float, tableSize * 3> table;
       this->ColorMap->GetTable(range[0], range[1], tableSize, table.data());
 
-      this->ColorMapTexture->Create1DFromRaw(tableSize, 3, VTK_FLOAT, table.data());
+      this->ColorMapTexture->Create2DFromRaw(tableSize, 1, 3, VTK_FLOAT, table.data());
       this->ColorMapBuildTime.Modified();
     }
   }

--- a/vtkext/private/module/vtkF3DRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DRenderPass.cxx
@@ -297,7 +297,7 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
 #if !defined(__EMSCRIPTEN__) && !defined(__ANDROID__)
     // Needed because VTK can pick the wrong format with certain drivers
     // But Fixed32 not supported on GLES
-    this->MainPass->SetDepthFormat(vtkTextureObject::Fixed32);
+    this->MainOnTopPass->SetDepthFormat(vtkTextureObject::Fixed32);
 #endif
   }
 

--- a/vtkext/private/module/vtkF3DRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DRenderPass.cxx
@@ -232,6 +232,12 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
     this->MainPass = vtkSmartPointer<vtkFramebufferPass>::New();
     this->MainPass->SetColorFormat(vtkTextureObject::Float32);
 
+#if !defined(__EMSCRIPTEN__) && !defined(__ANDROID__)
+    // Needed because VTK can pick the wrong format with certain drivers
+    // But Fixed32 not supported on GLES
+    this->MainPass->SetDepthFormat(vtkTextureObject::Fixed32);
+#endif
+
     // TAA
     if (renderer && renderer->GetAntiAliasingMode() == vtkF3DRenderer::AntiAliasingMode::TAA)
     {
@@ -287,6 +293,12 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
 
     this->MainOnTopPass = vtkSmartPointer<vtkFramebufferPass>::New();
     this->MainOnTopPass->SetDelegatePass(camP);
+
+#if !defined(__EMSCRIPTEN__) && !defined(__ANDROID__)
+    // Needed because VTK can pick the wrong format with certain drivers
+    // But Fixed32 not supported on GLES
+    this->MainPass->SetDepthFormat(vtkTextureObject::Fixed32);
+#endif
   }
 
   this->InitializeTime = this->GetMTime();

--- a/vtkext/private/module/vtkF3DRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DRenderPass.cxx
@@ -232,9 +232,6 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
     this->MainPass = vtkSmartPointer<vtkFramebufferPass>::New();
     this->MainPass->SetColorFormat(vtkTextureObject::Float32);
 
-    // Needed because VTK can pick the wrong format with certain drivers
-    this->MainPass->SetDepthFormat(vtkTextureObject::Fixed32);
-
     // TAA
     if (renderer && renderer->GetAntiAliasingMode() == vtkF3DRenderer::AntiAliasingMode::TAA)
     {
@@ -290,9 +287,6 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
 
     this->MainOnTopPass = vtkSmartPointer<vtkFramebufferPass>::New();
     this->MainOnTopPass->SetDelegatePass(camP);
-
-    // Needed because VTK can pick the wrong format with certain drivers
-    this->MainOnTopPass->SetDepthFormat(vtkTextureObject::Fixed32);
   }
 
   this->InitializeTime = this->GetMTime();

--- a/webassembly/testing/CMakeLists.txt
+++ b/webassembly/testing/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(f3djsTests_list
   "test_camera"
+  "test_depth"
   "test_engine"
   "test_image"
   "test_interactor"

--- a/webassembly/testing/test_depth.js
+++ b/webassembly/testing/test_depth.js
@@ -1,0 +1,22 @@
+import utils from "./utils.js";
+
+const settings = {
+  runBefore: (Module) => {
+    const options = Module.engineInstance.getOptions();
+
+    // background must be set to black for proper blending with transparent canvas
+    options.setAsString("render.background.color", "#000000");
+
+    // setup coloring
+    options.toggle("model.scivis.enable");
+    options.toggle("render.effect.display_depth");
+
+    // default to +Z
+    options.setAsString("scene.up_direction", "+Z");
+  },
+};
+
+utils.runRenderTest(settings, {
+  data: "f3d.vtp",
+  baseline: "TestWasmDepth.png",
+});


### PR DESCRIPTION
### Describe your changes

- Add default model (`f3d.vtp`) in the web example
- Add support for env variable `F3D_BUILD_TYPE` to allow `Debug` when building wasm
- Fix depth display on wasm by converting the unsupported 1D texture to a 2D texture with height=1
- Use `vtkTextureObject::Float32` (default) instead of `vtkTextureObject::Fixed32` which is not supported in GLES
- Add a wasm test for depth display

### Issue ticket number and link if any

Fixes: https://github.com/f3d-app/f3d/issues/1555
Related: https://github.com/f3d-app/f3d/issues/2307

### Checklist for finalizing the PR

- [x ] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
