### PR TITLE
Fix GLES skinning

### DIFF
--- a/testing/baselines/TestWasmSkinning.png
+++ b/testing/baselines/TestWasmSkinning.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c99f1b764ade78a1d30853a0438e19da824a633dac5612f9fb554ecbd94a29f
+size 5173

--- a/vtkext/private/module/vtkF3DMetaImporter.cxx
+++ b/vtkext/private/module/vtkF3DMetaImporter.cxx
@@ -19,6 +19,7 @@
 #include <vtkRendererCollection.h>
 #include <vtkSmartPointer.h>
 #include <vtkTexture.h>
+#include <vtkUnsignedIntArray.h>
 #include <vtkVersion.h>
 
 #include <cassert>
@@ -337,6 +338,21 @@ bool vtkF3DMetaImporter::Update()
       this->ActorCollection->AddItem(actor);
 
       vtkPolyData* surface = pdMapper->GetInput();
+
+      // On GLES, 16-bits attributes are not widely supported, which is used for joint indices.
+      // So we convert them to 32-bits attributes, which is supported everywhere.
+#ifdef F3D_USE_GLES
+      vtkDataArray* jointsArray = surface->GetPointData()->GetArray("JOINTS_0");
+      if (jointsArray != nullptr &&
+        (jointsArray->GetDataType() == VTK_SHORT ||
+          jointsArray->GetDataType() == VTK_UNSIGNED_SHORT))
+      {
+        vtkNew<vtkUnsignedIntArray> joints;
+        joints->DeepCopy(jointsArray);
+        joints->SetName("JOINTS_0");
+        surface->GetPointData()->AddArray(joints);
+      }
+#endif
 
       // convert to PBR materials if needed
       // this should be moved elsewhere, see https://github.com/f3d-app/f3d/issues/2995

