### PR TITLE
Add user notification callback

### DIFF
--- a/c/interactor_c_api.cxx
+++ b/c/interactor_c_api.cxx
@@ -318,8 +318,8 @@ void f3d_interactor_set_notification_callback(
   }
 
   cpp_interactor->setNotificationCallback(
-    [=](const std::string& desc, const std::string& value,
-                         const std::string& bind, double duration) -> bool
+    [=](const std::string& desc, const std::string& value, const std::string& bind,
+      double duration) -> bool
     {
       int res = callback(desc.c_str(), value.c_str(), bind.c_str(), duration, user_data);
       return res != 0;

--- a/c/interactor_c_api.cxx
+++ b/c/interactor_c_api.cxx
@@ -302,6 +302,31 @@ void f3d_interactor_set_event_loop_user_callback(
 }
 
 //----------------------------------------------------------------------------
+void f3d_interactor_set_notification_callback(
+  f3d_interactor_t* interactor, f3d_interactor_notification_callback_t callback, void* user_data)
+{
+  if (!interactor)
+  {
+    return;
+  }
+
+  f3d::interactor* cpp_interactor = reinterpret_cast<f3d::interactor*>(interactor);
+  if (!callback)
+  {
+    cpp_interactor->setNotificationCallback(nullptr);
+    return;
+  }
+
+  cpp_interactor->setNotificationCallback(
+    [=](const std::string& desc, const std::string& value,
+                         const std::string& bind, double duration) -> bool
+    {
+      int res = callback(desc.c_str(), value.c_str(), bind.c_str(), duration, user_data);
+      return res != 0;
+    });
+}
+
+//----------------------------------------------------------------------------
 void f3d_interactor_start(f3d_interactor_t* interactor, double delta_time)
 {
   if (!interactor)

--- a/c/interactor_c_api.h
+++ b/c/interactor_c_api.h
@@ -463,6 +463,27 @@ extern "C"
     f3d_interactor_t* interactor, f3d_interactor_callback_t callback, void* user_data);
 
   /**
+   * @brief Notification callback signature.
+   *
+   * Return zero to prevent standard notification from being displayed.
+   * Arguments are the description, value, bindings, and duration of the notification.
+   */
+  typedef int (*f3d_interactor_notification_callback_t)(const char* desc, const char* value,
+    const char* bind, double duration, void* user_data);
+
+  /**
+   * @brief Set the notification callback.
+   *
+   * The callback is invoked when a notification is triggered.
+   *
+   * @param interactor Interactor handle.
+   * @param callback Notification callback, or NULL to clear.
+   * @param user_data Optional opaque pointer passed to callback.
+   */
+  F3D_EXPORT void f3d_interactor_set_notification_callback(
+    f3d_interactor_t* interactor, f3d_interactor_notification_callback_t callback, void* user_data);
+
+  /**
    * @brief Stop the interactor.
    *
    * @param interactor Interactor handle.

--- a/c/interactor_c_api.h
+++ b/c/interactor_c_api.h
@@ -468,8 +468,8 @@ extern "C"
    * Return zero to prevent standard notification from being displayed.
    * Arguments are the description, value, bindings, and duration of the notification.
    */
-  typedef int (*f3d_interactor_notification_callback_t)(const char* desc, const char* value,
-    const char* bind, double duration, void* user_data);
+  typedef int (*f3d_interactor_notification_callback_t)(
+    const char* desc, const char* value, const char* bind, double duration, void* user_data);
 
   /**
    * @brief Set the notification callback.

--- a/c/testing/test_interactor.c
+++ b/c/testing/test_interactor.c
@@ -61,6 +61,7 @@ int test_interactor()
   f3d_interactor_trigger_event_loop(interactor, 0.016);
 
   f3d_interactor_trigger_notification(interactor, "foo", "bar", 3.0);
+  f3d_interactor_set_notification_callback(interactor, NULL, NULL);
 
   f3d_interactor_play_interaction(interactor, "/nonexistent.log", 1.0 / 30.0);
   f3d_interactor_record_interaction(interactor, "/tmp/test_interaction.log");

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -708,4 +708,58 @@ extern "C"
     GetInteractor(env, self).triggerNotification(valueCpp, valueCpp, duration);
     return self;
   }
+
+  JNIEXPORT jobject JAVA_BIND(Interactor, setNotificationCallback)(
+    JNIEnv* env, jobject self, jobject callback)
+  {
+    // store global ref
+    static jobject gNotificationCallback = nullptr;
+    if (gNotificationCallback != nullptr)
+    {
+      env->DeleteGlobalRef(gNotificationCallback);
+      gNotificationCallback = nullptr;
+    }
+
+    if (callback == nullptr)
+    {
+      GetInteractor(env, self).setNotificationCallback(nullptr);
+      return self;
+    }
+
+    gNotificationCallback = env->NewGlobalRef(callback);
+
+    GetInteractor(env, self).setNotificationCallback(
+      [](const std::string& desc, const std::string& value, const std::string& bind,
+         double duration) -> bool
+      {
+        JNIEnv* env = nullptr;
+#ifdef __ANDROID__
+        if (g_jvm->AttachCurrentThread(&env, nullptr) != JNI_OK)
+#else
+        if (g_jvm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr) != JNI_OK)
+#endif
+        {
+          return true;
+        }
+
+        jclass callbackClass = env->GetObjectClass(gNotificationCallback);
+        jmethodID callMethod = env->GetMethodID(callbackClass, "execute", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;D)Z");
+
+        jstring jdesc = env->NewStringUTF(desc.c_str());
+        jstring jvalue = env->NewStringUTF(value.c_str());
+        jstring jbind = env->NewStringUTF(bind.c_str());
+
+        jboolean result = env->CallBooleanMethod(gNotificationCallback, callMethod, jdesc, jvalue, jbind, duration);
+
+        env->DeleteLocalRef(jdesc);
+        env->DeleteLocalRef(jvalue);
+        env->DeleteLocalRef(jbind);
+
+        g_jvm->DetachCurrentThread();
+
+        return result == JNI_TRUE;
+      });
+
+    return self;
+  }
 }

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -749,8 +749,8 @@ extern "C"
         jstring jvalue = env->NewStringUTF(value.c_str());
         jstring jbind = env->NewStringUTF(bind.c_str());
 
-        jboolean result =
-          env->CallBooleanMethod(g_notificationCallback, callMethod, jdesc, jvalue, jbind, duration);
+        jboolean result = env->CallBooleanMethod(
+          g_notificationCallback, callMethod, jdesc, jvalue, jbind, duration);
 
         env->DeleteLocalRef(jdesc);
         env->DeleteLocalRef(jvalue);

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -10,6 +10,7 @@ namespace
 {
 std::map<std::string, jobject> g_commandCallbacks;
 jobject g_eventLoopCallback = nullptr;
+jobject g_notificationCallback = nullptr;
 JavaVM* g_jvm = nullptr;
 
 f3d::interactor& GetInteractor(JNIEnv* env, jobject self)
@@ -712,12 +713,10 @@ extern "C"
   JNIEXPORT jobject JAVA_BIND(Interactor, setNotificationCallback)(
     JNIEnv* env, jobject self, jobject callback)
   {
-    // store global ref
-    static jobject gNotificationCallback = nullptr;
-    if (gNotificationCallback != nullptr)
+    if (g_notificationCallback != nullptr)
     {
-      env->DeleteGlobalRef(gNotificationCallback);
-      gNotificationCallback = nullptr;
+      env->DeleteGlobalRef(g_notificationCallback);
+      g_notificationCallback = nullptr;
     }
 
     if (callback == nullptr)
@@ -726,7 +725,7 @@ extern "C"
       return self;
     }
 
-    gNotificationCallback = env->NewGlobalRef(callback);
+    g_notificationCallback = env->NewGlobalRef(callback);
 
     GetInteractor(env, self).setNotificationCallback(
       [](const std::string& desc, const std::string& value, const std::string& bind,
@@ -742,7 +741,7 @@ extern "C"
           return true;
         }
 
-        jclass callbackClass = env->GetObjectClass(gNotificationCallback);
+        jclass callbackClass = env->GetObjectClass(g_notificationCallback);
         jmethodID callMethod = env->GetMethodID(
           callbackClass, "execute", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;D)Z");
 
@@ -751,7 +750,7 @@ extern "C"
         jstring jbind = env->NewStringUTF(bind.c_str());
 
         jboolean result =
-          env->CallBooleanMethod(gNotificationCallback, callMethod, jdesc, jvalue, jbind, duration);
+          env->CallBooleanMethod(g_notificationCallback, callMethod, jdesc, jvalue, jbind, duration);
 
         env->DeleteLocalRef(jdesc);
         env->DeleteLocalRef(jvalue);

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -730,7 +730,7 @@ extern "C"
 
     GetInteractor(env, self).setNotificationCallback(
       [](const std::string& desc, const std::string& value, const std::string& bind,
-         double duration) -> bool
+        double duration) -> bool
       {
         JNIEnv* env = nullptr;
 #ifdef __ANDROID__
@@ -743,13 +743,15 @@ extern "C"
         }
 
         jclass callbackClass = env->GetObjectClass(gNotificationCallback);
-        jmethodID callMethod = env->GetMethodID(callbackClass, "execute", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;D)Z");
+        jmethodID callMethod = env->GetMethodID(
+          callbackClass, "execute", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;D)Z");
 
         jstring jdesc = env->NewStringUTF(desc.c_str());
         jstring jvalue = env->NewStringUTF(value.c_str());
         jstring jbind = env->NewStringUTF(bind.c_str());
 
-        jboolean result = env->CallBooleanMethod(gNotificationCallback, callMethod, jdesc, jvalue, jbind, duration);
+        jboolean result =
+          env->CallBooleanMethod(gNotificationCallback, callMethod, jdesc, jvalue, jbind, duration);
 
         env->DeleteLocalRef(jdesc);
         env->DeleteLocalRef(jvalue);

--- a/java/Interactor.java
+++ b/java/Interactor.java
@@ -157,6 +157,15 @@ public class Interactor {
         void execute(InteractorState state);
     }
 
+    /**
+     * Notification callback.
+     * Return false to prevent standard notification from being displayed, true to allow it.
+     * Arguments are the description, value, bindings, and duration of the notification.
+     */
+    public interface NotificationCallback {
+        boolean execute(String desc, String value, String bind, double duration);
+    }
+
     public interface CommandCallback {
         void execute(List<String> args);
     }
@@ -477,6 +486,11 @@ public class Interactor {
      * @return this interactor for method chaining
      */
     public native Interactor setEventLoopUserCallback(EventLoopCallback callback);
+
+    /**
+     * Set notification callback. If null, only standard notifications will be displayed.
+     */
+    public native Interactor setNotificationCallback(NotificationCallback callback);
 
     /**
      * Play a VTK interaction file.

--- a/java/testing/TestInteractor.java
+++ b/java/testing/TestInteractor.java
@@ -51,6 +51,11 @@ public class TestInteractor {
     interactor.isPlayingAnimation();
     interactor.getAnimationDirection();
 
+    interactor.setNotificationCallback((desc, value, bindStr, duration) -> {
+      System.out.println("Notification: " + desc + " " + value + " " + bindStr + " " + duration);
+      return true;
+    });
+
     interactor.triggerNotification("foo", "bar", 3.0);
 
     Interactor.AnimationDirection.FORWARD.getValue();

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -45,7 +45,7 @@ public:
   std::vector<std::string> getCommandActions() const override;
   bool triggerCommand(std::string_view command, bool keepComments = true) override;
   interactor& setNotificationCallback(
-    std::function<bool(std::string, std::string, std::string, double)> callback) override;
+    std::function<bool(const std::string&, const std::string&, const std::string&, double)> callback) override;
 
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -44,6 +44,8 @@ public:
   interactor& removeCommand(const std::string& action) override;
   std::vector<std::string> getCommandActions() const override;
   bool triggerCommand(std::string_view command, bool keepComments = true) override;
+  interactor& setNotificationCallback(
+    std::function<bool(std::string, std::string, std::string, double)> callback) override;
 
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,

--- a/library/private/interactor_impl.h
+++ b/library/private/interactor_impl.h
@@ -45,7 +45,8 @@ public:
   std::vector<std::string> getCommandActions() const override;
   bool triggerCommand(std::string_view command, bool keepComments = true) override;
   interactor& setNotificationCallback(
-    std::function<bool(const std::string&, const std::string&, const std::string&, double)> callback) override;
+    std::function<bool(const std::string&, const std::string&, const std::string&, double)>
+      callback) override;
 
   interactor& initBindings() override;
   interactor& addBinding(const interaction_bind_t& bind, std::vector<std::string> commands,

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -389,6 +389,15 @@ public:
     std::string desc, std::string value = "", double duration = 3.f) = 0;
 
   /**
+   * Set the notification callback, which is called when a notification is triggered.
+   * The callback should return true if the internal notification should be displayed, false otherwise.
+   * Arguments are the description, value, bindings, and duration of the notification.
+   * If the callback is set to nullptr, standard notifications will be displayed.
+   */
+  virtual interactor& setNotificationCallback(
+    std::function<bool(std::string, std::string, std::string, double)> callback) = 0;
+
+  /**
    * Play a VTK interaction file.
    * Provided file path is used as is and file existence will be checked.
    * If the event loop is not already running, it will be triggered every deltaTime in seconds.

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -390,9 +390,9 @@ public:
 
   /**
    * Set the notification callback, which is called when a notification is triggered.
-   * The callback should return true if the internal notification should be displayed, false otherwise.
-   * Arguments are the description, value, bindings, and duration of the notification.
-   * If the callback is set to nullptr, standard notifications will be displayed.
+   * The callback should return true if the internal notification should be displayed, false
+   * otherwise. Arguments are the description, value, bindings, and duration of the notification. If
+   * the callback is set to nullptr, standard notifications will be displayed.
    */
   virtual interactor& setNotificationCallback(
     std::function<bool(std::string, std::string, std::string, double)> callback) = 0;

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -395,7 +395,7 @@ public:
    * the callback is set to nullptr, standard notifications will be displayed.
    */
   virtual interactor& setNotificationCallback(
-    std::function<bool(std::string, std::string, std::string, double)> callback) = 0;
+    std::function<bool(const std::string&, const std::string&, const std::string&, double)> callback) = 0;
 
   /**
    * Play a VTK interaction file.

--- a/library/public/interactor.h
+++ b/library/public/interactor.h
@@ -395,7 +395,8 @@ public:
    * the callback is set to nullptr, standard notifications will be displayed.
    */
   virtual interactor& setNotificationCallback(
-    std::function<bool(const std::string&, const std::string&, const std::string&, double)> callback) = 0;
+    std::function<bool(const std::string&, const std::string&, const std::string&, double)>
+      callback) = 0;
 
   /**
    * Play a VTK interaction file.

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -673,7 +673,7 @@ public:
 
   double CallbackDeltaTime = 1.0 / 30; /* Default DeltaTime (30fps) */
 
-  std::function<bool(std::string, std::string, std::string, double)> NotificationCallback = nullptr;
+  std::function<bool(const std::string&, const std::string&, const std::string&, double)> NotificationCallback = nullptr;
 };
 
 //----------------------------------------------------------------------------
