### PR TITLE
feat: add options to customize normal glyphs color and arrow resolution

### DIFF
--- a/application/F3DOptionsTools.h
+++ b/application/F3DOptionsTools.h
@@ -132,6 +132,8 @@ static inline const std::map<std::string_view, std::string_view> LibOptionsNames
   { "metallic", "model.material.metallic" },
   { "normal-glyphs", "model.normal_glyphs.enable" },
   { "normal-glyphs-scale", "model.normal_glyphs.scale" },
+  { "normal-glyphs-color", "model.normal_glyphs.color" },
+  { "normal-glyphs-arrow-resolution", "model.normal_glyphs.arrow_resolution" },
   { "normal-scale", "model.normal.scale" },
   { "notifications", "ui.notifications.enable" },
   { "opacity", "model.color.opacity" },

--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -142,6 +142,8 @@ f3d_test(NAME TestVolumeColoringArray DATA waveletArrays.vti ARGS -vb --coloring
 f3d_test(NAME TestNormalGlyphsPerspectiveEnable DATA suzanne.obj ARGS --normal-glyphs)
 f3d_test(NAME TestNormalGlyphsOrthographicEnable DATA suzanne.obj ARGS --normal-glyphs --camera-orthographic)
 f3d_test(NAME TestNormalGlyphsScale DATA suzanne.obj ARGS --normal-glyphs --normal-glyphs-scale=0.1)
+f3d_test(NAME TestNormalGlyphsColor DATA suzanne.obj ARGS --normal-glyphs --normal-glyphs-color=1,0,0)
+f3d_test(NAME TestNormalGlyphsArrowResolution DATA suzanne.obj ARGS --normal-glyphs --normal-glyphs-arrow-resolution=3)
 f3d_test(NAME TestNormalGlyphsNoNormalsAvailable DATA cow.vtp ARGS --normal-glyphs NO_BASELINE REGEXP "does not contain any normals")
 
 ## Textures

--- a/doc/libf3d/03-OPTIONS.md
+++ b/doc/libf3d/03-OPTIONS.md
@@ -156,6 +156,14 @@ Render vertex normals as arrows on top of the geometry.
 
 Scales the normal glyphs
 
+### `model.normal_glyphs.color` (_color_, default: `f3d_white`)
+
+Color of the normal glyphs
+
+### `model.normal_glyphs.arrow_resolution` (_int_, default: `6`, range domain: `[3, 30]`, increment: `1`)
+
+Resolution/discretization of the normal glyph arrows
+
 ### `model.normal.scale` (_double_, optional, range domain: `[0, 3]`, increment: `0.1`)
 
 Normal scale affects the strength of the normal deviation from the normal texture. Model-specified by default.

--- a/doc/user/03-OPTIONS.md
+++ b/doc/user/03-OPTIONS.md
@@ -380,6 +380,14 @@ Adjusts the scales of normal glyphs.
 | ----------------------------------------- | ----------------------------------------- |
 | ![](./images/normal_glyphs_scale_0.3.png) | ![](./images/normal_glyphs_scale_0.7.png) |
 
+### `--normal-glyphs-color` (_color_, default: `f3d_white`)
+
+Color of the normal glyphs
+
+### `--normal-glyphs-arrow-resolution` (_int_, default: `6`)
+
+Resolution/discretization of the normal glyph arrows
+
 ### `-o`, `--point-sprites=<none|sphere|gaussian|circle|stddev|bound|cross>` (_string_, default: `none`, implicit: `sphere`)
 
 Select _points sprites_ types to show instead of the geometry.

--- a/library/options.json
+++ b/library/options.json
@@ -541,6 +541,20 @@
           "max": "10.0",
           "increment": "0.1"
         }
