### PR TITLE
Move DPI logic

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -88,6 +88,7 @@ Linux testing protocol:
 - Check that CTRL+O (file dialog) is working
 - Check that CTRL+S then CTRL+L (statefile save/load file dialogs) are working: save a statefile, change the background color, load it back and check the color is restored
 - Check that CTRL+C then CTRL+V (statefile save/load to clipboard) are working: copy the state, change the background color, paste it back and check the color is restored
+- Check that `--dpi-aware` has an effect and match the system value.
 - Press "Esc" and check the following commands `reload_current_file_group`, `set_camera top`, `toggle_volume_rendering`, `exit`
 
 macOS testing protocol:
@@ -102,6 +103,7 @@ macOS testing protocol:
 - Check that CMD+O (file dialog) is working
 - Check that CMD+S then CMD+L (statefile save/load file dialogs) are working: save a statefile, change the background color, load it back and check the color is restored
 - Check that CMD+C then CMD+V (statefile save/load to clipboard) are working: copy the state, change the background color, paste it back and check the color is restored
+- Check that `--dpi-aware` has an effect and match the system value.
 - Press "Esc" and check the following commands `reload_current_file_group`, `set_camera top`, `toggle_volume_rendering`, `exit`
 
 Windows testing protocol:
@@ -120,6 +122,7 @@ Windows testing protocol:
 - Check that CTRL+S then CTRL+L (statefile save/load file dialogs) are working: save a statefile, change the background color, load it back and check the color is restored
 - Check that CTRL+C then CTRL+V (statefile save/load to clipboard) are working: copy the state, change the background color, paste it back and check the color is restored
 - run `f3d-console --version` in a Windows command line and check it output the version
+- Check that `--dpi-aware` has an effect and match the system value.
 - Press "Esc" and check the following commands `reload_current_file_group`, `set_camera top`, `toggle_volume_rendering`, `exit`
 
 Python testing protocol:

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -411,7 +411,7 @@ runs:
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: |
-        ${{ env.F3D_BIN_PATH }} ../source/testing/data/dragon.vtu --output=output/install_output.png --reference=../source/.github/baselines/install_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --verbose --rendering-backend=${{ inputs.rendering_backend }} --camera-view-angle=32.1111
+        ${{ env.F3D_BIN_PATH }} ../source/testing/data/dragon.vtu --output=output/install_output.png --reference=../source/.github/baselines/install_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --dpi-aware=0 --verbose --rendering-backend=${{ inputs.rendering_backend }} --camera-view-angle=32.1111
 
     # macOS needs VTK > 9.7.20260706 for proper grid rendering using osmesa
     # this test works with VTK 9.6.1 otherwise
@@ -421,7 +421,7 @@ runs:
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: |
-        ${{ env.F3D_BIN_PATH }} ../source/examples/plugins/example-plugin/data.expl --output=output/install_example_plugin_output.png --reference=../source/.github/baselines/install_example_plugin_output.png  --resolution=300,300 --verbose --rendering-backend=${{ inputs.rendering_backend }}
+        ${{ env.F3D_BIN_PATH }} ../source/examples/plugins/example-plugin/data.expl --output=output/install_example_plugin_output.png --reference=../source/.github/baselines/install_example_plugin_output.png --resolution=300,300 --dpi-aware=0 --verbose --rendering-backend=${{ inputs.rendering_backend }}
 
     - name: Check Install Windows Console Executable
       if: |
@@ -430,7 +430,7 @@ runs:
       shell: bash
       working-directory: ${{github.workspace}}/install
       run: |
