### PR TITLE
CI: Clarify rendering backend usage and improve testing

### DIFF
--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -413,13 +413,15 @@ runs:
 
     # macOS needs VTK > 9.6.20260701 for proper grid rendering using osmesa
     # this test works with VTK 9.6.1 otherwise
+    # camera-view-angle is needed because of: https://github.com/f3d-app/f3d/issues/3375
+    # camera-position is needed until https://github.com/f3d-app/f3d/pull/3373 is merged
     - name: Check Install
       if: |
-        inputs.vtk_version == 'commit' && inputs.optdeps_label == 'optdeps'
+        inputs.vtk_version == 'commit' && inputs.optdeps_label == 'optdeps' && inputs.cpu != 'arm64'
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: |
-        ${{ env.F3D_BIN_PATH }} ../source/testing/data/dragon.vtu --output=output/install_output.png --reference=../source/.github/baselines/install_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --verbose --rendering-backend=${{ inputs.rendering_backend }}
+        ${{ env.F3D_BIN_PATH }} ../source/testing/data/dragon.vtu --output=output/install_output.png --reference=../source/.github/baselines/install_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --verbose --rendering-backend=${{ inputs.rendering_backend }} --camera-position=334.215,169.822,341.61 --camera-view-angle=32.1111
 
     # macOS needs VTK > 9.6.20260701 for proper grid rendering using osmesa
     # this test works with VTK 9.6.1 otherwise

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -414,14 +414,13 @@ runs:
     # macOS needs VTK > 9.6.20260701 for proper grid rendering using osmesa
     # this test works with VTK 9.6.1 otherwise
     # camera-view-angle is needed because of: https://github.com/f3d-app/f3d/issues/3375
-    # camera-position is needed until https://github.com/f3d-app/f3d/pull/3373 is merged
     - name: Check Install
       if: |
         inputs.vtk_version == 'commit' && inputs.optdeps_label == 'optdeps' && inputs.cpu != 'arm64'
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: |
-        ${{ env.F3D_BIN_PATH }} ../source/testing/data/dragon.vtu --output=output/install_output.png --reference=../source/.github/baselines/install_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --verbose --rendering-backend=${{ inputs.rendering_backend }} --camera-position=334.215,169.822,341.61 --camera-view-angle=32.1111
+        ${{ env.F3D_BIN_PATH }} ../source/testing/data/dragon.vtu --output=output/install_output.png --reference=../source/.github/baselines/install_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --verbose --rendering-backend=${{ inputs.rendering_backend }} --camera-view-angle=32.1111
 
     # macOS needs VTK > 9.6.20260701 for proper grid rendering using osmesa
     # this test works with VTK 9.6.1 otherwise

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -216,6 +216,39 @@ runs:
       working-directory: ${{github.workspace}}/build
       run: cmake --build . --parallel 2 --config Release
 
+    - name: Set F3D binary path Linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "F3D_BUILD_BIN_PATH=./bin/f3d" >> $GITHUB_ENV
+        echo "F3D_BIN_PATH=./bin/f3d" >> $GITHUB_ENV
+
+    - name: Set F3D binary path Windows
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        echo "F3D_BUILD_BIN_PATH=./bin_Release/f3d.exe" >> $GITHUB_ENV
+        echo "F3D_BIN_PATH=./bin/f3d.exe" >> $GITHUB_ENV
+        echo "F3D_CONSOLE_BIN_PATH=./bin/f3d-console.exe" >> $GITHUB_ENV
+
+    - name: Set F3D binary path MacOS bundle
+      if: |
+        runner.os == 'macOS' &&
+        inputs.bundle_label == 'bundle'
+      shell: bash
+      run: |
+        echo "F3D_BUILD_BIN_PATH=./bin/f3d.app/Contents/MacOS/f3d" >> $GITHUB_ENV
+        echo "F3D_BIN_PATH=./f3d.app/Contents/MacOS/f3d" >> $GITHUB_ENV
+
+    - name: Set F3D binary path MacOS no-bundle
+      if: |
+        runner.os == 'macOS' &&
+        inputs.bundle_label != 'bundle'
+      shell: bash
+      run: |
+        echo "F3D_BUILD_BIN_PATH=./bin/f3d" >> $GITHUB_ENV
+        echo "F3D_BIN_PATH=./bin/f3d" >> $GITHUB_ENV
+
     # Linux: Xvfb is not running, should fallback to egl
     # Windows: mesa binary is not installed, should fallback to osmesa
     # macOS: No fallback mechanism to test, CI always uses osmesa (with VTK > 9.6.20260701), check cocoa is functional
@@ -223,7 +256,7 @@ runs:
       shell: bash
       working-directory: ${{github.workspace}}/build
       run: |