+      },
+      "color": {
+        "type": "color",
+        "parsed_default_value": "f3d_white"
+      },
+      "arrow_resolution": {
+        "type": "int",
+        "default_value": "6",
+        "domain": {
+          "style": "range",
+          "min": "3",
+          "max": "30",
+          "increment": "1"
+        }
       }
     },
     "volume": {

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -418,6 +418,8 @@ void window_impl::UpdateDynamicOptions()
 
   renderer->SetUseNormalGlyphs(opt.model.normal_glyphs.enable);
   renderer->SetNormalGlyphScaleMultiplier(opt.model.normal_glyphs.scale);
+  renderer->SetNormalGlyphsColor(opt.model.normal_glyphs.color);
+  renderer->SetNormalGlyphsArrowResolution(opt.model.normal_glyphs.arrow_resolution);
 
   // XXX: model.point_sprites.type only has an effect on geometry scene
   // but we set it here for practical reasons

--- a/resources/cli-options.json
+++ b/resources/cli-options.json
@@ -347,6 +347,16 @@
           "longName": "normal-glyphs-scale",
           "helpText": "Scale normal glyphs",
           "valueHelper": "<ratio>"
+        },
+        {
+          "longName": "normal-glyphs-color",
+          "helpText": "Color of the normal glyphs",
+          "valueHelper": "<color>"
+        },
+        {
+          "longName": "normal-glyphs-arrow-resolution",
+          "helpText": "Resolution/discretization of the normal glyph arrows",
+          "valueHelper": "<int>"
         }
       ]
     },

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -18,6 +18,7 @@
 #include "vtkF3DSolidBackgroundPass.h"
 #include "vtkF3DUserRenderPass.h"
 
+#include <vtkArrowSource.h>
 #include <vtkAxesActor.h>
 #include <vtkBoundingBox.h>
 #include <vtkCamera.h>
@@ -1726,6 +1727,33 @@ void vtkF3DRenderer::SetBlurCircleOfConfusionRadius(double radius)
 void vtkF3DRenderer::SetNormalGlyphScaleMultiplier(double multiplier)
 {
   this->NormalGlyphScaleMultiplier = multiplier;
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DRenderer::SetNormalGlyphsColor(const std::vector<double>& color)
+{
+  for (const auto& normalGlyph : this->Importer->GetNormalGlyphsActorsAndMappers())
+  {
+    normalGlyph.Actor->GetProperty()->SetColor(color.data());
+  }
+}
+
+//----------------------------------------------------------------------------
+void vtkF3DRenderer::SetNormalGlyphsArrowResolution(int resolution)
+{
+  for (const auto& normalGlyph : this->Importer->GetNormalGlyphsActorsAndMappers())
+  {
+    if (normalGlyph.GlyphMapper && normalGlyph.GlyphMapper->GetSourceConnection(0))
+    {
+      vtkArrowSource* arrowSource = vtkArrowSource::SafeDownCast(
+        normalGlyph.GlyphMapper->GetSourceConnection(0)->GetProducer());
+      if (arrowSource)
+      {
+        arrowSource->SetTipResolution(resolution);
+        arrowSource->SetShaftResolution(resolution);
+      }
+    }
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -361,6 +361,16 @@ public:
   void SetNormalGlyphScaleMultiplier(double multiplier);
 
   /**
+   * Sets the normal glyphs color
+   */
+  void SetNormalGlyphsColor(const std::vector<double>& color);
+
+  /**
+   * Sets the normal glyphs arrow resolution
+   */
+  void SetNormalGlyphsArrowResolution(int resolution);
+
+  /**
    * Set the visibility of the point sprites actor.
    * It will only be shown if raytracing and volume are not enabled
    */


### PR DESCRIPTION
Adds options to libf3d and the F3D application to customize the color and shape/discretization of normal glyph arrows.

Added model.normal_glyphs.color option to set actor color.
Added model.normal_glyphs.arrow_resolution option to dynamically set tip and shaft resolution of vtkArrowSource via the vtkGlyph3DMapper.
Added command line arguments --normal-glyphs-color and --normal-glyphs-arrow-resolution.
Updated library and user documentation.

Resolves #3120

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [x] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [ ] I have not used AI to generate any of the content of this pull request
- [x] I have used AI to generate code in this pull request:
- [x] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
- [x] I have carefully reviewed and completely understood every generated line.
- [x] I disclose below which parts of the code were generated and with which AI model:
    All code changes (options schemas, F3DOptionsTools mapping, CLI arguments description, C++ renderer additions, and integration tests) were designed and generated using Google's Gemini coding assistant.

...

### Continuous integration
\ci fast
Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