-        ${{ env.F3D_CONSOLE_BIN_PATH }} ../source/testing/data/dragon.vtu --output=output/install_output.png --reference=../source/.github/baselines/install_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --verbose --rendering-backend=${{ inputs.rendering_backend }}
+        ${{ env.F3D_CONSOLE_BIN_PATH }} ../source/testing/data/dragon.vtu --output=output/install_output.png --reference=../source/.github/baselines/install_output.png --resolution=300,300 --colormap-file=viridis --coloring-component=0 --dpi-aware=0 --verbose --rendering-backend=${{ inputs.rendering_backend }}
 
     - name: Upload Tests Install Artifact
       if: failure()

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -1080,7 +1080,9 @@ public:
       f3d::window& window = this->Engine->getWindow();
       if (this->AppOptions.Resolution.size() == 2)
       {
-        double dpiScale = this->LibOptions.ui.dpi_aware ? f3d::utils::getDPIScale() : 1.0;
+        double dpiScale = window.getDPIScale();
+
+        f3d::log::debug("DPI scale: ", dpiScale);
 
         window.setSize(static_cast<int>(this->AppOptions.Resolution[0] * dpiScale),
           static_cast<int>(this->AppOptions.Resolution[1] * dpiScale));

--- a/c/testing/test_window.c
+++ b/c/testing/test_window.c
@@ -21,6 +21,14 @@ int test_window()
     return 1;
   }
 
+  double dpi_scale = f3d_window_get_dpi_scale(window);
+  if (dpi_scale < 1.0)
+  {
+    puts("[ERROR] DPI scale value unexpected");
+    f3d_engine_delete(engine);
+    return 1;
+  }
+
   f3d_window_type_t type = f3d_window_get_type(window);
   (void)type;
 

--- a/c/utils_c_api.cxx
+++ b/c/utils_c_api.cxx
@@ -153,9 +153,3 @@ void f3d_utils_string_free(char* str)
 {
   delete[] str;
 }
-
-//----------------------------------------------------------------------------
-double f3d_utils_get_dpi_scale()
-{
-  return f3d::utils::getDPIScale();
-}

--- a/c/utils_c_api.h
+++ b/c/utils_c_api.h
@@ -102,15 +102,6 @@ extern "C"
    */
   F3D_EXPORT void f3d_utils_string_free(char* str);
 
-  /**
-   * @brief Calculate the primary monitor system zoom scale base on DPI.
-   *
-   * Only supported on Windows platform.
-   *
-   * @return DPI scale in double, or 1.0 on other platforms.
-   */
-  F3D_EXPORT double f3d_utils_get_dpi_scale();
-
 #ifdef __cplusplus
 }
 #endif

--- a/c/window_c_api.cxx
+++ b/c/window_c_api.cxx
@@ -172,3 +172,15 @@ void f3d_window_get_display_from_world(
   display_point[1] = cpp_display_point[1];
   display_point[2] = cpp_display_point[2];
 }
+
+//----------------------------------------------------------------------------
+double f3d_window_get_dpi_scale(f3d_window_t* window)
+{
+  if (!window)
+  {
+    return 1.0;
+  }
+
+  f3d::window* cpp_window = reinterpret_cast<f3d::window*>(window);
+  return cpp_window->getDPIScale();
+}

--- a/c/window_c_api.h
+++ b/c/window_c_api.h
@@ -151,6 +151,15 @@ extern "C"
   F3D_EXPORT void f3d_window_get_display_from_world(
     const f3d_window_t* window, const f3d_point3_t world_point, f3d_point3_t display_point);
 
+  /**
+   * @brief Get the DPI scale value of the window.
+   *
+   * Returns 1.0 on platforms where DPI scaling is not supported.
+   *
+   * @return DPI scale.
+   */
+  F3D_EXPORT double f3d_window_get_dpi_scale(f3d_window_t* window);
+
 #ifdef __cplusplus
 }
 #endif

--- a/doc/libf3d/06-MIGRATION.md
+++ b/doc/libf3d/06-MIGRATION.md
@@ -56,3 +56,7 @@ The `ui.animation_progress` option (CLI `--animation-progress`) was a boolean to
 
 The function `f3d::context::getSymbol` function is now expecting a library full path or a filename.
 The library prefix and extension is not appended automatically anymore.
+
+## DPI scaling
+
+`f3d::window::getDPIScale()` should now be used instead of the static `f3d::utils::getDPIScale()` API to get the DPI scaling value.