--- a/vtkext/private/module/vtkF3DRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DRenderPass.cxx
@@ -531,7 +531,7 @@ void vtkF3DRenderPass::ReplaceSkinningMorphing(
       {
         // automatically added with GLES
 #ifdef F3D_USE_GLES
-        customDecl += "uniform mediump isampler2D joints;\n"
+        customDecl += "uniform mediump usampler2D joints;\n"
                       "uniform mediump sampler2D weights;\n";
 #else
         customDecl += "in vec4 joints;\n"
@@ -540,7 +540,7 @@ void vtkF3DRenderPass::ReplaceSkinningMorphing(
 
 #ifdef F3D_USE_GLES
         beginImpl += "  vec4 currentWeight = texelFetchBuffer(weights, pointId);\n"
-                     "  ivec4 currentJoints = texelFetchBuffer(joints, pointId);\n";
+                     "  uvec4 currentJoints = texelFetchBuffer(joints, pointId);\n";
 #else
         beginImpl += "  vec4 currentWeight = weights;\n"
                      "  ivec4 currentJoints = ivec4(joints);\n";
@@ -690,7 +690,7 @@ bool vtkF3DRenderPass::PostReplaceShaderValues([[maybe_unused]] std::string& ver
         // clang-format off
         replacementLines +=
           "  vec4 currentWeight" + index + " = texelFetchBuffer(weights, p" + index + ");\n"
-          "  ivec4 currentJoints" + index + " = texelFetchBuffer(joints, p" + index + ");\n"
+          "  uvec4 currentJoints" + index + " = texelFetchBuffer(joints, p" + index + ");\n"
           "  mat4 skinMat" + index + " = currentWeight" + index + ".x * jointMatrices[currentJoints" + index + ".x]\n"
           "             + currentWeight" + index + ".y * jointMatrices[currentJoints" + index + ".y]\n"
           "             + currentWeight" + index + ".z * jointMatrices[currentJoints" + index + ".z]\n"

--- a/webassembly/CMakeLists.txt
+++ b/webassembly/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(f3djs PRIVATE libf3d embind)
 target_link_options(f3djs PRIVATE
   "$<IF:$<CONFIG:Release>,-Oz,-O0>"
   "--emit-tsd=f3d.d.ts"
+  "SHELL:-sASSERTIONS=1"
   "SHELL:-sEXPORT_NAME=f3d"
   "SHELL:-sALLOW_MEMORY_GROWTH=1"
   "SHELL:-sEMULATE_FUNCTION_POINTER_CASTS=0"

--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -461,10 +461,8 @@ EMSCRIPTEN_BINDINGS(f3d)
       emscripten::return_value_policy::reference())
     .function(
       "requestStop", &f3d::interactor::requestStop, emscripten::return_value_policy::reference())
-    .function(
-      "triggerNotification",
-      +[](f3d::interactor& interactor, std::string desc, std::string value, double duration)
-      { interactor.triggerNotification(desc, value, duration); })
+    .function("triggerNotification", &f3d::interactor::triggerNotification,
+      emscripten::return_value_policy::reference())
     .function(
       "setNotificationCallback",
       +[](f3d::interactor& interactor, const emscripten::val& callback)

--- a/webassembly/testing/CMakeLists.txt
+++ b/webassembly/testing/CMakeLists.txt
@@ -7,6 +7,7 @@ set(f3djsTests_list
   "test_options"
   "test_render"
   "test_scene"
+  "test_skinning"
   "test_splats"
   "test_custom_canvas"
   "test_statefile"

--- a/webassembly/testing/test_interactor.js
+++ b/webassembly/testing/test_interactor.js
@@ -97,11 +97,9 @@ const settings = {
       return true;
     });
 
-    interactor.triggerNotification("Test notification", "value", 1.0);
+    // TODO: remove "binding"
+    interactor.triggerNotification("Test notification", "value", "binding", 1.0);
     utils.assert(notifCount === 1, "notification callback not called");
-
-    //TODO: remove. It's there to detect an error in the CI.
-    utils.assert(notifCount === 3, "should assert");
 
     // only for coverage, do not test the actual feature yet
     interactor.disableCameraMovement();

--- a/webassembly/testing/test_interactor.js
+++ b/webassembly/testing/test_interactor.js
@@ -49,20 +49,6 @@ const settings = {
       "animation should not be playing",
     );
 
-    interactor.startAnimation();
-    utils.assert(
-      interactor.isPlayingAnimation() &&
-        interactor.getAnimationDirection() ==
-          Module.InteractorAnimationDirection.FORWARD,
-      "animation should be playing",
-    );
-
-    interactor.stopAnimation();
-    utils.assert(
-      !interactor.isPlayingAnimation(),
-      "animation should not be playing",
-    );
-
     interactor.startAnimation(Module.InteractorAnimationDirection.FORWARD);
     utils.assert(
       interactor.isPlayingAnimation() &&
@@ -71,6 +57,10 @@ const settings = {
       "animation should be playing forward",
     );
     interactor.stopAnimation();
+    utils.assert(
+      !interactor.isPlayingAnimation(),
+      "animation should not be playing",
+    );
 
     interactor.startAnimation(Module.InteractorAnimationDirection.BACKWARD);
     utils.assert(
@@ -78,15 +68,6 @@ const settings = {
         interactor.getAnimationDirection() ==
           Module.InteractorAnimationDirection.BACKWARD,
       "animation should be playing backward",
-    );
-    interactor.stopAnimation();
-
-    interactor.toggleAnimation();
-    utils.assert(
-      interactor.isPlayingAnimation() &&
-        interactor.getAnimationDirection() ==
-          Module.InteractorAnimationDirection.FORWARD,
-      "animation should be playing forward",
     );
     interactor.stopAnimation();
 
@@ -116,13 +97,11 @@ const settings = {
       return true;
     });
 
-    interactor.triggerNotification(
-      "Test notification",
-      "value",
-      "binding",
-      1.0,
-    );
+    interactor.triggerNotification("Test notification", "value", 1.0);
     utils.assert(notifCount === 1, "notification callback not called");
+
+    //TODO: remove. It's there to detect an error in the CI.
+    utils.assert(notifCount === 3, "should assert");
 
     // only for coverage, do not test the actual feature yet
     interactor.disableCameraMovement();

--- a/webassembly/testing/test_interactor.js
+++ b/webassembly/testing/test_interactor.js
@@ -97,8 +97,7 @@ const settings = {
       return true;
     });
 
-    // TODO: remove "binding"
-    interactor.triggerNotification("Test notification", "value", "binding", 1.0);
+    interactor.triggerNotification("Test notification", "value", 1.0);
     utils.assert(notifCount === 1, "notification callback not called");
 
     // only for coverage, do not test the actual feature yet

--- a/webassembly/testing/test_scene.js
+++ b/webassembly/testing/test_scene.js
@@ -48,7 +48,7 @@ const settings = {
     scene.loadAnimationTime(0.5);
 
     utils.assert(
-      scene.getAnimationName() == "stand",
+      scene.getAnimationName(-1) == "stand",
       "getAnimationName returns name",
     );
 

--- a/webassembly/testing/test_skinning.js
+++ b/webassembly/testing/test_skinning.js
@@ -1,0 +1,22 @@
+import utils from "./utils.js";
+
+const settings = {
+  runBefore: (Module) => {
+    const options = Module.engineInstance.getOptions();
+
+    // background must be set to black for proper blending with transparent canvas
+    options.setAsString("render.background.color", "#000000");
+
+    // armature
+    options.toggle("render.armature.enable");
+  },
+
+  runAfter: (Module) => {
+    Module.engineInstance.getScene().loadAnimationTime(0.5);
+  },
+};
+
+utils.runRenderTest(settings, {
+  data: "RiggedFigure.glb",
+  baseline: "TestWasmSkinning.png",
+});


### PR DESCRIPTION
### Describe your changes

Skinning was working on Chromium and Linux (GLES), but I noticed that it failed on Firefox and Android.
It's coming from the lack of 16-bits textures on some GLES implementations.
I fixed that by expanding the joint array to 32-bits indices, which is supported everywhere.

Moreover, when playing the tests locally, I noticed many failures because asserts are only raised when building in Debug mode. I've enabled it in Release mode too. This adds ~100kB only in f3d.js size (f3d.wasm file is the same size).

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [ ] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
