### PR TITLE
Move matcap and skin/morph logic

### DIFF
--- a/vtkext/private/module/vtkF3DPolyDataMapper.cxx
+++ b/vtkext/private/module/vtkF3DPolyDataMapper.cxx
@@ -8,6 +8,7 @@
 #include <vtkObjectFactory.h>
 #include <vtkOpenGLRenderWindow.h>
 #include <vtkOpenGLRenderer.h>
+#include <vtkOpenGLUniforms.h>
 #include <vtkOpenGLVertexBufferObject.h>
 #include <vtkOpenGLVertexBufferObjectGroup.h>
 #include <vtkPointData.h>
@@ -19,123 +20,21 @@
 #include <vtkUniforms.h>
 #include <vtkVersion.h>
 
+#include <regex>
+
 vtkStandardNewMacro(vtkF3DPolyDataMapper);
-
-//-----------------------------------------------------------------------------
-vtkF3DPolyDataMapper::vtkF3DPolyDataMapper()
-{
-  this->SetVBOShiftScaleMethod(vtkPolyDataMapper::ShiftScaleMethodType::DISABLE_SHIFT_SCALE);
-
-  // map glTF arrays to GPU VBOs
-  this->MapDataArrayToVertexAttribute(
-    "weights", "WEIGHTS_0", vtkDataObject::FIELD_ASSOCIATION_POINTS);
-  this->MapDataArrayToVertexAttribute(
-    "joints", "JOINTS_0", vtkDataObject::FIELD_ASSOCIATION_POINTS);
-
-  // morph targets
-  // OpenGL limits the input attributes to 16 vectors
-  // We ignore morphing on tangent on purpose to maximize the number of targets we
-  // can support
-  for (int i = 0; i < 4; i++)
-  {
-    std::string name = "target" + std::to_string(i) + "_position";
-    this->MapDataArrayToVertexAttribute(
-      name.c_str(), name.c_str(), vtkDataObject::FIELD_ASSOCIATION_POINTS);
-    name = "target" + std::to_string(i) + "_normal";
-    this->MapDataArrayToVertexAttribute(
-      name.c_str(), name.c_str(), vtkDataObject::FIELD_ASSOCIATION_POINTS);
-  }
-}
 
 //-----------------------------------------------------------------------------
 void vtkF3DPolyDataMapper::ReplaceShaderValues(
   std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor)
 {
-  auto vertexShader = shaders[vtkShader::Vertex];
-  auto VSSource = vertexShader->GetSource();
-
-  bool hasTangents =
-    this->VBOs->GetNumberOfComponents("tangentMC") == 3 && actor->GetProperty()->GetLighting();
-  bool hasNormals =
-    this->VBOs->GetNumberOfComponents("normalMC") == 3 && actor->GetProperty()->GetLighting();
+  this->Superclass::ReplaceShaderValues(shaders, ren, actor);
 
   vtkUniforms* uniforms = actor->GetShaderProperty()->GetVertexCustomUniforms();
-
-#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 4, 20250218)
-  using f3d_texinfo = vtkOpenGLPolyDataMapper::texinfo;
-#else
-  using f3d_texinfo = std::pair<vtkTexture*, std::string>;
-#endif
-  std::vector<f3d_texinfo> textures = this->GetTextures(actor);
-  hasTangents = hasTangents &&
-    std::ranges::find_if(
-      textures, [](const f3d_texinfo& tex) { return tex.second == "normalTex"; }) != textures.end();
-
-  std::string customDecl = "//VTK::CustomUniforms::Dec\n";
-  std::string beginImpl;
-  std::string posImpl = "  vec4 posMC = vertexMC;\n";
-
-  // normals and tangents can be modified by skinnning and morphing in model space
-  std::string normalImpl;
-  if (hasNormals)
-  {
-    normalImpl += "  normalVCVSOutput = normalMC;\n";
-  }
-  if (hasTangents)
-  {
-    normalImpl += "  tangentVCVSOutput = tangentMC;\n";
-  }
-
-  // morphing
-  vtkUniforms::TupleType type = uniforms->GetUniformTupleType("morphWeights");
-  if (type != vtkUniforms::TupleTypeInvalid)
-  {
-    for (int i = 0; i < 4; i++)
-    {
-      std::string name = "target" + std::to_string(i) + "_position";
-
-      // modify position using morph weights
-      if (this->VBOs->GetNumberOfComponents(name.c_str()) == 3)
-      {
-        customDecl += "in vec3 ";
-        customDecl += name;
-        customDecl += ";\n";
-
-        posImpl += " posMC += morphWeights[";
-        posImpl += std::to_string(i);
-        posImpl += "] * vec4(";
-        posImpl += name;
-        posImpl += ", 0);\n";
-      }
-
-      name = "target" + std::to_string(i) + "_normal";
-
-      // modify normal using morph weights
-      if (this->VBOs->GetNumberOfComponents(name.c_str()) == 3)
-      {
-        customDecl += "in vec3 ";
-        customDecl += name;
-        customDecl += ";\n";
-
-        if (hasNormals)
-        {
-          normalImpl += " normalVCVSOutput += morphWeights[";
-          normalImpl += std::to_string(i);
-          normalImpl += "] * ";
-          normalImpl += name;
-          normalImpl += ";\n";
-        }
-      }
-    }
-  }
-
-  // skin
-  type = uniforms->GetUniformTupleType("jointMatrices");
+  vtkUniforms::TupleType type = uniforms->GetUniformTupleType("jointMatrices");
   if (type != vtkUniforms::TupleTypeInvalid)
   {
     int nbJoints = uniforms->GetUniformNumberOfTuples("jointMatrices");
-
-    bool skinningSupported = true;
 
     // The number of uniform values required by OpenGL is 4096
     // Since a mat4 is 16 values, it means we can only support 256 bones
@@ -153,20 +52,18 @@ void vtkF3DPolyDataMapper::ReplaceShaderValues(
       // 4.3 is required for SSBO
       if (major == 4 && minor >= 3)
       {
-        std::vector<float> buffer(16 * sizeof(float) * nbJoints);
-        uniforms->GetUniformMatrix4x4v("jointMatrices", buffer);
+        // PBR requires linear color space
+        auto vertexShader = shaders[vtkShader::Vertex];
+        auto VSSource = vertexShader->GetSource();
 
-        this->JointMatrices->Upload(buffer, vtkOpenGLBufferObject::ArrayBuffer);
-        this->JointMatrices->BindShaderStorage(0);
-
-        uniforms->RemoveUniform("jointMatrices");
-
-        customDecl += "layout(std430, binding = 0) readonly buffer JointsData\n"
-                      "{\n"
-                      "  mat4 jointMatrices[];\n"
-                      "};\n";
+        std::regex regex("uniform mat4 jointMatrices\\[[0-9]+\\];");
+        VSSource = std::regex_replace(VSSource, regex,
+          "layout(std430, binding = 0) buffer JointMatrices { mat4 jointMatrices[]; };");
 
         vtkShaderProgram::Substitute(VSSource, "//VTK::System::Dec", "#version 430");
+
+        vertexShader->SetSource(VSSource);
+        this->HasSSBOSkinning = true;
       }
       else
       {
@@ -174,73 +71,27 @@ void vtkF3DPolyDataMapper::ReplaceShaderValues(
           std::to_string(nbJoints) + "), which requires OpenGL >= 4.3";
         F3DLog::Print(F3DLog::Severity::Warning, msg);
 
-        skinningSupported = false;
-      }
-    }
-
-    if (skinningSupported)
-    {
-      customDecl += "in vec4 joints;\n"
-                    "in vec4 weights;\n";
-
-      // compute skinning matrix with current uniform weights
-      beginImpl += "  mat4 skinMat = weights.x * jointMatrices[int(joints.x)]\n"
-                   "               + weights.y * jointMatrices[int(joints.y)]\n"
-                   "               + weights.z * jointMatrices[int(joints.z)]\n"
-                   "               + weights.w * jointMatrices[int(joints.w)];\n";
-
-      posImpl += "  posMC = skinMat * posMC;\n";
-
-      // apply the matrix to normals and tangents
-      if (hasNormals)
-      {
-        normalImpl += "  normalVCVSOutput = mat3(skinMat) * normalVCVSOutput;\n";
-      }
-      if (hasTangents)
-      {
-        normalImpl += "  tangentVCVSOutput = mat3(skinMat) * tangentVCVSOutput;\n";
+        uniforms->RemoveUniform("jointMatrices");
       }
     }
   }
-
-  posImpl += "  gl_Position = MCDCMatrix * posMC;\n";
-
-  if (this->PrimitiveInfo[this->LastBoundBO].LastLightComplexity > 0)
-  {
-    posImpl += "  vertexVCVSOutput = MCVCMatrix * posMC;\n";
-  }
-
-  if (hasNormals)
-  {
-    normalImpl += "  normalVCVSOutput = normalMatrix * normalVCVSOutput;\n";
-  }
-  if (hasTangents)
-  {
-    normalImpl += "  tangentVCVSOutput = normalMatrix * tangentVCVSOutput;\n";
-  }
-
-  vtkShaderProgram::Substitute(VSSource, "//VTK::CustomUniforms::Dec", customDecl);
-  vtkShaderProgram::Substitute(VSSource, "//VTK::PositionVC::Impl", posImpl);
-  vtkShaderProgram::Substitute(VSSource, "//VTK::Normal::Impl", normalImpl);
-  vtkShaderProgram::Substitute(VSSource, "//VTK::CustomBegin::Impl", beginImpl);
-
-  vertexShader->SetSource(VSSource);
-
-  this->Superclass::ReplaceShaderValues(shaders, ren, actor);
 }
 
 //-----------------------------------------------------------------------------
-bool vtkF3DPolyDataMapper::RenderWithMatCap(vtkActor* actor)
+void vtkF3DPolyDataMapper::SetCustomUniforms(vtkOpenGLHelper& cellBO, vtkActor* actor)
 {
-  // check if we have normals
-  if (this->VBOs->GetNumberOfComponents("normalMC") != 3)
-  {
-    return false;
-  }
+  this->Superclass::SetCustomUniforms(cellBO, actor);
 
-  auto textures = actor->GetProperty()->GetAllTextures();
-  auto fn = [](const std::pair<std::string, vtkTexture*>& tex) { return tex.first == "matcap"; };
-  return std::ranges::find_if(textures, fn) != textures.end();
+  if (this->HasSSBOSkinning)
+  {
+    vtkUniforms* uniforms = actor->GetShaderProperty()->GetVertexCustomUniforms();
+
+    std::vector<float> buffer(16 * uniforms->GetUniformNumberOfTuples("jointMatrices"));
+    uniforms->GetUniformMatrix4x4v("jointMatrices", buffer);
+
+    this->JointMatrices->Upload(buffer, vtkOpenGLBufferObject::ArrayBuffer);
+    this->JointMatrices->BindShaderStorage(0);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -268,23 +119,7 @@ void vtkF3DPolyDataMapper::ReplaceShaderColor(
   }
 #endif
 
-  if (this->RenderWithMatCap(actor))
-  {
-    auto fragmentShader = shaders[vtkShader::Fragment];
-    auto FSSource = fragmentShader->GetSource();
-
-    std::string customLight = "//VTK::Color::Impl\n"
-                              "vec2 uv = vec2(normalVCVSOutput.xy) * 0.5 + vec2(0.5,0.5);\n"
-                              "vec3 diffuseColor = vec3(0.0);\n"
-                              "vec3 ambientColor = texture(matcap, uv).rgb;\n";
-
-    vtkShaderProgram::Substitute(FSSource, "//VTK::Color::Impl", customLight);
-    fragmentShader->SetSource(FSSource);
-  }
-  else
-  {
-    this->Superclass::ReplaceShaderColor(shaders, ren, actor);
-  }
+  this->Superclass::ReplaceShaderColor(shaders, ren, actor);
 }
 
 //-----------------------------------------------------------------------------
@@ -308,54 +143,5 @@ void vtkF3DPolyDataMapper::ReplaceShaderLight(
   }
 #endif
 
-  if (this->RenderWithMatCap(actor))
-  {
-    auto fragmentShader = shaders[vtkShader::Fragment];
-    auto FSSource = fragmentShader->GetSource();
-
-    // set final color to gamma-corrected ambient color
-    std::string customLight = "//VTK::Light::Impl\n"
-                              "gl_FragData[0] = vec4(pow(ambientColor, vec3(1.0/2.2)), 1.0);\n";
-
-    vtkShaderProgram::Substitute(FSSource, "//VTK::Light::Impl", customLight);
-    fragmentShader->SetSource(FSSource);
-  }
-  else
-  {
-    this->Superclass::ReplaceShaderLight(shaders, ren, actor);
-  }
-}
-
-//-----------------------------------------------------------------------------
-void vtkF3DPolyDataMapper::ReplaceShaderTCoord(
-  std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor)
-{
-  if (this->RenderWithMatCap(actor))
-  {
-    // disable default behavior of VTK with textures to avoid blending with itself
-    auto fragmentShader = shaders[vtkShader::Fragment];
-    std::string FSSource = fragmentShader->GetSource();
-
-    vtkShaderProgram::Substitute(FSSource, "//VTK::TCoord::Impl", "");
-
-    fragmentShader->SetSource(FSSource);
-  }
-
-  // unlit gamma correction
-  if (!actor->GetProperty()->GetLighting() && actor->GetProperty()->GetInterpolation() != VTK_PBR)
-  {
-    auto fragmentShader = shaders[vtkShader::Fragment];
-    std::string FSSource = fragmentShader->GetSource();
-
-    // apply final gamma-correction
-    std::string customGamma =
-      "//VTK::TCoord::Impl\n"
-      "gl_FragData[0] = vec4(pow(gl_FragData[0].rgb, vec3(1.0/2.2)), gl_FragData[0].a);\n";
-
-    vtkShaderProgram::Substitute(FSSource, "//VTK::TCoord::Impl", customGamma);
-
-    fragmentShader->SetSource(FSSource);
-  }
-
-  this->Superclass::ReplaceShaderTCoord(shaders, ren, actor);
+  this->Superclass::ReplaceShaderLight(shaders, ren, actor);
 }

--- a/vtkext/private/module/vtkF3DPolyDataMapper.h
+++ b/vtkext/private/module/vtkF3DPolyDataMapper.h
@@ -2,10 +2,8 @@
  * @class   vtkF3DPolyDataMapper
  * @brief   Custom surface mapper used to include F3D features
  *
- * This mapper is used to add many F3D custom features:
- * - skinning and morphing capabilities
- * - support for MatCap rendering
- * - support for TAA jittering
+ * This mapper is used to add support for SSBO skinning and
+ * backward compatibility with old VTK versions for unlit materials.
  */
 
 #ifndef vtkF3DPolyDataMapper_h
@@ -28,27 +26,26 @@ public:
 
   ///@{
   /**
-   * Modify the shaders to use MatCap if enabled
+   * Modify the shaders to handle color space
    */
   void ReplaceShaderColor(
     std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor) override;
   void ReplaceShaderLight(
     std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor) override;
-  void ReplaceShaderTCoord(
-    std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor) override;
   ///@}
 
+  /**
+   * Set the SSBO for skinning if needed
+   */
+  void SetCustomUniforms(vtkOpenGLHelper& cellBO, vtkActor* actor) override;
+
 protected:
-  vtkF3DPolyDataMapper();
+  vtkF3DPolyDataMapper() = default;
   ~vtkF3DPolyDataMapper() override = default;
 
 private:
-  /**
-   * Returns true if a MatCap texture is defined by the user and the actor has normals
-   */
-  bool RenderWithMatCap(vtkActor* actor);
-
   vtkNew<vtkOpenGLBufferObject> JointMatrices;
+  bool HasSSBOSkinning = false;
 };
 
 #endif