--- a/examples/libf3d/web/multiple-instances/src/main.js
+++ b/examples/libf3d/web/multiple-instances/src/main.js
@@ -28,10 +28,11 @@ f3d({})
       engine.getOptions().toggle("render.effect.tone_mapping");
       engine.getOptions().toggle("render.effect.ambient_occlusion");
       engine.getOptions().toggle("render.hdri.ambient");
+      engine.getOptions().toggle("ui.dpi_aware");
 
       // setup the window size based on the canvas size
       const canvas = document.getElementById(id);
-      const scale = window.devicePixelRatio;
+      const scale = engine.getWindow().getDPIScale();
       engine
         .getWindow()
         .setSize(scale * canvas.clientWidth, scale * canvas.clientHeight);

--- a/java/F3DUtilsBindings.cxx
+++ b/java/F3DUtilsBindings.cxx
@@ -124,9 +124,4 @@ extern "C"
 
     return result.has_value() ? env->NewStringUTF(result.value().c_str()) : nullptr;
   }
-
-  JNIEXPORT jdouble JAVA_BIND(Utils, getDPIScale)(JNIEnv* env, jclass)
-  {
-    return static_cast<jdouble>(f3d::utils::getDPIScale());
-  }
 }

--- a/java/F3DWindowBindings.cxx
+++ b/java/F3DWindowBindings.cxx
@@ -138,3 +138,8 @@ extern "C"
     return ret;
   }
 }
+
+JNIEXPORT jdouble JAVA_BIND(Window, getDPIScale)(JNIEnv* env, jobject self)
+{
+  return static_cast<jdouble>(GetEngine(env, self)->getWindow().getDPIScale());
+}

--- a/java/Utils.java
+++ b/java/Utils.java
@@ -121,13 +121,4 @@ public class Utils {
      * @return folder path, or null on non-Windows platforms or error
      */
     public static native String getKnownFolder(KnownFolder knownFolder);
-
-    /**
-    * Calculate the primary monitor system zoom scale base on DPI.
-    * 
-    * Only supported on Windows platform.
-    * 
-    * @return DPI scale in double, or 1.0 on other platforms.
-    */
-    public static native double getDPIScale();
 }

--- a/java/Window.java
+++ b/java/Window.java
@@ -132,6 +132,14 @@ public class Window {
      */
     public native double[] getDisplayFromWorld(double[] worldPoint);
 
+    /**
+    * Get the DPI scale value of the window.
+    * Returns 1.0 on platforms where DPI scaling is not supported.
+    * 
+    * @return DPI scale.
+    */
+    public native double getDPIScale();
+
     private long mNativeAddress;
     private Camera mCamera;
 }

--- a/java/testing/TestWindow.java
+++ b/java/testing/TestWindow.java
@@ -27,6 +27,11 @@ public class TestWindow {
 
     window.render();
 
+    double dpiScale = window.getDPIScale();
+    if (dpiScale < 1.0) {
+      throw new RuntimeException("DPI scale value unexpected: " + dpiScale);
+    }
+
     Image img = window.renderToImage(true);
     img.getWidth();
     img.getHeight();

--- a/library/private/window_impl.h
+++ b/library/private/window_impl.h
@@ -48,6 +48,7 @@ public:
    */
   Type getType() override;
   bool isOffscreen() override;
+  double getDPIScale() override;
   camera& getCamera() override;
   bool render() override;
   image renderToImage(bool noBackground = false) override;

--- a/library/public/utils.h
+++ b/library/public/utils.h
@@ -92,13 +92,6 @@ public:
   [[nodiscard]] static std::string globToRegex(std::string_view glob, char pathSeparator = '/');
 
   /**
-   * Calculate the primary monitor system zoom scale base on DPI.
-   * Only supported on Windows platform.
-   * Return 1.0 on other platforms.
-   */
-  [[nodiscard]] static double getDPIScale();
-
-  /**
    * Get an environment variable value, returns std::nullopt if not set
    */
   [[nodiscard]] static std::optional<std::string> getEnv(const std::string& env);

--- a/library/public/window.h
+++ b/library/public/window.h
@@ -58,6 +58,12 @@ public:
   [[nodiscard]] virtual bool isOffscreen() = 0;
 
   /**
+   * Get the DPI scale value of the window.
+   * Returns 1.0 on platforms where DPI scaling is not supported.
+   */
+  [[nodiscard]] virtual double getDPIScale() = 0;
+
+  /**
    * Get the camera provided by the window.
    */
   [[nodiscard]] virtual camera& getCamera() = 0;

--- a/library/src/utils.cxx
+++ b/library/src/utils.cxx
@@ -333,12 +333,6 @@ std::string utils::globToRegex(std::string_view glob, char pathSeparator)
 }
 
 //----------------------------------------------------------------------------
