### PR TITLE
Implement multiple animations support for assimp

### DIFF
--- a/application/testing/tests.assimp.cmake
+++ b/application/testing/tests.assimp.cmake
@@ -39,6 +39,7 @@ if(VTK_VERSION VERSION_GREATER_EQUAL 9.5.20251006)
   f3d_test(NAME TestFBXAnimation DATA animatedWorld.fbx PLUGIN assimp ARGS --animation-time=2 --animation-progress UI)
   f3d_test(NAME TestFBXAnimationLights DATA animatedLights.fbx PLUGIN assimp ARGS --animation-time=1.8 --animation-progress UI)
   f3d_test(NAME TestFBXAnimationCamera DATA animatedCamera.fbx PLUGIN assimp ARGS --camera-index=0 --animation-indices=0 --animation-time=3 --animation-progress UI)
+  f3d_test(NAME TestFBXMultipleAnimations DATA multipleAnimatedObjects.fbx PLUGIN assimp ARGS --animation-indices=-1 --animation-time=1 --animation-progress UI)
   f3d_test(NAME TestDAEAnimationLights DATA animatedLights.dae PLUGIN assimp ARGS --animation-time=1.8 --animation-progress UI)
 endif()
 

--- a/doc/user/02-SUPPORTED_FORMATS.md
+++ b/doc/user/02-SUPPORTED_FORMATS.md
@@ -36,11 +36,11 @@ F3D supports the following file formats:
 | Draco                                     | `.drc`                                         | No         | NONE              | YES               | `draco`   | `Draco`                 |
 | Autodesk 3D Studio                        | `.3ds`                                         | Yes        | NONE              | YES (VTK 9.6)     | `native`  | `3DS`                   |
 | Virtual Reality Modeling Language         | `.wrl`, `.vrml`                                | Yes        | NONE              | NO                | `native`  | `VRMLReader`            |
-| Autodesk Filmbox                          | `.fbx`                                         | Yes        | SINGLE            | YES (VTK 9.6)     | `assimp`  | `FBX`                   |
-| COLLADA                                   | `.dae`                                         | Yes        | SINGLE            | PARTIAL (VTK 9.6) | `assimp`  | `COLLADA`               |
+| Autodesk Filmbox                          | `.fbx`                                         | Yes        | MULTI             | YES (VTK 9.6)     | `assimp`  | `FBX`                   |
+| COLLADA                                   | `.dae`                                         | Yes        | MULTI             | PARTIAL (VTK 9.6) | `assimp`  | `COLLADA`               |
 | Object File Format                        | `.off`                                         | Yes        | NONE              | YES (VTK 9.6)     | `assimp`  | `OFF`                   |
 | Drawing Exchange Format                   | `.dxf`                                         | Yes        | NONE              | YES (VTK 9.6)     | `assimp`  | `DXF`                   |
-| DirectX                                   | `.x`                                           | Yes        | SINGLE            | YES (VTK 9.6)     | `assimp`  | `DirectX`               |
+| DirectX                                   | `.x`                                           | Yes        | MULTI             | YES (VTK 9.6)     | `assimp`  | `DirectX`               |
 | 3D Manufacturing Format                   | `.3mf`                                         | Yes        | NONE              | YES (VTK 9.6)     | `assimp`  | `3MF`                   |
 | Universal Scene Description               | `.usd`, `.usda`, `.usdc`, `.usdz`              | Yes        | SINGLE            | YES (VTK 9.6)     | `usd`     | `USD`                   |
 | VDB                                       | `.vdb`                                         | No         | NONE              | YES (VTK 9.6)     | `vdb`     | `VDB`                   |

--- a/plugins/assimp/module/vtkF3DAssimpImporter.cxx
+++ b/plugins/assimp/module/vtkF3DAssimpImporter.cxx
@@ -1052,7 +1052,7 @@ public:
   std::vector<vtkSmartPointer<vtkPolyData>> Meshes;
   std::vector<vtkSmartPointer<vtkProperty>> Properties;
   std::vector<vtkSmartPointer<vtkTexture>> EmbeddedTextures;