--- a/vtkext/private/module/vtkF3DRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DRenderPass.cxx
@@ -371,22 +371,9 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
 }
 
 // ----------------------------------------------------------------------------
-bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader,
-  std::string& geometryShader, std::string& fragmentShader, vtkAbstractMapper* mapper,
-  vtkProp* prop)
+void vtkF3DRenderPass::ReplaceMatCapShader(std::string& fragmentShader, vtkActor* actor, vtkPolyData* polyData)
 {
-  vtkPolyDataMapper* polyMapper = vtkPolyDataMapper::SafeDownCast(mapper);
-  vtkActor* actor = vtkActor::SafeDownCast(prop);
-
-  if (!polyMapper || !actor)
-  {
-    return true;
-  }
-
-  vtkPolyData* input = polyMapper->GetNumberOfInputPorts() > 0 ? polyMapper->GetInput() : nullptr;
-
-  // insert matcap shader
-  if (input && input->GetPointData()->GetNormals() != nullptr) // check if we have normals
+  if (polyData && polyData->GetPointData()->GetNormals() != nullptr) // check if we have normals
   {
     auto textures = actor->GetProperty()->GetAllTextures();
     auto fn = [](const std::pair<std::string, vtkTexture*>& tex) { return tex.first == "matcap"; };
@@ -411,20 +398,12 @@ bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader,
       vtkShaderProgram::Substitute(fragmentShader, "//VTK::TCoord::Impl", "");
     }
   }
