### PR TITLE
CI: Make it more granular

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -15,6 +15,7 @@ jobs:
   build_website:
     name: Build website
     if: github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:website') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,16 @@ jobs:
     name: Update LFS data cache
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:android') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:not_as_fast') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:linux') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:macos_arm') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:macos_intel') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:windows') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:python') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:sanitizer') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:analysis') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:wasm') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     outputs:
@@ -50,7 +58,10 @@ jobs:
     name: Recover VTK matrix
     runs-on: ubuntu-24.04
     if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:linux') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:macos_arm') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:macos_intel') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:windows') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     outputs:
@@ -77,7 +88,7 @@ jobs:
   windows:
     needs: [cache_lfs, recover_vtk_matrix]
     if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:windows') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     strategy:
@@ -117,7 +128,6 @@ jobs:
     needs: cache_lfs
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
@@ -141,10 +151,40 @@ jobs:
           versions_file: ./source/.github/workflows/versions.json
           build_type: fast
           vtk_version: v9.6.2
-          rendering_backend: auto
           optdeps_label: no-optdeps
           exclude_deprecated_label: exclude-deprecated
-          static_label: no-static
+          lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
+
+  #----------------------------------------------------------------------------
+  # Linux not as fast CI: Build and test a single complete linux CI
+  #----------------------------------------------------------------------------
+  linux_fast:
+    needs: cache_lfs
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:not_as_fast') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04
+    container: ghcr.io/f3d-app/f3d-ci
+
+    env:
+      CMAKE_POLICY_VERSION_MINIMUM: 3.5
+      DISPLAY: :0
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          path: "source"
+          fetch-depth: 0
+          lfs: false
+
+      - name: Generic CI
+        uses: ./source/.github/actions/generic-ci
+        with:
+          versions_file: ./source/.github/workflows/versions.json
+          build_type: not-as-fast
+          vtk_version: commit
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
 
   #----------------------------------------------------------------------------
@@ -153,7 +193,7 @@ jobs:
   linux:
     needs: [cache_lfs, recover_vtk_matrix]
     if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:linux') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     strategy:
@@ -244,6 +284,7 @@ jobs:
   macos_intel:
     needs: [cache_lfs, recover_vtk_matrix]
     if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:macos_intel') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     strategy:
@@ -281,7 +322,7 @@ jobs:
   macos_arm:
     needs: [cache_lfs, recover_vtk_matrix]
     if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:macos_arm') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     strategy:
@@ -330,6 +371,7 @@ jobs:
   python_packaging:
     needs: cache_lfs
     if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:python') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     strategy:
@@ -378,7 +420,7 @@ jobs:
   coverage:
     needs: cache_lfs
     if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:coverage') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
@@ -411,6 +453,7 @@ jobs:
   sanitizer:
     needs: cache_lfs
     if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:sanitizer') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     strategy:
@@ -449,7 +492,7 @@ jobs:
   static-analysis:
     needs: cache_lfs
     if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:analysis') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     strategy:
@@ -482,6 +525,7 @@ jobs:
   #----------------------------------------------------------------------------
   external-build:
     if: |
+      contains(github.event.pull_request.labels.*.name, 'ci:external') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     strategy:
@@ -514,6 +558,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:android') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:wasm') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Update LFS data cache
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:not_as_fast') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:extended') ||
       contains(github.event.pull_request.labels.*.name, 'ci:linux') ||
       contains(github.event.pull_request.labels.*.name, 'ci:macos_arm') ||
       contains(github.event.pull_request.labels.*.name, 'ci:macos_intel') ||
@@ -158,10 +158,10 @@ jobs:
   #----------------------------------------------------------------------------
   # Linux not as fast CI: Build and test a single complete linux CI
   #----------------------------------------------------------------------------
-  linux_fast:
+  linux_extended:
     needs: cache_lfs
     if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:not_as_fast') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:extended') ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
@@ -183,7 +183,7 @@ jobs:
         uses: ./source/.github/actions/generic-ci
         with:
           versions_file: ./source/.github/workflows/versions.json
-          build_type: not-as-fast
+          build_type: extended
           vtk_version: commit
           lfs_sha: ${{ needs.cache_lfs.outputs.lfs_sha}}
 

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -12,10 +12,6 @@ jobs:
   style_checks:
     name: Formatting Check
     runs-on: ubuntu-latest
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:fast') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:main') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full')
     env:
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ To run the CI, just add a comment like this in your PR:
 - `\ci wasm`: Build docker images and then build libf3d with webassambly.
 - `\ci android`: Build docker images and then build libf3d for android.
 - `\ci website`: Build the f3d.app website using current state of the doc.
-- `\ci full`: All of the above, required before merging
+- `\ci full`: All of the above, required before merging.
 
 After this, the CI will always be run every time you push to your branch.
 To remove a label, use the same syntax with a `-` before the label, eg: `\ci -fast`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,17 +85,17 @@ Make sure to check the results for yourself and ask for help if needed.
 
 To run the CI, just add a comment like this in your PR:
 
