### PR TITLE
Fix OBJ 16-bits textures

### DIFF
--- a/application/testing/tests.native.cmake
+++ b/application/testing/tests.native.cmake
@@ -2,6 +2,7 @@
 f3d_test(NAME TestPLY DATA suzanne.ply)
 f3d_test(NAME TestOBJ DATA world.obj)
 f3d_test(NAME TestOBJUnlit DATA cube_unlit.obj)
+f3d_test(NAME TestOBJ16bits DATA cube_16bits.obj)
 f3d_test(NAME TestSTL DATA suzanne.stl)
 f3d_test(NAME TestVTICell DATA waveletMaterial.vti ARGS -s --coloring-array=Material -c --roughness=1)
 f3d_test(NAME TestVTU DATA dragon.vtu)

--- a/testing/baselines/TestOBJ16bits.png
+++ b/testing/baselines/TestOBJ16bits.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5360dda930ac28636cedc981d918396594ba6b53cc5ee35859e8afdfc0468f4d
-size 39557
+oid sha256:05e7f1f31540564e3683954589f8c6c5845cfa071e42dbcc125708c510f51a15
+size 37897

--- a/testing/baselines/TestOBJ16bits.png
+++ b/testing/baselines/TestOBJ16bits.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5360dda930ac28636cedc981d918396594ba6b53cc5ee35859e8afdfc0468f4d
+size 39557

--- a/testing/data/cube_16bits.mtl
+++ b/testing/data/cube_16bits.mtl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19980240356b7f2d3f0771f0ed7800e48dc470bb055abf77557cc005ed13205f
+size 33

--- a/testing/data/cube_16bits.obj
+++ b/testing/data/cube_16bits.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:279ffd3e9181a08ad7c95bff00da0cd1f821eda7aaa7bab9721160c0401556e9
+size 675

--- a/testing/data/cube_16bits.obj
+++ b/testing/data/cube_16bits.obj
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:279ffd3e9181a08ad7c95bff00da0cd1f821eda7aaa7bab9721160c0401556e9
-size 675
+oid sha256:1bc90bb229181248a78aa84537cbc3fa2287104d8b43975d7dd31e8194f17ce2
+size 251

--- a/vtkext/private/module/vtkF3DMetaImporter.cxx
+++ b/vtkext/private/module/vtkF3DMetaImporter.cxx
@@ -350,7 +350,16 @@ bool vtkF3DMetaImporter::Update()
         }
         if (diffuseTex)
         {
-          diffuseTex->UseSRGBColorSpaceOn();
+          vtkImageData* image = diffuseTex->GetInput();
+          if (image)
+          {
+            // If 1 byte per channel, the texture is usually sRGB
+            if (image->GetScalarSize() == 1)
+            {
+              diffuseTex->UseSRGBColorSpaceOn();
+            }
+            diffuseTex->SetColorModeToDirectScalars();
+          }
         }
 
         if (actor->GetProperty()->GetLighting())

--- a/vtkext/private/module/vtkF3DMetaImporter.cxx
+++ b/vtkext/private/module/vtkF3DMetaImporter.cxx
@@ -350,16 +350,8 @@ bool vtkF3DMetaImporter::Update()
         }
         if (diffuseTex)
         {
-          vtkImageData* image = diffuseTex->GetInput();
-          if (image)
-          {
-            // If 1 byte per channel, the texture is usually sRGB
-            if (image->GetScalarSize() == 1)
-            {
-              diffuseTex->UseSRGBColorSpaceOn();
-            }
-            diffuseTex->SetColorModeToDirectScalars();
-          }
+          diffuseTex->UseSRGBColorSpaceOn();
+          diffuseTex->SetColorModeToDirectScalars();
         }
 
         if (actor->GetProperty()->GetLighting())


### PR DESCRIPTION
### Describe your changes

When a texture has more than 8-bits per channel, VTK automatically does color mapping.
We need to enforce `SetColorModeToDirectScalars` on textures.

16-bits textures are usually sRGB encoded, just like 8-bits textures, so the PR improves the 16-bits texture handling but there's still an incorrect color space conversion. I'll open an issue.

### Issue ticket number and link if any

Fix https://github.com/f3d-app/f3d/issues/3427

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [ ] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