@@ -1838,7 +1838,7 @@ interactor& interactor_impl::triggerNotification(
 
 //----------------------------------------------------------------------------
 interactor& interactor_impl::setNotificationCallback(
-  std::function<bool(std::string, std::string, std::string, double)> callback)
+  std::function<bool(const std::string&, const std::string&, const std::string&, double)> callback)
 {
   this->Internals->NotificationCallback = std::move(callback);
   return *this;

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -1830,9 +1830,6 @@ interactor& interactor_impl::triggerNotification(
 {
   if (!desc.empty())
   {
-    vtkRenderWindow* renWin = this->Internals->Window.GetRenderWindow();
-    vtkF3DRenderer* ren = vtkF3DRenderer::SafeDownCast(renWin->GetRenderers()->GetFirstRenderer());
-
     this->Internals->AddNotification(desc, value, {}, duration);
   }
 

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -520,10 +520,6 @@ public:
       if (binding.Notify && binding.DocumentationCallback)
       {
         // trigger notification
-        vtkRenderWindow* renWin = this->Window.GetRenderWindow();
-        vtkF3DRenderer* ren =
-          vtkF3DRenderer::SafeDownCast(renWin->GetRenderers()->GetFirstRenderer());
-
         auto [desc, value] = binding.DocumentationCallback();
         this->AddNotification(desc, value, bind.format(), 3.0);
       }

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -673,7 +673,8 @@ public:
 
   double CallbackDeltaTime = 1.0 / 30; /* Default DeltaTime (30fps) */
 
-  std::function<bool(const std::string&, const std::string&, const std::string&, double)> NotificationCallback = nullptr;
+  std::function<bool(const std::string&, const std::string&, const std::string&, double)>
+    NotificationCallback = nullptr;
 };
 
 //----------------------------------------------------------------------------

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -442,6 +442,24 @@ public:
   }
 
   //----------------------------------------------------------------------------
+  void AddNotification(
+    const std::string& desc, const std::string& value, const std::string& bind, double duration)
+  {
+    if (this->NotificationCallback)
+    {
+      if (!this->NotificationCallback(desc, value, bind, duration))
+      {
+        return;
+      }
+    }
+
+    vtkRenderWindow* renWin = this->Window.GetRenderWindow();
+    vtkF3DRenderer* ren = vtkF3DRenderer::SafeDownCast(renWin->GetRenderers()->GetFirstRenderer());
+
+    ren->AddNotification(desc, value, bind, duration);
+  }
+
+  //----------------------------------------------------------------------------
   void TriggerBinding(const std::string& interaction, const std::string& argsString)
   {
     mod_t mod = mod_t::NONE;
@@ -507,7 +525,7 @@ public:
           vtkF3DRenderer::SafeDownCast(renWin->GetRenderers()->GetFirstRenderer());
 
         auto [desc, value] = binding.DocumentationCallback();
-        ren->AddNotification(desc, value, bind.format(), 3.0);
+        this->AddNotification(desc, value, bind.format(), 3.0);
       }
     }
 