-- `\ci fast`: A fast linux job, always make this work first.
-- `\ci not_as_fast`: A "not as fast" linux job, always make this work second.
-- `\ci linux: Many different linux jobs across CMake options, dependencies and vtk versions.
-- `\ci windows: Cross VTK versions of Windows jobs.
-- `\ci macos_intel: Cross VTK versions of macOS intel jobs.
-- `\ci macos_arm: Cross VTK versions of macOS arm64 jobs.
-- `\ci coverage: A linux job dedicated to coverage computation.
-- `\ci sanitizer: Linux jobs running with different sanitizer settings.
-- `\ci analysis: A Linux cppcheck job.
-- `\ci external: A linux job building the libf3d as a subproject of a larger project.
-- `\ci python: Cross-platform cross-version jobs building libf3d for python.
+- `\ci fast`: A fast linux job without optional dependencies, always make this work first.
+- `\ci extended`: An extended linux job with depencies and recent VTK, always make this work second.
+- `\ci linux`: Many different linux jobs across CMake options, dependencies and vtk versions.
+- `\ci windows`: Cross VTK versions of Windows jobs.
+- `\ci macos_intel`: Cross VTK versions of macOS intel jobs.
+- `\ci macos_arm`: Cross VTK versions of macOS arm64 jobs.
+- `\ci coverage`: A linux job dedicated to coverage computation.
+- `\ci sanitizer`: Linux jobs running with different sanitizer settings.
+- `\ci analysis`: A Linux cppcheck job.
+- `\ci external`: A linux job building the libf3d as a subproject of a larger project.
+- `\ci python`: Cross-platform cross-version jobs building libf3d for python.
 - `\ci wasm`: Build docker images and then build libf3d with webassambly.
 - `\ci android`: Build docker images and then build libf3d for android.
 - `\ci website`: Build the f3d.app website using current state of the doc.
@@ -103,6 +103,8 @@ To run the CI, just add a comment like this in your PR:
 
 After this, the CI will always be run every time you push to your branch.
 To remove a label, use the same syntax with a `-` before the label, eg: `\ci -fast`.
+
+Please add only the labels required to work on your feature, in order to avoid using the limited pool of runners for no good reason.
 
 F3D continuous integration will also check the coverage as it is a good way to evaluate if new features are being tested or not.
 When adding code to F3D, always try to cover it by adding/modifying [tests](doc/dev/06-TESTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Make sure to check the results for yourself and ask for help if needed.
 To run the CI, just add a comment like this in your PR:
 
 - `\ci fast`: A fast linux job without optional dependencies, always make this work first.
-- `\ci extended`: An extended linux job with depencies and recent VTK, always make this work second.
+- `\ci extended`: An extended linux job with dependencies and recent VTK, always make this work second.
 - `\ci linux`: Many different linux jobs across CMake options, dependencies and vtk versions.
 - `\ci windows`: Cross VTK versions of Windows jobs.
 - `\ci macos_intel`: Cross VTK versions of macOS intel jobs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,11 +85,21 @@ Make sure to check the results for yourself and ask for help if needed.
 
 To run the CI, just add a comment like this in your PR:
 
-- `\ci fast`: Style checks and a fast linux job, always make this work first.
-- `\ci main`: Cross platform CI that cover most usecases, including coverage, contains `ci:fast`, ask for a maintainer review before running this.
+- `\ci fast`: A fast linux job, always make this work first.
+- `\ci not_as_fast`: A "not as fast" linux job, always make this work second.
+- `\ci linux: Many different linux jobs across CMake options, dependencies and vtk versions.
+- `\ci windows: Cross VTK versions of Windows jobs.
+- `\ci macos_intel: Cross VTK versions of macOS intel jobs.
+- `\ci macos_arm: Cross VTK versions of macOS arm64 jobs.
+- `\ci coverage: A linux job dedicated to coverage computation.
+- `\ci sanitizer: Linux jobs running with different sanitizer settings.
+- `\ci analysis: A Linux cppcheck job.
+- `\ci external: A linux job building the libf3d as a subproject of a larger project.
+- `\ci python: Cross-platform cross-version jobs building libf3d for python.
 - `\ci wasm`: Build docker images and then build libf3d with webassambly.
 - `\ci android`: Build docker images and then build libf3d for android.
-- `\ci full`: Complete CI, required before merge, contains `ci:main`, `ci:wasm`, `ci:android`.
+- `\ci website`: Build the f3d.app website using current state of the doc.
+- `\ci full`: All of the above, required before merging
 
 After this, the CI will always be run every time you push to your branch.
 To remove a label, use the same syntax with a `-` before the label, eg: `\ci -fast`.


### PR DESCRIPTION
### Describe your changes

Make CI labels more granular

- `\ci fast`: A fast linux job without optional dependencies, always make this work first.
- `\ci extended`: An extended linux job with dependencies and recent VTK, always make this work second.
- `\ci linux`: Many different linux jobs across CMake options, dependencies and vtk versions.
- `\ci windows`: Cross VTK versions of Windows jobs.
- `\ci macos_intel`: Cross VTK versions of macOS intel jobs.
- `\ci macos_arm`: Cross VTK versions of macOS arm64 jobs.
- `\ci coverage`: A linux job dedicated to coverage computation.
- `\ci sanitizer`: Linux jobs running with different sanitizer settings.
- `\ci analysis`: A Linux cppcheck job.
- `\ci external`: A linux job building the libf3d as a subproject of a larger project.
- `\ci python`: Cross-platform cross-version jobs building libf3d for python.
- `\ci wasm`: Build docker images and then build libf3d with webassambly.
- `\ci android`: Build docker images and then build libf3d for android.
- `\ci website`: Build the f3d.app website using current state of the doc.
- `\ci full`: All of the above, required before merging.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I did not use AI to generate any of the content of that pull request
- [ ] I used AI to generate code in that pull request, if yes [please disclose](https://f3d.app/dev/AI_POLICY) which part of the code was generated and with which model.
- ...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
