### PR TITLE
clip: fix 1s exit delay after clipboard save on X11

### DIFF
--- a/external/clip/clip_x11.cpp
+++ b/external/clip/clip_x11.cpp
@@ -593,6 +593,16 @@ private:
   void handle_selection_notify_event(xcb_selection_notify_event_t* event) {
     assert(event->requestor == m_window);
 
+#ifdef CLIP_SUPPORT_SAVE_TARGETS
+    // A SAVE_TARGETS conversion produces no reply data (the clipboard
+    // manager acknowledges by setting the property to XCB_ATOM_NONE),
+    // so unblock the waiter directly to avoid the wait_for timeout.
+    if (event->target == get_atom(SAVE_TARGETS)) {
+      call_callback(nullptr);
+      return;
+    }
+#endif
+
     if (event->target == get_atom(TARGETS))
       m_target_atom = get_atom(ATOM);
     else


### PR DESCRIPTION
## Summary

Fixes #3353.

After saving the state to the clipboard on X11 (Ctrl+C), F3D took ~1s to exit instead of exiting instantaneously.

## Root cause

On exit, `clip`'s `Manager` destructor hands off the clipboard content to the X11 clipboard manager via a `SAVE_TARGETS` conversion, then waits on `m_cv` for the `SelectionNotify` reply. `handle_selection_notify_event` only calls `call_callback` (which notifies `m_cv`) when `get_and_delete_property` returns a non-null reply. A `SAVE_TARGETS` conversion produces no reply data (per ICCCM the property is set to `XCB_ATOM_NONE` on success), so `call_callback` is never invoked and the wait blocks for the full `get_x11_wait_timeout()` (1000 ms) before falling through.

## Changes

- `external/clip/clip_x11.cpp`: in `handle_selection_notify_event`, short-circuit `SAVE_TARGETS` notifications by calling `call_callback(nullptr)` to unblock the waiter immediately.

## Testing

Manual verification on Linux (from the issue reproducer):
- `f3d path/to/cow.vtp`
- Ctrl+C (save state to clipboard)
- Ctrl+Q — process now exits instantaneously.