-double utils::getDPIScale()
-{
-  return F3DUtils::getDPIScale();
-}
-
-//----------------------------------------------------------------------------
 std::optional<std::string> utils::getEnv(const std::string& env)
 {
   std::string val;

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -280,6 +280,13 @@ bool window_impl::isOffscreen()
 }
 
 //----------------------------------------------------------------------------
+double window_impl::getDPIScale()
+{
+  this->Internals->Renderer->SetDPIAware(this->Internals->Options.ui.dpi_aware);
+  return this->Internals->Renderer->GetDPIScale();
+}
+
+//----------------------------------------------------------------------------
 camera& window_impl::getCamera()
 {
   return *this->Internals->Camera;

--- a/library/testing/TestSDKWindowAuto.cxx
+++ b/library/testing/TestSDKWindowAuto.cxx
@@ -19,6 +19,7 @@ int TestSDKWindowAuto([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
   test("window height", win.getHeight(), 300);
   test("window type", win.getType() != f3d::window::Type::UNKNOWN);
   test("window offscreen", win.isOffscreen());
+  test("window dpi", win.getDPIScale() >= 1.0);
 
   f3d::options& options = eng.getOptions();
   options.render.background.color = { 0.8, 0.2, 0.9 };

--- a/python/F3DPythonBindings.cxx
+++ b/python/F3DPythonBindings.cxx
@@ -359,7 +359,6 @@ PYBIND11_MODULE(pyf3d, module)
     .def_static("tokenize", &f3d::utils::tokenize, py::arg("str"), py::arg("keep_comments") = true)
     .def_static(
       "glob_to_regex", &f3d::utils::globToRegex, py::arg("glob"), py::arg("path_separator") = '/')
-    .def_static("get_dpi_scale", &f3d::utils::getDPIScale)
     .def_static("get_env", &f3d::utils::getEnv)
     .def_static("get_known_folder", &f3d::utils::getKnownFolder);
 
@@ -917,7 +916,8 @@ PYBIND11_MODULE(pyf3d, module)
     .def("get_world_from_display", &f3d::window::getWorldFromDisplay,
       "Get world coordinate point from display coordinate")
     .def("get_display_from_world", &f3d::window::getDisplayFromWorld,
-      "Get display coordinate point from world coordinate");
+      "Get display coordinate point from world coordinate")
+    .def("get_dpi_scale", &f3d::window::getDPIScale, "Get the DPI scale of the window");
 
   // libInformation
   py::class_<f3d::engine::libInformation>(module, "LibInformation")

--- a/python/testing/test_scene.py
+++ b/python/testing/test_scene.py
@@ -44,6 +44,8 @@ def test_scene():
     engine.scene.add(sphere1)
     engine.scene.add([sphere2, cube])
 
+    assert engine.window.get_dpi_scale() >= 1.0
+
     assert engine.scene.animation_time_range() == (0.0, 4.0)
     engine.scene.load_animation_time(2)
 

--- a/vtkext/private/module/Testing/TestF3DRendererWithColoring.cxx
+++ b/vtkext/private/module/Testing/TestF3DRendererWithColoring.cxx
@@ -20,6 +20,10 @@ int TestF3DRendererWithColoring(int argc, char* argv[])
   importer->SetRenderWindow(window);
   renderer->SetImporter(importer);
 
+  // coverage for DPI change
+  renderer->Initialize();
+  window->SetDPI(144);
+
   // Check invalid bounding box code path
   renderer->ShowGrid(true);
   renderer->UpdateActors();
@@ -85,9 +89,6 @@ int TestF3DRendererWithColoring(int argc, char* argv[])
   vtkNew<vtkF3DInteractorStyle> style;
   interactor->SetInteractorStyle(style);
   renderer->SetInteractionStyle("invalid");
-
-  // Cover DPI change code path
-  window->SetDPI(144);
 
   return EXIT_SUCCESS;
 }

--- a/vtkext/private/module/Testing/TestF3DRendererWithColoring.cxx
+++ b/vtkext/private/module/Testing/TestF3DRendererWithColoring.cxx
@@ -86,5 +86,8 @@ int TestF3DRendererWithColoring(int argc, char* argv[])
   interactor->SetInteractorStyle(style);
   renderer->SetInteractionStyle("invalid");
 
+  // Cover DPI change code path
+  window->SetDPI(144);
+
   return EXIT_SUCCESS;
 }

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -336,6 +336,22 @@ void vtkF3DRenderer::Initialize()
     });
   this->RenderWindow->AddObserver(vtkCommand::WindowResizeEvent, modernAxisWidgetResizeCallback);
 #endif