-  vtkIdType ActiveAnimation = -1; // -1 means no animation enabled here
+  std::set<vtkIdType> EnabledAnimations; // indices of currently enabled animations
   std::vector<std::pair<std::string, vtkSmartPointer<vtkLight>>> Lights;
   std::vector<
     std::pair<std::string, std::pair<vtkSmartPointer<vtkCamera>, vtkSmartPointer<vtkCamera>>>>
@@ -1117,111 +1117,115 @@ std::string vtkF3DAssimpImporter::GetOutputsDescription()
 //----------------------------------------------------------------------------
 bool vtkF3DAssimpImporter::UpdateAtTimeValue(double timeValue)
 {
-  assert(this->Internals->ActiveAnimation < this->GetNumberOfAnimations());
-  if (this->Internals->ActiveAnimation == -1)
+  if (this->Internals->EnabledAnimations.empty())
   {
     return true;
   }
 
-  // get the animation tick
-  double fps =
-    this->Internals->Scene->mAnimations[this->Internals->ActiveAnimation]->mTicksPerSecond;
-  if (fps == 0.0)
-  {
-    fps = 1.0;
-  }
-
-  aiAnimation* anim = this->Internals->Scene->mAnimations[this->Internals->ActiveAnimation];
-  double tick = timeValue * fps;
-
   Assimp::Interpolator<aiVectorKey> vectorInterpolator;
   Assimp::Interpolator<aiQuatKey> quaternionInterpolator;
 
-  for (unsigned int nodeChannelId = 0; nodeChannelId < anim->mNumChannels; nodeChannelId++)
+  for (vtkIdType activeAnimation : this->Internals->EnabledAnimations)
   {
-    aiNodeAnim* nodeAnim = anim->mChannels[nodeChannelId];
+    assert(activeAnimation < this->GetNumberOfAnimations());
 
-    aiVector3D translation;
-    aiVector3D scaling;
-    aiQuaternion quaternion;
+    aiAnimation* anim = this->Internals->Scene->mAnimations[activeAnimation];
 
-    aiVectorKey* positionKey = std::lower_bound(nodeAnim->mPositionKeys,
-      nodeAnim->mPositionKeys + nodeAnim->mNumPositionKeys, tick,
-      [](const aiVectorKey& key, const double& time) { return key.mTime < time; });
-
-    if (positionKey == nodeAnim->mPositionKeys)
+    // get the animation tick
+    double fps = anim->mTicksPerSecond;
+    if (fps == 0.0)
     {
-      translation = positionKey->mValue;
-    }
-    else if (positionKey == nodeAnim->mPositionKeys + nodeAnim->mNumPositionKeys)
-    {
-      translation = (positionKey - 1)->mValue;
-    }
-    else
-    {
-      aiVectorKey* prev = positionKey - 1;
-      ai_real d = (tick - prev->mTime) / (positionKey->mTime - prev->mTime);
-      vectorInterpolator(translation, *prev, *positionKey, d);
+      fps = 1.0;
     }
 
-    aiQuatKey* rotationKey = std::lower_bound(nodeAnim->mRotationKeys,
-      nodeAnim->mRotationKeys + nodeAnim->mNumRotationKeys, tick,
-      [](const aiQuatKey& key, const double& time) { return key.mTime < time; });
+    double tick = timeValue * fps;
 
-    if (rotationKey == nodeAnim->mRotationKeys)
+    for (unsigned int nodeChannelId = 0; nodeChannelId < anim->mNumChannels; nodeChannelId++)
     {
-      quaternion = rotationKey->mValue;
-    }
-    else if (rotationKey == nodeAnim->mRotationKeys + nodeAnim->mNumRotationKeys)
-    {
-      quaternion = (rotationKey - 1)->mValue;
-    }
-    else
-    {
-      aiQuatKey* prev = rotationKey - 1;
-      ai_real d = (tick - prev->mTime) / (rotationKey->mTime - prev->mTime);
-      quaternionInterpolator(quaternion, *prev, *rotationKey, d);
-    }
+      aiNodeAnim* nodeAnim = anim->mChannels[nodeChannelId];
 
-    aiVectorKey* scalingKey =
-      std::lower_bound(nodeAnim->mScalingKeys, nodeAnim->mScalingKeys + nodeAnim->mNumScalingKeys,
-        tick, [](const aiVectorKey& key, const double& time) { return key.mTime < time; });
+      aiVector3D translation;
+      aiVector3D scaling;
+      aiQuaternion quaternion;
 
-    if (scalingKey == nodeAnim->mScalingKeys)
-    {
-      scaling = scalingKey->mValue;
-    }
-    else if (scalingKey == nodeAnim->mScalingKeys + nodeAnim->mNumScalingKeys)
-    {
-      scaling = (scalingKey - 1)->mValue;
-    }
-    else
-    {
-      aiVectorKey* prev = scalingKey - 1;
-      ai_real d = (tick - prev->mTime) / (scalingKey->mTime - prev->mTime);
-      vectorInterpolator(scaling, *prev, *scalingKey, d);
-    }
+      aiVectorKey* positionKey = std::lower_bound(nodeAnim->mPositionKeys,
+        nodeAnim->mPositionKeys + nodeAnim->mNumPositionKeys, tick,
+        [](const aiVectorKey& key, const double& time) { return key.mTime < time; });
 
-    vtkMatrix4x4* transform = this->Internals->NodeLocalMatrix[nodeAnim->mNodeName.data];
-
-    if (transform)
-    {
-      // Initialize quaternion
-      vtkQuaternion<double> rotation;
-      rotation.Set(quaternion.w, quaternion.x, quaternion.y, quaternion.z);
-      rotation.Normalize();
-
-      double rotationMatrix[3][3];
-      rotation.ToMatrix3x3(rotationMatrix);
-
-      // Apply transformations
-      for (int i = 0; i < 3; i++)
+      if (positionKey == nodeAnim->mPositionKeys)
       {
-        for (int j = 0; j < 3; j++)
+        translation = positionKey->mValue;
+      }
+      else if (positionKey == nodeAnim->mPositionKeys + nodeAnim->mNumPositionKeys)
+      {
+        translation = (positionKey - 1)->mValue;
+      }
+      else
+      {
+        aiVectorKey* prev = positionKey - 1;
+        ai_real d = (tick - prev->mTime) / (positionKey->mTime - prev->mTime);
+        vectorInterpolator(translation, *prev, *positionKey, d);
+      }
+
+      aiQuatKey* rotationKey = std::lower_bound(nodeAnim->mRotationKeys,
+        nodeAnim->mRotationKeys + nodeAnim->mNumRotationKeys, tick,
+        [](const aiQuatKey& key, const double& time) { return key.mTime < time; });
+
+      if (rotationKey == nodeAnim->mRotationKeys)
+      {
+        quaternion = rotationKey->mValue;
+      }
+      else if (rotationKey == nodeAnim->mRotationKeys + nodeAnim->mNumRotationKeys)
+      {
+        quaternion = (rotationKey - 1)->mValue;
+      }
+      else
+      {
+        aiQuatKey* prev = rotationKey - 1;
+        ai_real d = (tick - prev->mTime) / (rotationKey->mTime - prev->mTime);
+        quaternionInterpolator(quaternion, *prev, *rotationKey, d);
+      }
+
+      aiVectorKey* scalingKey =
+        std::lower_bound(nodeAnim->mScalingKeys, nodeAnim->mScalingKeys + nodeAnim->mNumScalingKeys,
+          tick, [](const aiVectorKey& key, const double& time) { return key.mTime < time; });
+
+      if (scalingKey == nodeAnim->mScalingKeys)
+      {
+        scaling = scalingKey->mValue;
+      }
+      else if (scalingKey == nodeAnim->mScalingKeys + nodeAnim->mNumScalingKeys)
+      {
+        scaling = (scalingKey - 1)->mValue;
+      }
+      else
+      {
+        aiVectorKey* prev = scalingKey - 1;
+        ai_real d = (tick - prev->mTime) / (scalingKey->mTime - prev->mTime);
+        vectorInterpolator(scaling, *prev, *scalingKey, d);
+      }
+
+      vtkMatrix4x4* transform = this->Internals->NodeLocalMatrix[nodeAnim->mNodeName.data];
+
+      if (transform)
+      {
+        // Initialize quaternion
+        vtkQuaternion<double> rotation;
+        rotation.Set(quaternion.w, quaternion.x, quaternion.y, quaternion.z);
+        rotation.Normalize();
+
+        double rotationMatrix[3][3];
+        rotation.ToMatrix3x3(rotationMatrix);
+
+        // Apply transformations
+        for (int i = 0; i < 3; i++)
         {
-          transform->SetElement(i, j, scaling[j] * rotationMatrix[i][j]);
+          for (int j = 0; j < 3; j++)
+          {
+            transform->SetElement(i, j, scaling[j] * rotationMatrix[i][j]);
+          }
+          transform->SetElement(i, 3, translation[i]);
         }
-        transform->SetElement(i, 3, translation[i]);
       }
     }
   }
@@ -1254,13 +1258,15 @@ void vtkF3DAssimpImporter::EnableAnimation(vtkIdType animationIndex)
 {
   assert(animationIndex < this->GetNumberOfAnimations());
   assert(animationIndex >= 0);
-  this->Internals->ActiveAnimation = animationIndex;
+  this->Internals->EnabledAnimations.insert(animationIndex);
 }
 
 //----------------------------------------------------------------------------
-void vtkF3DAssimpImporter::DisableAnimation(vtkIdType vtkNotUsed(animationIndex))
+void vtkF3DAssimpImporter::DisableAnimation(vtkIdType animationIndex)
 {
-  this->Internals->ActiveAnimation = -1;
+  assert(animationIndex < this->GetNumberOfAnimations());
+  assert(animationIndex >= 0);
+  this->Internals->EnabledAnimations.erase(animationIndex);
 }
 
 //----------------------------------------------------------------------------
@@ -1268,7 +1274,7 @@ bool vtkF3DAssimpImporter::IsAnimationEnabled(vtkIdType animationIndex)
 {
   assert(animationIndex < this->GetNumberOfAnimations());
   assert(animationIndex >= 0);
-  return this->Internals->ActiveAnimation == animationIndex;
+  return this->Internals->EnabledAnimations.count(animationIndex) > 0;
 }
 
 //----------------------------------------------------------------------------

--- a/plugins/assimp/module/vtkF3DAssimpImporter.h
+++ b/plugins/assimp/module/vtkF3DAssimpImporter.h
@@ -35,11 +35,11 @@ public:
 
   /**
    * Get the level of animation support in this importer, which is always
-   * AnimationSupportLevel::SINGLE
+   * AnimationSupportLevel::MULTI
    */
   AnimationSupportLevel GetAnimationSupportLevel() override
   {
-    return AnimationSupportLevel::SINGLE;
+    return AnimationSupportLevel::MULTI;
   }
 
   /**
@@ -55,7 +55,7 @@ public:
   ///@{
   /**
    * Enable/Disable/Get the status of specific animations
-   * Only one single animation can be enabled
+   * Multiple animations can be enabled simultaneously
    * By default, no animation are enabled
    * As specified in the vtkImporter API, animationIndex
    * is expected to be 0 < GetNumberOfAnimations

--- a/testing/baselines/TestFBXMultipleAnimations.png
+++ b/testing/baselines/TestFBXMultipleAnimations.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3638bcf34b4dd9dcbdbfcebb71f15915c3a104ef42f4008e7b73024e99f4187
+size 8450

--- a/testing/data/multipleAnimatedObjects.fbx
+++ b/testing/data/multipleAnimatedObjects.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4be4cbf14d9a0c4002a485883e87de17c382baa39c273cc91cbafad5a0e6d32f
+size 107116


### PR DESCRIPTION
### Describe your changes

Implement multiple animations support for assimp-based formats. Specifically tested for fbx. Implementation is similar to existing GLTFImporter - it goes through enabled animations and appllies them. If animations affect different object it just enables all of them at once, if some of animations are affecting the same object animation with the last ID does the job only (overwrites earlier animations).

### Issue ticket number and link if any

https://github.com/f3d-app/f3d/issues/2302

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [ ] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [x] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model
  - [x] I used Claude Code Opus 4.8 to generate test fbx file with multiple animations it did it using Python scripts+Blender

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