+}
 
-  // 2. unlit gamma correction
-  if (!actor->GetProperty()->GetLighting() && actor->GetProperty()->GetInterpolation() != VTK_PBR)
-  {
-    // apply final gamma-correction
-    std::string customGamma =
-      "//VTK::TCoord::Impl\n"
-      "gl_FragData[0] = vec4(pow(gl_FragData[0].rgb, vec3(1.0/2.2)), gl_FragData[0].a);\n";
-
-    vtkShaderProgram::Substitute(fragmentShader, "//VTK::TCoord::Impl", customGamma);
-  }
-
-  // 3. skinning/morphing
-  if (input)
+// ----------------------------------------------------------------------------
+void vtkF3DRenderPass::ReplaceSkinningMorphing(std::string& vertexShader, vtkActor* actor, vtkPolyData* polyData)
+{
+  if (polyData)
   {
     vtkUniforms* uniforms = actor->GetShaderProperty()->GetVertexCustomUniforms();
     bool hasMorphing =
@@ -435,8 +414,8 @@ bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader,
     if (hasMorphing || hasSkinning)
     {
       bool hasTangents =
-        input->GetPointData()->GetTangents() && actor->GetProperty()->GetLighting();
-      bool hasNormals = input->GetPointData()->GetNormals() && actor->GetProperty()->GetLighting();
+        polyData->GetPointData()->GetTangents() && actor->GetProperty()->GetLighting();
+      bool hasNormals = polyData->GetPointData()->GetNormals() && actor->GetProperty()->GetLighting();
       hasTangents = hasTangents && (actor->GetProperty()->GetTexture("normalTex") != nullptr);
 
       std::string customDecl = "//VTK::CustomUniforms::Dec\n";
@@ -463,7 +442,7 @@ bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader,
           std::string name = "target" + std::to_string(i) + "_position";
 
           // modify position using morph weights
-          if (input->GetPointData()->GetArray(name.c_str()) != nullptr)
+          if (polyData->GetPointData()->GetArray(name.c_str()) != nullptr)
           {
             customDecl += "in vec3 ";
             customDecl += name;
@@ -479,7 +458,7 @@ bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader,
           name = "target" + std::to_string(i) + "_normal";
 
           // modify normal using morph weights
-          if (input->GetPointData()->GetArray(name.c_str()) != nullptr)
+          if (polyData->GetPointData()->GetArray(name.c_str()) != nullptr)
           {
             customDecl += "in vec3 ";
             customDecl += name;
@@ -538,11 +517,7 @@ bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader,
       }
       if (hasTangents)
       {
-#ifndef F3D_USE_GLES
         normalImpl += "  tangentVCVSOutput = normalMatrix * tangentVCVSOutput;\n";
-#else
-        normalImpl += "  tangentVCVS = normalMatrix * tangentVCVS;\n";
-#endif
       }
 
       vtkShaderProgram::Substitute(vertexShader, "//VTK::CustomUniforms::Dec", customDecl);
@@ -551,6 +526,36 @@ bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader,
       vtkShaderProgram::Substitute(vertexShader, "//VTK::CustomBegin::Impl", beginImpl);
     }
   }
+}
+
+// ----------------------------------------------------------------------------
+bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader,
+  std::string& geometryShader, std::string& fragmentShader, vtkAbstractMapper* mapper,
+  vtkProp* prop)
+{
+  vtkPolyDataMapper* polyMapper = vtkPolyDataMapper::SafeDownCast(mapper);
+  vtkActor* actor = vtkActor::SafeDownCast(prop);
+
+  if (!polyMapper || !actor)
+  {
+    return true;
+  }
+
+  vtkPolyData* input = polyMapper->GetNumberOfInputPorts() > 0 ? polyMapper->GetInput() : nullptr;
+
+  this->ReplaceMatCapShader(fragmentShader, actor, input);
+
+  if (!actor->GetProperty()->GetLighting() && actor->GetProperty()->GetInterpolation() != VTK_PBR)
+  {
+    // apply final gamma-correction
+    std::string customGamma =
+      "//VTK::TCoord::Impl\n"
+      "gl_FragData[0] = vec4(pow(gl_FragData[0].rgb, vec3(1.0/2.2)), gl_FragData[0].a);\n";
+
+    vtkShaderProgram::Substitute(fragmentShader, "//VTK::TCoord::Impl", customGamma);
+  }
+
+  this->ReplaceSkinningMorphing(vertexShader, actor, input);
 
   return true;
 }