+
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 7, 20260729)
+  // create a dpi changed callback to rebuild UI with proper size
+  vtkNew<vtkCallbackCommand> dpiChangedCallback;
+  dpiChangedCallback->SetClientData(this);
+  dpiChangedCallback->SetCallback(
+    [](vtkObject* const, unsigned long, void* clientData, void* callData)
+    {
+      vtkF3DRenderer* self = static_cast<vtkF3DRenderer*>(clientData);
+      self->TextActorsConfigured = false;
+      self->ConfigureTextActors();
+      F3DLog::Print(
+        F3DLog::Severity::Info, "DPI changed to " + std::to_string(*static_cast<int*>(callData)));
+    });
+  this->RenderWindow->AddObserver(vtkCommand::DPIChangedEvent, dpiChangedCallback);
+#endif
 }
 
 //----------------------------------------------------------------------------
@@ -1521,6 +1537,35 @@ void vtkF3DRenderer::ConfigureHDRISkybox()
 }
 
 //----------------------------------------------------------------------------
+double vtkF3DRenderer::GetDPIScale()
+{
+  std::string forceDpiStr;
+  if (vtksys::SystemTools::GetEnv("CTEST_F3D_FORCE_DPI_SCALE", forceDpiStr))
+  {
+    try
+    {
+      return std::stod(forceDpiStr);
+    }
+    catch (const std::exception&)
+    {
+      // silently ignore invalid values
+    }
+  }
+
+#ifdef __APPLE__
+  constexpr int baseDPI = 72;
+#else
+  constexpr int baseDPI = 96;
+#endif
+
+  if (this->DPIAware && this->GetRenderWindow()->DetectDPI())
+  {
+    return static_cast<double>(this->GetRenderWindow()->GetDPI()) / baseDPI; // LCOV_EXCL_LINE
+  }
+  return 1.0;
+}
+
+//----------------------------------------------------------------------------
 void vtkF3DRenderer::ConfigureTextActors()
 {
   // Font
@@ -1543,11 +1588,8 @@ void vtkF3DRenderer::ConfigureTextActors()
     }
   }
 
