### PR TITLE
Fix crash when no backend is available

### DIFF
--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -106,7 +106,9 @@ public:
 #endif
 
     // OSMesa
-    return vtkSmartPointer<vtkOSOpenGLRenderWindow>::New();
+    vtkSmartPointer<vtkRenderWindow> osmesaRenWin = vtkSmartPointer<vtkOSOpenGLRenderWindow>::New();
+    osmesaRenWin->Initialize();
+    return osmesaRenWin->GetInitialized() ? osmesaRenWin : nullptr;
 #else
     // fallback on VTK logic for other systems
     return vtkSmartPointer<vtkRenderWindow>::New();


### PR DESCRIPTION
### Describe your changes

Automatic backend returns null is OSMesa is not available.

### Issue ticket number and link if any

Fix https://github.com/f3d-app/f3d/issues/2522

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [ ] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