--- a/vtkext/private/module/vtkF3DRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DRenderPass.cxx
@@ -371,7 +371,8 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
 }
 
 // ----------------------------------------------------------------------------
-void vtkF3DRenderPass::ReplaceMatCapShader(std::string& fragmentShader, vtkActor* actor, vtkPolyData* polyData)
+void vtkF3DRenderPass::ReplaceMatCapShader(
+  std::string& fragmentShader, vtkActor* actor, vtkPolyData* polyData)
 {
   if (polyData && polyData->GetPointData()->GetNormals() != nullptr) // check if we have normals
   {
@@ -401,7 +402,8 @@ void vtkF3DRenderPass::ReplaceMatCapShader(std::string& fragmentShader, vtkActor
 }
 
 // ----------------------------------------------------------------------------
-void vtkF3DRenderPass::ReplaceSkinningMorphing(std::string& vertexShader, vtkActor* actor, vtkPolyData* polyData)
+void vtkF3DRenderPass::ReplaceSkinningMorphing(
+  std::string& vertexShader, vtkActor* actor, vtkPolyData* polyData)
 {
   if (polyData)
   {
@@ -415,7 +417,8 @@ void vtkF3DRenderPass::ReplaceSkinningMorphing(std::string& vertexShader, vtkAct
     {
       bool hasTangents =
         polyData->GetPointData()->GetTangents() && actor->GetProperty()->GetLighting();
-      bool hasNormals = polyData->GetPointData()->GetNormals() && actor->GetProperty()->GetLighting();
+      bool hasNormals =
+        polyData->GetPointData()->GetNormals() && actor->GetProperty()->GetLighting();
       hasTangents = hasTangents && (actor->GetProperty()->GetTexture("normalTex") != nullptr);
 
       std::string customDecl = "//VTK::CustomUniforms::Dec\n";
@@ -529,9 +532,8 @@ void vtkF3DRenderPass::ReplaceSkinningMorphing(std::string& vertexShader, vtkAct
 }
 
 // ----------------------------------------------------------------------------
-bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader,
-  std::string& geometryShader, std::string& fragmentShader, vtkAbstractMapper* mapper,
-  vtkProp* prop)
+bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader, std::string&,
+  std::string& fragmentShader, vtkAbstractMapper* mapper, vtkProp* prop)
 {
   vtkPolyDataMapper* polyMapper = vtkPolyDataMapper::SafeDownCast(mapper);
   vtkActor* actor = vtkActor::SafeDownCast(prop);

--- a/vtkext/private/module/vtkF3DRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DRenderPass.cxx
@@ -22,7 +22,9 @@
 #include <vtkOpenGLRenderWindow.h>
 #include <vtkOpenGLShaderCache.h>
 #include <vtkOpenGLState.h>
+#include <vtkOpenGLVertexBufferObjectGroup.h>
 #include <vtkOverlayPass.h>
+#include <vtkPointData.h>
 #include <vtkProp.h>
 #include <vtkRenderPassCollection.h>
 #include <vtkRenderState.h>
@@ -32,10 +34,12 @@
 #include <vtkSSAOPass.h>
 #include <vtkSequencePass.h>
 #include <vtkShaderProgram.h>
+#include <vtkShaderProperty.h>
 #include <vtkSkybox.h>
 #include <vtkTextureObject.h>
 #include <vtkToneMappingPass.h>
 #include <vtkTranslucentPass.h>
+#include <vtkUniforms.h>
 #include <vtkVersion.h>
 #include <vtkVolumetricPass.h>
 
@@ -115,9 +119,68 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
       }
       else
       {
+        vtkActor* actor = vtkActor::SafeDownCast(prop);
+
+        if (actor)
+        {
+          vtkPolyDataMapper* polyMapper = vtkPolyDataMapper::SafeDownCast(actor->GetMapper());
+          if (polyMapper)
+          {
+            polyMapper->SetVBOShiftScaleMethod(
+              vtkPolyDataMapper::ShiftScaleMethodType::DISABLE_SHIFT_SCALE);
+
+            vtkPolyData* input =
+              polyMapper->GetNumberOfInputPorts() > 0 ? polyMapper->GetInput() : nullptr;
+
+            // handle skinning/morphing attributes for the actor
+            if (input)
+            {
+              if (input->GetNumberOfPoints() == 0)
+              {
+                // skip rendering if no point
+                continue;
+              }
+
+              // skinning
+              if (input->GetPointData()->GetArray("WEIGHTS_0") != nullptr &&
+                input->GetPointData()->GetArray("JOINTS_0") != nullptr)
+              {
+                // map glTF arrays to GPU VBOs
+                polyMapper->MapDataArrayToVertexAttribute(
+                  "weights", "WEIGHTS_0", vtkDataObject::FIELD_ASSOCIATION_POINTS);
+                polyMapper->MapDataArrayToVertexAttribute(
+                  "joints", "JOINTS_0", vtkDataObject::FIELD_ASSOCIATION_POINTS);
+              }
+
+              // morph targets
+              // OpenGL limits the input attributes to 16 vectors
+              // We ignore morphing on tangent on purpose to maximize the number of targets we
+              // can support
+              for (int j = 0; j < 4; j++)
+              {
+                std::string namePosition = "target" + std::to_string(j) + "_position";
+
+                if (input->GetPointData()->GetArray(namePosition.c_str()) == nullptr)
+                {
+                  break;
+                }
+
+                polyMapper->MapDataArrayToVertexAttribute(namePosition.c_str(),
+                  namePosition.c_str(), vtkDataObject::FIELD_ASSOCIATION_POINTS);
+
+                std::string nameNormal = "target" + std::to_string(j) + "_normal";
+                if (input->GetPointData()->GetArray(nameNormal.c_str()) != nullptr)
+                {
+                  polyMapper->MapDataArrayToVertexAttribute(nameNormal.c_str(), nameNormal.c_str(),
+                    vtkDataObject::FIELD_ASSOCIATION_POINTS);
+                }
+              }
+            }
+          }
+        }
+
         this->MainProps.push_back(prop);
 
-        vtkActor* actor = vtkActor::SafeDownCast(prop);
         if (!actor || vtkF3DOpenGLGridMapper::SafeDownCast(actor->GetMapper()) == nullptr)
         {
           // Do not add the grid into the reflective actors
@@ -133,7 +196,10 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
     return;
   }
 
-  this->ReleaseGraphicsResources(s->GetRenderer()->GetRenderWindow());
+  vtkOpenGLRenderer* glRenderer = vtkOpenGLRenderer::SafeDownCast(s->GetRenderer());
+  this->LightComplexity = glRenderer->GetLightingComplexity();
+
+  this->ReleaseGraphicsResources(glRenderer->GetRenderWindow());
 
   // background pass, setup framebuffer, clear and draw skybox
   vtkNew<vtkOpaquePass> bgP;
@@ -202,7 +268,7 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
     }
 
     // translucent and volumic
-    const vtkF3DRenderer* renderer = vtkF3DRenderer::SafeDownCast(s->GetRenderer());
+    const vtkF3DRenderer* renderer = vtkF3DRenderer::SafeDownCast(glRenderer);
     if (renderer && renderer->GetBlendingMode() == vtkF3DRenderer::BlendingMode::DUAL_DEPTH_PEELING)
     {
       vtkNew<vtkDualDepthPeelingPass> ddpP;
@@ -244,9 +310,9 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
       vtkNew<vtkF3DTAAPass> taaP;
       taaP->SetDelegatePass(camP);
 
-      s->GetRenderer()->GetRenderWindow()->AddObserver(
+      glRenderer->GetRenderWindow()->AddObserver(
         vtkCommand::WindowResizeEvent, taaP.Get(), &vtkF3DTAAPass::ResetIterations);
-      s->GetRenderer()->GetRenderWindow()->GetInteractor()->GetInteractorStyle()->AddObserver(
+      glRenderer->GetRenderWindow()->GetInteractor()->GetInteractorStyle()->AddObserver(
         vtkCommand::InteractionEvent, taaP.Get(), &vtkF3DTAAPass::ResetIterations);
 
       this->MainPass->SetDelegatePass(taaP);
@@ -305,8 +371,195 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
 }
 
 // ----------------------------------------------------------------------------
+bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader,
+  std::string& geometryShader, std::string& fragmentShader, vtkAbstractMapper* mapper,
+  vtkProp* prop)
+{
+  vtkPolyDataMapper* polyMapper = vtkPolyDataMapper::SafeDownCast(mapper);
+  vtkActor* actor = vtkActor::SafeDownCast(prop);
+
+  if (!polyMapper || !actor)
+  {
+    return true;
+  }
+
+  vtkPolyData* input = polyMapper->GetNumberOfInputPorts() > 0 ? polyMapper->GetInput() : nullptr;
+
+  // insert matcap shader
+  if (input && input->GetPointData()->GetNormals() != nullptr) // check if we have normals
+  {
+    auto textures = actor->GetProperty()->GetAllTextures();
+    auto fn = [](const std::pair<std::string, vtkTexture*>& tex) { return tex.first == "matcap"; };
+    bool hasMatcap = std::ranges::find_if(textures, fn) != textures.end();
+
+    if (hasMatcap)
+    {
+      // disable PBR light, just sample matcap and set final color to gamma-corrected ambient color
+
+      std::string customColor = "  //VTK::Color::Impl\n"
+                                "  vec2 uv = vec2(normalVCVSOutput.xy) * 0.5 + vec2(0.5,0.5);\n"
+                                "  diffuseColor = vec3(0.0);\n"
+                                "  ambientColor = texture(matcap, uv).rgb;\n";
+
+      vtkShaderProgram::Substitute(fragmentShader, "  //VTK::Color::Impl", customColor);
+
+      std::string customLight = "  gl_FragData[0] = vec4(pow(ambientColor, vec3(1.0/2.2)), 1.0);\n";
+
+      vtkShaderProgram::Substitute(fragmentShader, "  //VTK::Light::Impl", customLight);
+
+      // disable default behavior of VTK with textures to avoid blending with itself
+      vtkShaderProgram::Substitute(fragmentShader, "//VTK::TCoord::Impl", "");
+    }
+  }
+
+  // 2. unlit gamma correction
+  if (!actor->GetProperty()->GetLighting() && actor->GetProperty()->GetInterpolation() != VTK_PBR)
+  {
+    // apply final gamma-correction
+    std::string customGamma =
+      "//VTK::TCoord::Impl\n"
+      "gl_FragData[0] = vec4(pow(gl_FragData[0].rgb, vec3(1.0/2.2)), gl_FragData[0].a);\n";
+
+    vtkShaderProgram::Substitute(fragmentShader, "//VTK::TCoord::Impl", customGamma);
+  }
+
+  // 3. skinning/morphing
+  if (input)
+  {
+    vtkUniforms* uniforms = actor->GetShaderProperty()->GetVertexCustomUniforms();
+    bool hasMorphing =
+      uniforms->GetUniformTupleType("morphWeights") != vtkUniforms::TupleTypeInvalid;
+    bool hasSkinning =
+      uniforms->GetUniformTupleType("jointMatrices") != vtkUniforms::TupleTypeInvalid;
+
+    if (hasMorphing || hasSkinning)
+    {
+      bool hasTangents =
+        input->GetPointData()->GetTangents() && actor->GetProperty()->GetLighting();
+      bool hasNormals = input->GetPointData()->GetNormals() && actor->GetProperty()->GetLighting();
+      hasTangents = hasTangents && (actor->GetProperty()->GetTexture("normalTex") != nullptr);
+
+      std::string customDecl = "//VTK::CustomUniforms::Dec\n";
+      std::string beginImpl = "//VTK::CustomBegin::Impl\n";
+      std::string posImpl = "//VTK::PositionVC::Impl\n"
+                            "  vec4 posMC = vertexMC;\n";
+
+      // normals and tangents can be modified by skinnning and morphing in model space
+      std::string normalImpl = "//VTK::Normal::Impl\n";
+      if (hasNormals)
+      {
+        normalImpl += "  normalVCVSOutput = normalMC;\n";
+      }
+      if (hasTangents)
+      {
+        normalImpl += "  tangentVCVSOutput = tangentMC;\n";
+      }
+
+      // morphing
+      if (hasMorphing)
+      {
+        for (int i = 0; i < 4; i++)
+        {
+          std::string name = "target" + std::to_string(i) + "_position";
+
+          // modify position using morph weights
+          if (input->GetPointData()->GetArray(name.c_str()) != nullptr)
+          {
+            customDecl += "in vec3 ";
+            customDecl += name;
+            customDecl += ";\n";
+
+            posImpl += " posMC += morphWeights[";
+            posImpl += std::to_string(i);
+            posImpl += "] * vec4(";
+            posImpl += name;
+            posImpl += ", 0);\n";
+          }
+
+          name = "target" + std::to_string(i) + "_normal";
+
+          // modify normal using morph weights
+          if (input->GetPointData()->GetArray(name.c_str()) != nullptr)
+          {
+            customDecl += "in vec3 ";
+            customDecl += name;
+            customDecl += ";\n";
+
+            if (hasNormals)
+            {
+              normalImpl += " normalVCVSOutput += morphWeights[";
+              normalImpl += std::to_string(i);
+              normalImpl += "] * ";
+              normalImpl += name;
+              normalImpl += ";\n";
+            }
+          }
+        }
+      }
+
+      // skin
+      if (hasSkinning)
+      {
+        customDecl += "in vec4 joints;\n"
+                      "in vec4 weights;\n";
+
+        beginImpl += "vec4 currentWeight = weights;\n"
+                     "ivec4 currentJoints = ivec4(joints);\n";
+
+        // compute skinning matrix with current uniform weights
+        beginImpl += "  mat4 skinMat = currentWeight.x * jointMatrices[currentJoints.x]\n"
+                     "               + currentWeight.y * jointMatrices[currentJoints.y]\n"
+                     "               + currentWeight.z * jointMatrices[currentJoints.z]\n"
+                     "               + currentWeight.w * jointMatrices[currentJoints.w];\n";
+
+        posImpl += "  posMC = skinMat * posMC;\n";
+
+        // apply the matrix to normals and tangents
+        if (hasNormals)
+        {
+          normalImpl += "  normalVCVSOutput = mat3(skinMat) * normalVCVSOutput;\n";
+        }
+        if (hasTangents)
+        {
+          normalImpl += "  tangentVCVSOutput = mat3(skinMat) * tangentVCVSOutput;\n";
+        }
+      }
+
+      posImpl += "  gl_Position = MCDCMatrix * posMC;\n";
+
+      if (this->LightComplexity > 0)
+      {
+        posImpl += "  vertexVCVSOutput = MCVCMatrix * posMC;\n";
+      }
+
+      if (hasNormals)
+      {
+        normalImpl += "  normalVCVSOutput = normalMatrix * normalVCVSOutput;\n";
+      }
+      if (hasTangents)
+      {
+#ifndef F3D_USE_GLES
+        normalImpl += "  tangentVCVSOutput = normalMatrix * tangentVCVSOutput;\n";
+#else
+        normalImpl += "  tangentVCVS = normalMatrix * tangentVCVS;\n";
+#endif
+      }
+
+      vtkShaderProgram::Substitute(vertexShader, "//VTK::CustomUniforms::Dec", customDecl);
+      vtkShaderProgram::Substitute(vertexShader, "//VTK::PositionVC::Impl", posImpl);
+      vtkShaderProgram::Substitute(vertexShader, "//VTK::Normal::Impl", normalImpl);
+      vtkShaderProgram::Substitute(vertexShader, "//VTK::CustomBegin::Impl", beginImpl);
+    }
+  }
+
+  return true;
+}
+
+// ----------------------------------------------------------------------------
 void vtkF3DRenderPass::Render(const vtkRenderState* s)
 {
+  this->PreRender(s);
+
   this->Initialize(s);
 
   double bgColor[3];
@@ -381,6 +634,8 @@ void vtkF3DRenderPass::Render(const vtkRenderState* s)
   this->Blend(s);
 
   this->NumberOfRenderedProps = this->MainPass->GetNumberOfRenderedProps();
+
+  this->PostRender(s);
 }
 
 // ----------------------------------------------------------------------------

--- a/vtkext/private/module/vtkF3DRenderPass.h
+++ b/vtkext/private/module/vtkF3DRenderPass.h
@@ -9,7 +9,7 @@
  * background (and optionally blur it using Bokeh depth of field) and the dataset image.
  *
  * @sa
- * vtkRenderPass
+ * vtkOpenGLRenderPass
  */
 
 #ifndef vtkF3DRenderPass_h
@@ -17,6 +17,7 @@
 
 #include <vtkFramebufferPass.h>
 #include <vtkOpenGLQuadHelper.h>
+#include <vtkOpenGLRenderPass.h>
 #include <vtkSmartPointer.h>
 #include <vtkTimeStamp.h>
 
@@ -25,14 +26,15 @@
 
 class vtkCamera;
 class vtkInformationIntegerKey;
+class vtkAbstractMapper;
 class vtkMatrix4x4;
 class vtkProp;
 
-class vtkF3DRenderPass : public vtkRenderPass
+class vtkF3DRenderPass : public vtkOpenGLRenderPass
 {
 public:
   static vtkF3DRenderPass* New();
-  vtkTypeMacro(vtkF3DRenderPass, vtkRenderPass);
+  vtkTypeMacro(vtkF3DRenderPass, vtkOpenGLRenderPass);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   void Render(const vtkRenderState* s) override;
@@ -45,6 +47,12 @@ public:
   vtkSetVector6Macro(Bounds, double);
   vtkSetMacro(CircleOfConfusionRadius, double);
   vtkSetMacro(RenderReflection, bool);
+
+  /**
+   * Modify shader code for jittering
+   */
+  bool PreReplaceShaderValues(std::string& vertexShader, std::string& geometryShader,
+    std::string& fragmentShader, vtkAbstractMapper* mapper, vtkProp* prop) override;
 
   vtkF3DRenderPass(const vtkF3DRenderPass&) = delete;
   void operator=(const vtkF3DRenderPass&) = delete;
@@ -80,6 +88,8 @@ protected:
   double Bounds[6] = {};
 
   vtkMTimeType InitializeTime = 0;
+
+  int LightComplexity = 0;
 
   std::vector<vtkProp*> BackgroundProps;
   std::vector<vtkProp*> MainOnTopProps;

--- a/vtkext/private/module/vtkF3DRenderPass.h
+++ b/vtkext/private/module/vtkF3DRenderPass.h
@@ -24,9 +24,11 @@
 #include <memory>
 #include <vector>
 
+class vtkActor;
 class vtkCamera;
 class vtkInformationIntegerKey;
 class vtkAbstractMapper;
+class vtkPolyData;
 class vtkMatrix4x4;
 class vtkProp;
 
@@ -97,6 +99,10 @@ protected:
   std::vector<vtkProp*> ReflectionProps;
 
   std::shared_ptr<vtkOpenGLQuadHelper> BlendQuadHelper;
+
+private:
+  void ReplaceMatCapShader(std::string& fragmentShader, vtkActor* actor, vtkPolyData* polyData);
+  void ReplaceSkinningMorphing(std::string& vertexShader, vtkActor* actor, vtkPolyData* polyData);
 };
 
 #endif


### PR DESCRIPTION
### Describe your changes

In order to prepare matcap and skin/morph features for GLES, the shader modification logic should be moved to the render pass in order to affect all mappers, including the low-mem one used in GLES.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [ ] I have not used AI to generate any of the content of this pull request
- [x] I have used AI to generate code in this pull request:
  - [x] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [x] I have carefully reviewed and completely understood every generated line.
  - [x] I disclose below which parts of the code were generated and with which AI model:

Only VSCode AI autocompletion (auto mode) has been used

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