-        ./bin/f3d ../source/testing/data/dragon.vtu --output=Testing/Temporary/build_output.png --reference=../source/.github/baselines/build_output.png --resolution=300,300 --verbose
+        ${{ env.F3D_BUILD_BIN_PATH }} ../source/testing/data/dragon.vtu --output=Testing/Temporary/build_output.png --reference=../source/.github/baselines/build_output.png --resolution=300,300 --verbose
 
     # When running standard test with auto rendering backend on linux, use glx
     - name: Run Xvfb ubuntu
@@ -370,32 +403,6 @@ runs:
       working-directory: ${{github.workspace}}
       run: ctest --test-dir build_plugins --no-tests=error -C Release -VV
 
-    - name: Set F3D binary path Linux
-      if: runner.os == 'Linux'
-      shell: bash
-      run: echo "F3D_BIN_PATH=./bin/f3d" >> $GITHUB_ENV
-
-    - name: Set F3D binary path Windows
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        echo "F3D_BIN_PATH=./bin/f3d.exe" >> $GITHUB_ENV
-        echo "F3D_CONSOLE_BIN_PATH=./bin/f3d-console.exe" >> $GITHUB_ENV
-
-    - name: Set F3D binary path MacOS bundle
-      if: |
-        runner.os == 'macOS' &&
-        inputs.bundle_label == 'bundle'
-      shell: bash
-      run: echo "F3D_BIN_PATH=./f3d.app/Contents/MacOS/f3d" >> $GITHUB_ENV
-
-    - name: Set F3D binary path MacOS no-bundle
-      if: |
-        runner.os == 'macOS' &&
-        inputs.bundle_label != 'bundle'
-      shell: bash
-      run: echo "F3D_BIN_PATH=./bin/f3d" >> $GITHUB_ENV
-
     - name: Install plugin examples
       if: inputs.static_label == 'no-static'
       shell: bash
@@ -418,7 +425,7 @@ runs:
     # this test works with VTK 9.6.1 otherwise
     - name: Check Install plugins
       if: |
-        inputs.vtk_version == 'commit' && inputs.optdeps_label == 'optdeps'
+        inputs.vtk_version == 'commit' && inputs.optdeps_label == 'optdeps' && inputs.static_label == 'no-static'
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: |

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -223,7 +223,7 @@ runs:
       shell: bash
       working-directory: ${{github.workspace}}/build
       run: |
-        ./bin/f3d ../source/testing/data/dragon.vtu --output=Testing/Temporary/build_output.png --reference=../source/.github/baselines/build_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --verbose
+        ./bin/f3d ../source/testing/data/dragon.vtu --output=Testing/Temporary/build_output.png --reference=../source/.github/baselines/build_output.png --resolution=300,300 --verbose
 
     # When running standard test with auto rendering backend on linux, use glx
     - name: Run Xvfb ubuntu

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -218,7 +218,7 @@ runs:
 
     # Linux: Xvfb is not running, should fallback to egl
     # Windows: mesa binary is not installed, should fallback to osmesa
-    # macOS: No fallback mechanism to test, CI always uses osmesa (with VTK > 9.6.20260701), check cocoa is functionnal
+    # macOS: No fallback mechanism to test, CI always uses osmesa (with VTK > 9.6.20260701), check cocoa is functional
     - name: Check rendering backend logic
       shell: bash
       working-directory: ${{github.workspace}}/build

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -216,6 +216,16 @@ runs:
       working-directory: ${{github.workspace}}/build
       run: cmake --build . --parallel 2 --config Release
 
+    # Linux: Xvfb is not running, should fallback to egl
+    # Windows: mesa binary is not installed, should fallback to osmesa
+    # macOS: No fallback mechanism to test, CI always uses osmesa (with VTK > 9.6.20260701), check cocoa is functionnal
+    - name: Check rendering backend logic
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      run: |
+        ./bin/f3d ../source/testing/data/dragon.vtu --output=Testing/Temporary/build_output.png --reference=../source/.github/baselines/build_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --verbose
+
+    # When running standard test with auto rendering backend on linux, use glx
     - name: Run Xvfb ubuntu
       if: |
         runner.os == 'Linux' &&
@@ -223,8 +233,7 @@ runs:
       shell: bash
       run: Xvfb $DISPLAY -screen 0 1280x1024x24 &
 
-    # We install a proper WGL Mesa driver for regular tests
-    # This is needed because F3D_TESTING_ENABLE_WGL_TESTS options is enabled
+    # When running standard test on windows, use wgl
     - name: Install Mesa Windows
       if: runner.os == 'Windows'
       uses: f3d-app/install-mesa-windows-action@v3
@@ -238,7 +247,7 @@ runs:
       run: echo "F3D_CTEST_EXCEPTIONS=(test_scene_zero_copy)" >> $GITHUB_ENV
 
     # Certain tests are failing on macOS software rendering
-    # OSMesa is used for VTK > 9.6, remove when it's dropped
+    # OSMesa is used for VTK > 9.6.20260701, remove when it's dropped
     - name: Set CI test exception for macOS x86_64
       if: |
         runner.os == 'macOS' &&