@@ -658,6 +676,8 @@ public:
   std::atomic<bool> StopRequested = false;
 
   double CallbackDeltaTime = 1.0 / 30; /* Default DeltaTime (30fps) */
+
+  std::function<bool(std::string, std::string, std::string, double)> NotificationCallback = nullptr;
 };
 
 //----------------------------------------------------------------------------
@@ -1817,9 +1837,17 @@ interactor& interactor_impl::triggerNotification(
     vtkRenderWindow* renWin = this->Internals->Window.GetRenderWindow();
     vtkF3DRenderer* ren = vtkF3DRenderer::SafeDownCast(renWin->GetRenderers()->GetFirstRenderer());
 
-    ren->AddNotification(desc, value, {}, duration);
+    this->Internals->AddNotification(desc, value, {}, duration);
   }
 
+  return *this;
+}
+
+//----------------------------------------------------------------------------
+interactor& interactor_impl::setNotificationCallback(
+  std::function<bool(std::string, std::string, std::string, double)> callback)
+{
+  this->Internals->NotificationCallback = std::move(callback);
   return *this;
 }
 

--- a/library/testing/TestSDKNotification.cxx
+++ b/library/testing/TestSDKNotification.cxx
@@ -33,12 +33,26 @@ int TestSDKNotification([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]
   sce.add(dataPath);
   win.render();
 
+  int notifCount = 0;
+  inter.setNotificationCallback(
+    [&](std::string, std::string, std::string, double) {
+      notifCount++;
+      return true;
+    });
+
   inter.triggerKeyboardKey(f3d::interactor::InputAction::PRESS, "E");
   inter.triggerKeyboardKey(f3d::interactor::InputAction::RELEASE, "E");
   inter.triggerKeyboardKey(f3d::interactor::InputAction::PRESS, "T");
   inter.triggerKeyboardKey(f3d::interactor::InputAction::RELEASE, "T");
+
+  test("Expected notifications count", notifCount, 2);
+
+  inter.setNotificationCallback(nullptr);
+
   inter.triggerKeyboardKey(f3d::interactor::InputAction::PRESS, "G");
   inter.triggerKeyboardKey(f3d::interactor::InputAction::RELEASE, "G");
+
+  test("Expected notifications count after reset", notifCount, 2);
 
   inter.triggerEventLoop(0.2); // allow fade-in
   test("stacking notifications",
@@ -74,6 +88,19 @@ int TestSDKNotification([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]
   inter.triggerEventLoop(0.2); // allow fade-in
   test("user define notifications",
     TestSDKHelpers::RenderTest(win, baselinePath, outputPath, "TestSDKNotificationUser"));
+
+  // test that returning false from the callback prevents the notification from being displayed
+  inter.setNotificationCallback(
+    [](std::string, std::string, std::string, double) {
+      return false;
+    });
+
+  inter.triggerNotification("Test Hidden Notification", "Test Hidden Value");
+
+  test("hidden notifications",
+    TestSDKHelpers::RenderTest(win, baselinePath, outputPath, "TestSDKNotificationUserHidden"));
+
+  inter.setNotificationCallback(nullptr);
 
   inter.triggerEventLoop(3.0);
   inter.triggerKeyboardKey(f3d::interactor::InputAction::PRESS, "E");

--- a/library/testing/TestSDKNotification.cxx
+++ b/library/testing/TestSDKNotification.cxx
@@ -34,11 +34,10 @@ int TestSDKNotification([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]
   win.render();
 
   int notifCount = 0;
-  inter.setNotificationCallback(
-    [&](std::string, std::string, std::string, double) {
-      notifCount++;
-      return true;
-    });
+  inter.setNotificationCallback([&](std::string, std::string, std::string, double) {
+    notifCount++;
+    return true;
+  });
 
   inter.triggerKeyboardKey(f3d::interactor::InputAction::PRESS, "E");
   inter.triggerKeyboardKey(f3d::interactor::InputAction::RELEASE, "E");
@@ -91,9 +90,7 @@ int TestSDKNotification([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]
 
   // test that returning false from the callback prevents the notification from being displayed
   inter.setNotificationCallback(
-    [](std::string, std::string, std::string, double) {
-      return false;
-    });
+    [](std::string, std::string, std::string, double) { return false; });
 
   inter.triggerNotification("Test Hidden Notification", "Test Hidden Value");
 

--- a/library/testing/TestSDKNotification.cxx
+++ b/library/testing/TestSDKNotification.cxx
@@ -34,10 +34,11 @@ int TestSDKNotification([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]
   win.render();
 
   int notifCount = 0;
-  inter.setNotificationCallback([&](const std::string&, const std::string&, const std::string&, double) {
-    notifCount++;
-    return true;
-  });
+  inter.setNotificationCallback(
+    [&](const std::string&, const std::string&, const std::string&, double) {
+      notifCount++;
+      return true;
+    });
 
   inter.triggerKeyboardKey(f3d::interactor::InputAction::PRESS, "E");
   inter.triggerKeyboardKey(f3d::interactor::InputAction::RELEASE, "E");

--- a/library/testing/TestSDKNotification.cxx
+++ b/library/testing/TestSDKNotification.cxx
@@ -34,7 +34,7 @@ int TestSDKNotification([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]
   win.render();
 
   int notifCount = 0;
-  inter.setNotificationCallback([&](std::string, std::string, std::string, double) {
+  inter.setNotificationCallback([&](const std::string&, const std::string&, const std::string&, double) {
     notifCount++;
     return true;
   });

--- a/library/testing/TestSDKNotification.cxx
+++ b/library/testing/TestSDKNotification.cxx
@@ -91,7 +91,7 @@ int TestSDKNotification([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]
 
   // test that returning false from the callback prevents the notification from being displayed
   inter.setNotificationCallback(
-    [](std::string, std::string, std::string, double) { return false; });
+    [](const std::string&, const std::string&, const std::string&, double) { return false; });
 
   inter.triggerNotification("Test Hidden Notification", "Test Hidden Value");
 

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -438,7 +438,8 @@ PYBIND11_MODULE(pyf3d, module)
       "Disable the camera interaction")
     .def("set_event_loop_user_callback", &f3d::interactor::setEventLoopUserCallback,
       "Set the user callback of the event loop", py::arg("user_callback") = nullptr)
-    .def("set_notification_callback",
+    .def(
+      "set_notification_callback",
       [](f3d::interactor& interactor, py::object callback)
       {
         if (callback.is_none())
@@ -447,11 +448,9 @@ PYBIND11_MODULE(pyf3d, module)
           return;
         }
 
-        auto cb = [=](const std::string& desc, const std::string& value,
-                      const std::string& bind, double duration) -> bool
-        {
-          return py::bool_(callback(desc, value, bind, duration));
-        };
+        auto cb = [=](const std::string& desc, const std::string& value, const std::string& bind,
+                    double duration) -> bool
+        { return py::bool_(callback(desc, value, bind, duration)); };
 
         interactor.setNotificationCallback(cb);
       },

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -438,6 +438,24 @@ PYBIND11_MODULE(pyf3d, module)
       "Disable the camera interaction")
     .def("set_event_loop_user_callback", &f3d::interactor::setEventLoopUserCallback,
       "Set the user callback of the event loop", py::arg("user_callback") = nullptr)
+    .def("set_notification_callback",
+      [](f3d::interactor& interactor, py::object callback)
+      {
+        if (callback.is_none())
+        {
+          interactor.setNotificationCallback(nullptr);
+          return;
+        }
+
+        auto cb = [=](const std::string& desc, const std::string& value,
+                      const std::string& bind, double duration) -> bool
+        {
+          return py::bool_(callback(desc, value, bind, duration));
+        };
+
+        interactor.setNotificationCallback(cb);
+      },
+      "Set the notification callback (desc, value, bind, duration) -> bool", py::arg("callback"))
     .def("trigger_mod_update", &f3d::interactor::triggerModUpdate, "Trigger a key modifier update")
     .def("trigger_mouse_button", &f3d::interactor::triggerMouseButton, "Trigger a mouse button")
     .def(

--- a/python/testing/test_interactor.py
+++ b/python/testing/test_interactor.py
@@ -15,6 +15,12 @@ def compl_fn(args: list[str]):
     return ["compl"]
 
 
+def notif_fn(desc, value, bind, duration):
+    nonlocal counter_notif
+    counter_notif += 1
+    return True
+
+
 def test_command(capfd: pytest.CaptureFixture[str]):
     engine = f3d.Engine.create(True)
     inter = engine.interactor
@@ -156,7 +162,12 @@ def test_trigger_key(capfd: pytest.CaptureFixture[str]):
     engine.interactor.trigger_mouse_wheel(f3d.Interactor.WheelDirection.FORWARD)
     engine.interactor.trigger_text_character(0)
 
+    counter_notif = 0
+    engine.interactor.set_notification_callback(notif_fn)
+    assert counter_notif == 0
+
     engine.interactor.trigger_notification("foo", "bar", 3.0)
+    assert counter_notif == 1
 
 
 def test_interactor_animation(capfd: pytest.CaptureFixture[str]):

--- a/python/testing/test_interactor.py
+++ b/python/testing/test_interactor.py
@@ -15,12 +15,6 @@ def compl_fn(args: list[str]):
     return ["compl"]
 
 
-def notif_fn(desc, value, bind, duration):
-    nonlocal counter_notif
-    counter_notif += 1
-    return True
-
-
 def test_command(capfd: pytest.CaptureFixture[str]):
     engine = f3d.Engine.create(True)
     inter = engine.interactor
@@ -163,6 +157,12 @@ def test_trigger_key(capfd: pytest.CaptureFixture[str]):
     engine.interactor.trigger_text_character(0)
 
     counter_notif = 0
+
+    def notif_fn(desc, value, bind, duration):
+        nonlocal counter_notif
+        counter_notif += 1
+        return True
+
     engine.interactor.set_notification_callback(notif_fn)
     assert counter_notif == 0
 

--- a/testing/baselines/TestSDKNotificationUserHidden.png
+++ b/testing/baselines/TestSDKNotificationUserHidden.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19f8ad77ed69d5777a228f88d50d3ec789e0e9739c1729c813dc9a5fa0b943be
+size 26711

--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -465,6 +465,25 @@ EMSCRIPTEN_BINDINGS(f3d)
       +[](f3d::interactor& interactor, std::string desc, std::string value, double duration)
       { interactor.triggerNotification(desc, value, duration); });
 
+  // Bind notification callback: returns true to show notification, false to suppress
+  emscripten::function("setNotificationCallback",
+    +[](f3d::interactor& interactor, const emscripten::val& callback)
+    {
+      if (callback.isUndefined() || callback.isNull())
+      {
+        interactor.setNotificationCallback(nullptr);
+        return;
+      }
+
+      auto cb = [=](const std::string& desc, const std::string& value,
+                           const std::string& bind, double duration) -> bool
+      {
+        return callback(desc, value, bind, duration).as<bool>();
+      };
+
+      interactor.setNotificationCallback(cb);
+    });
+
   // f3d::engine
   // Not bound on purpose because only one engine is supported:
   // create*, getRenderingBackendList

--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -466,7 +466,8 @@ EMSCRIPTEN_BINDINGS(f3d)
       { interactor.triggerNotification(desc, value, duration); });
 
   // Bind notification callback: returns true to show notification, false to suppress
-  emscripten::function("setNotificationCallback",
+  emscripten::function(
+    "setNotificationCallback",
     +[](f3d::interactor& interactor, const emscripten::val& callback)
     {
       if (callback.isUndefined() || callback.isNull())
@@ -475,11 +476,9 @@ EMSCRIPTEN_BINDINGS(f3d)
         return;
       }
 
-      auto cb = [=](const std::string& desc, const std::string& value,
-                           const std::string& bind, double duration) -> bool
-      {
-        return callback(desc, value, bind, duration).as<bool>();
-      };
+      auto cb = [=](const std::string& desc, const std::string& value, const std::string& bind,
+                  double duration) -> bool
+      { return callback(desc, value, bind, duration).as<bool>(); };
 
       interactor.setNotificationCallback(cb);
     });

--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -465,21 +465,21 @@ EMSCRIPTEN_BINDINGS(f3d)
       +[](f3d::interactor& interactor, std::string desc, std::string value, double duration)
       { interactor.triggerNotification(desc, value, duration); })
     .function(
-    "setNotificationCallback",
-    +[](f3d::interactor& interactor, const emscripten::val& callback)
-    {
-      if (callback.isUndefined() || callback.isNull())
+      "setNotificationCallback",
+      +[](f3d::interactor& interactor, const emscripten::val& callback)
       {
-        interactor.setNotificationCallback(nullptr);
-        return;
-      }
+        if (callback.isUndefined() || callback.isNull())
+        {
+          interactor.setNotificationCallback(nullptr);
+          return;
+        }
 
-      auto cb = [=](const std::string& desc, const std::string& value, const std::string& bind,
-                  double duration) -> bool
-      { return callback(desc, value, bind, duration).as<bool>(); };
+        auto cb = [=](const std::string& desc, const std::string& value, const std::string& bind,
+                    double duration) -> bool
+        { return callback(desc, value, bind, duration).as<bool>(); };
 
-      interactor.setNotificationCallback(cb);
-    });
+        interactor.setNotificationCallback(cb);
+      });
 
   // f3d::engine
   // Not bound on purpose because only one engine is supported:

--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -463,10 +463,8 @@ EMSCRIPTEN_BINDINGS(f3d)
     .function(
       "triggerNotification",
       +[](f3d::interactor& interactor, std::string desc, std::string value, double duration)
-      { interactor.triggerNotification(desc, value, duration); });
-
-  // Bind notification callback: returns true to show notification, false to suppress
-  emscripten::function(
+      { interactor.triggerNotification(desc, value, duration); })
+    .function(
     "setNotificationCallback",
     +[](f3d::interactor& interactor, const emscripten::val& callback)
     {

--- a/webassembly/testing/test_interactor.js
+++ b/webassembly/testing/test_interactor.js
@@ -116,7 +116,12 @@ const settings = {
       return true;
     });
 
-    interactor.triggerNotification("Test notification", "value", "binding", 1.0);
+    interactor.triggerNotification(
+      "Test notification",
+      "value",
+      "binding",
+      1.0,
+    );
     utils.assert(notifCount === 1, "notification callback not called");
 
     // only for coverage, do not test the actual feature yet

--- a/webassembly/testing/test_interactor.js
+++ b/webassembly/testing/test_interactor.js
@@ -108,6 +108,17 @@ const settings = {
     );
     interactor.stopAnimation();
 
+    // notifications
+    let notifCount = 0;
+
+    interactor.setNotificationCallback((desc, value, bind, duration) => {
+      notifCount++;
+      return true;
+    });
+
+    interactor.triggerNotification("Test notification", "value", "binding", 1.0);
+    utils.assert(notifCount === 1, "notification callback not called");
+
     // only for coverage, do not test the actual feature yet
     interactor.disableCameraMovement();
     interactor.enableCameraMovement();


### PR DESCRIPTION
### Describe your changes

In the context of the web viewer (and all external app in general), it's useful to be able to display notifications with pure HTML elements.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [ ] I have not used AI to generate any of the content of this pull request
- [x] I have used AI to generate code in this pull request:
  - [x] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [x] I have carefully reviewed and completely understood every generated line.
  - [x] I disclose below which parts of the code were generated and with which AI model:

VSCode AI auto-completion has been used.
GPT-5 mini have been used in Ask mode to help with emscripten/pybind11 implementations.

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