-  this->UIActor->SetFontColor(FontColor);
-
-  double scaleFactor = this->DPIAware ? F3DUtils::getDPIScale() : 1.0;
-
-  this->UIActor->SetFontScale(this->FontScale * scaleFactor);
+  this->UIActor->SetFontColor(this->FontColor);
+  this->UIActor->SetFontScale(this->FontScale * this->GetDPIScale());
 
   this->TextActorsConfigured = true;
 }

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -1560,6 +1560,8 @@ double vtkF3DRenderer::GetDPIScale()
 
   if (this->DPIAware && this->GetRenderWindow()->DetectDPI())
   {
+    // In the CI, DetectDPI() returns 0, even if .Xresources contains Xft.dpi
+    // xvfb seems to ignore it, so we cannot cover this line
     return static_cast<double>(this->GetRenderWindow()->GetDPI()) / baseDPI; // LCOV_EXCL_LINE
   }
   return 1.0;

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -595,6 +595,11 @@ public:
    */
   void UpdateAnimationTime(double currentTime);
 
+  /**
+   * Get the DPI scale based on the current render window
+   */
+  double GetDPIScale();
+
 private:
   vtkF3DRenderer();
   ~vtkF3DRenderer() override;

--- a/vtkext/public/module/F3DUtils.cxx
+++ b/vtkext/public/module/F3DUtils.cxx
@@ -57,35 +57,3 @@ int F3DUtils::ParseToInt(const std::string& str, int def, const std::string& nam
   }
   return value;
 }
-
-//----------------------------------------------------------------------------
-double F3DUtils::getDPIScale()
-{
-  std::string forceDpiStr;
-  if (vtksys::SystemTools::GetEnv("CTEST_F3D_FORCE_DPI_SCALE", forceDpiStr))
-  {
-    try
-    {
-      return std::stod(forceDpiStr);
-    }
-    catch (const std::exception&)
-    {
-      // silently ignore invalid values
-    }
-  }
-
-  constexpr int baseDPI = 96;
-  unsigned int dpi = baseDPI;
-
-#ifdef _WIN32
-  dpi = GetDeviceCaps(wglGetCurrentDC(), LOGPIXELSY);
-
-  if (dpi == 0)
-  {
-    vtkWarningWithObjectMacro(nullptr, "Fail to get DPI.");
-    dpi = baseDPI;
-  }
-#endif
-
-  return static_cast<double>(dpi) / baseDPI;
-}

--- a/vtkext/public/module/F3DUtils.h
+++ b/vtkext/public/module/F3DUtils.h
@@ -30,13 +30,6 @@ VTKEXT_EXPORT double ParseToDouble(
  * Use nameError in the log for easier debugging.
  */
 VTKEXT_EXPORT int ParseToInt(const std::string& str, int def, const std::string& nameError);
-
-/*
- * Calculate the primary monitor system zoom scale base on DPI.
- * Only supported on Windows platform.
- * Return 1.0 on other platforms.
- */
-VTKEXT_EXPORT double getDPIScale();
 };
 
 #endif

--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -393,7 +393,8 @@ EMSCRIPTEN_BINDINGS(f3d)
       {
         return containerToJSArray(win.getDisplayFromWorld(
           { jsArray[0].as<float>(), jsArray[1].as<float>(), jsArray[2].as<float>() }));
-      });
+      })
+    .function("getDPIScale", &f3d::window::getDPIScale);
 
   // f3d::interactor
   emscripten::enum_<f3d::interactor::AnimationDirection>("InteractorAnimationDirection")

--- a/webassembly/testing/test_render.js
+++ b/webassembly/testing/test_render.js
@@ -47,6 +47,11 @@ const settings = {
 
     // just for coverage
     Module.engineInstance.setCachePath("/tmp");
+
+    utils.assert(
+      window.getDPIScale() >= 1.0,
+      "DPI scale value unexpected: " + window.getDPIScale(),
+    );
   },
 };
 


### PR DESCRIPTION
### Describe your changes

The code in `utils::getDPIScale()` used WIN32 API already available in `vtkWin32OpenGLRenderWindow::DetectDPI()`, so let's use that instead.

Related VTK MR: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/13501

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [ ] I have not used AI to generate any of the content of this pull request
- [x] I have used AI to generate code in this pull request:
  - [x] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [x] I have carefully reviewed and completely understood every generated line.
  - [x] I disclose below which parts of the code were generated and with which AI model:

VSCode AI autocompletion (model: auto)

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