@@ -248,7 +257,7 @@ runs:
       run: echo "F3D_CTEST_EXCEPTIONS=(TestDXF)|(TestPipedDXF)|(TestScalarsCell)|(TestXCAFColors)|(TestInteractionAnimationSlow)|(TestInteractionFocalPointPickingPoints)|(TestInteractionCycleAnimation)|(TestInteractionCycleComp)|(TestGLTFRigArmature)|(TestInteractionNoModelScrollWheel)|(TestInteractionNoModelScrollBar)|(TestInteractionTAA)|(TestInteractionPointCloudTAA)|(TestInteractionStochasticTAA)" >> $GITHUB_ENV
 
     # Certain tests are failing on macOS software rendering
-    # OSMesa is used for VTK > 9.6, remove when it's dropped
+    # OSMesa is used for VTK > 9.6.20260701, remove when it's dropped
     - name: Set CI test exception for macOS arm64
       if: |
         runner.os == 'macOS' &&
@@ -288,6 +297,12 @@ runs:
         cmake --install . --component configuration
         cmake --install . --component colormaps
 
+    - name: Install Mesa Windows in install
+      if: runner.os == 'Windows'
+      uses: f3d-app/install-mesa-windows-action@v2
+      with:
+        path: ${{github.workspace}}\install\bin
+
     - name: Build and configure python externally
       if: |
         inputs.optdeps_label == 'optdeps' &&
@@ -318,6 +333,14 @@ runs:
       shell: bash
       working-directory: ${{github.workspace}}
       run: cmake --build build_examples --config Release
+
+    - name: Install Mesa Windows examples
+      if: |
+        runner.os == 'Windows' &&
+        inputs.static_label == 'no-static'
+      uses: f3d-app/install-mesa-windows-action@v2
+      with:
+        path: ${{github.workspace}}\build_examples\*\*\Release
 
     # older VTK version create different renderings so they are not tested
     - name: Test libf3d examples
@@ -381,21 +404,21 @@ runs:
         cmake --install build_plugins --config Release
         cmake --install build_plugins --config Release --component configuration
 
-    # Grid rendering has artifacts in macOS arm64 CI
-    # https://github.com/f3d-app/f3d/issues/1276
+    # macOS needs VTK > 9.6.20260701 for proper grid rendering using osmesa
+    # this test works with VTK 9.6.1 otherwise
     - name: Check Install
       if: |
-        inputs.vtk_version != 'v9.4.2' && inputs.vtk_version != 'v9.5.2'
-        && inputs.cpu != 'arm64' && inputs.optdeps_label == 'optdeps'
+        inputs.vtk_version == 'commit' && inputs.optdeps_label == 'optdeps'
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: |
         ${{ env.F3D_BIN_PATH }} ../source/testing/data/dragon.vtu --output=output/install_output.png --reference=../source/.github/baselines/install_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --verbose --rendering-backend=${{ inputs.rendering_backend }}
 
+    # macOS needs VTK > 9.6.20260701 for proper grid rendering using osmesa
+    # this test works with VTK 9.6.1 otherwise
     - name: Check Install plugins
       if: |
-        inputs.vtk_version != 'v9.4.2' && inputs.vtk_version != 'v9.5.2' && inputs.cpu != 'arm64'
-        && inputs.static_label == 'no-static' && inputs.optdeps_label == 'optdeps'
+        inputs.vtk_version == 'commit' && inputs.optdeps_label == 'optdeps'
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: |

--- a/.github/actions/python-ci/action.yml
+++ b/.github/actions/python-ci/action.yml
@@ -118,7 +118,6 @@ runs:
       shell: bash
       run: Xvfb $DISPLAY -screen 0 1280x1024x24 &
 
-    # Needed for examples/libf3d/python/qt6/test_minimal_qt6.py
     - name: Install Mesa Windows
       if: runner.os == 'Windows'
       uses: f3d-app/install-mesa-windows-action@v3

--- a/.github/baselines/build_output.png
+++ b/.github/baselines/build_output.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12796ac661c86aa6a607f7e53f4476b5c7e2600adc636d35f71af721c54e0bf2
+size 21914


### PR DESCRIPTION
### Describe your changes

Clarify the behavior of the CI in regards to rendering backend:

- Linux (auto): Use Xvfb for all standard test trough the logic that should select `glx`, special test may use `egl` or `osmesa`
- Linux (egl): Use system egl for all standard test trough the `egl` rendering backend, special test may use `osmesa`
- Linux (osmesa): Use our own built osmesa for all standard test trough the `osmesa` rendering backend, special test may use `egl`
- Windows : Use binary mesa installed next to binaries, except for special tests using our own built `osmesa`
- macOS [commit]: Use osmesa everywhere, except for a special CI test using cocoa
- macOS [vtk 9.6 and older]: Use cocoa everywhere

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
