### PR TITLE
Fix/scale HDRI lighting by render.light.intensity

### DIFF
--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -348,8 +348,8 @@ endif()
 f3d_test(NAME TestHDRI DATA suzanne.ply HDRI shanghai_bund_1k.hdr THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
 f3d_test(NAME TestHDRICache DATA suzanne.ply HDRI shanghai_bund_1k.hdr DEPENDS TestHDRI THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
 # HDRI ambient lighting must follow render.light.intensity (see https://github.com/f3d-app/f3d/issues/3312)
-f3d_test(NAME TestHDRILightIntensityZero DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS --light-intensity=0.0 DEPENDS TestHDRI THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
-f3d_test(NAME TestHDRILightIntensityBrighter DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS --light-intensity=5.0 DEPENDS TestHDRI THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
+f3d_test(NAME TestHDRILightIntensityDimmer DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS --light-intensity=0.1 DEPENDS TestHDRI THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
+f3d_test(NAME TestHDRILightIntensityBrighter DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS --light-intensity=2.0 DEPENDS TestHDRI THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
 f3d_test(NAME TestHDRIBlur DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS -u THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
 f3d_test(NAME TestHDRIBlurCoCSmall DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS -u --blur-coc=10 --camera-position=-20,0,20)
 f3d_test(NAME TestHDRIBlurCoCMedium DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS -u --blur-coc=50 --camera-position=-20,0,20)

--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -347,6 +347,9 @@ endif()
 ## HDRI
 f3d_test(NAME TestHDRI DATA suzanne.ply HDRI shanghai_bund_1k.hdr THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
 f3d_test(NAME TestHDRICache DATA suzanne.ply HDRI shanghai_bund_1k.hdr DEPENDS TestHDRI THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
+# HDRI ambient lighting must follow render.light.intensity (see https://github.com/f3d-app/f3d/issues/3312)
+f3d_test(NAME TestHDRILightIntensityZero DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS --light-intensity=0.0 DEPENDS TestHDRI THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
+f3d_test(NAME TestHDRILightIntensityBrighter DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS --light-intensity=5.0 DEPENDS TestHDRI THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
 f3d_test(NAME TestHDRIBlur DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS -u THRESHOLD 0.07) # Small rendering differences on GLES due to LUT precision
 f3d_test(NAME TestHDRIBlurCoCSmall DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS -u --blur-coc=10 --camera-position=-20,0,20)
 f3d_test(NAME TestHDRIBlurCoCMedium DATA suzanne.ply HDRI shanghai_bund_1k.hdr ARGS -u --blur-coc=50 --camera-position=-20,0,20)

--- a/doc/libf3d/03-OPTIONS.md
+++ b/doc/libf3d/03-OPTIONS.md
@@ -440,7 +440,7 @@ CLI: `--blur-coc`.
 
 ### `render.light.intensity` (_double_, default: `1.0`, range domain: `[0, 5]`, increment: `0.02`)
 
-Adjust the intensity of every light in the scene (except HDRI).
+Adjust the intensity of every light in the scene, including HDRI image-based lighting.
 
 CLI: `--light-intensity`.
 

--- a/doc/user/03-OPTIONS.md
+++ b/doc/user/03-OPTIONS.md
@@ -723,7 +723,7 @@ Blur circle of confusion radius.
 
 ### `--light-intensity` (_double_, default: `1.0`)
 
-_Adjust the intensity_ of every light in the scene (except HDRI).
+_Adjust the intensity_ of every light in the scene, including HDRI image-based lighting.
 
 #### compare
 

--- a/testing/baselines/TestHDRILightIntensityBrighter.png
+++ b/testing/baselines/TestHDRILightIntensityBrighter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db6c207cb0f8df3e6f8ede16b9c3d642b35a907d6d420ba5f885b394f01ea0d0
+size 80619

--- a/testing/baselines/TestHDRILightIntensityBrighter.png
+++ b/testing/baselines/TestHDRILightIntensityBrighter.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db6c207cb0f8df3e6f8ede16b9c3d642b35a907d6d420ba5f885b394f01ea0d0
-size 80619
+oid sha256:aa3e2fa34b5c5a09510447889a39d9241c896c49c7ce40cd9ea608a1e72caa83
+size 96589

--- a/testing/baselines/TestHDRILightIntensityDimmer.png
+++ b/testing/baselines/TestHDRILightIntensityDimmer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5f8591dfa62aeee730b4845e76b8a152e043c15b038c74389bd325e8723bedf
+size 101144

--- a/testing/baselines/TestHDRILightIntensityZero.png
+++ b/testing/baselines/TestHDRILightIntensityZero.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18fe90ea10446d6d8205934e050ff1db2c81f628d7cd0f9e75a5f198c5aa7844
+size 80261

--- a/vtkext/private/module/vtkF3DRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DRenderPass.cxx
@@ -634,9 +634,23 @@ bool vtkF3DRenderPass::PreReplaceShaderValues(std::string& vertexShader, std::st
 
 // ----------------------------------------------------------------------------
 bool vtkF3DRenderPass::PostReplaceShaderValues([[maybe_unused]] std::string& vertexShader,
-  std::string&, std::string&, [[maybe_unused]] vtkAbstractMapper* mapper,
+  std::string&, std::string& fragmentShader, [[maybe_unused]] vtkAbstractMapper* mapper,
   [[maybe_unused]] vtkProp* prop)
 {
+  // Scale the HDRI image-based lighting (diffuse + specular) by IBLIntensity so it
+  // follows render.light.intensity just like explicit lights do.
+  // The IBLIntensity uniform is declared automatically via VTK's //VTK::CustomUniforms::Dec
+  // mechanism: vtkF3DRenderer::UpdateLights calls SetUniformf("IBLIntensity", ...) on every
+  // actor each frame so the declaration is always present when the shader is compiled.
+  // This substitution lives here (in the render pass, not the mapper) so it applies to
+  // both the standard OpenGL mapper and the GLES mapper used for web and Android.
+  // see https://github.com/f3d-app/f3d/issues/3312
+  if (fragmentShader.find("iblDiffuse") != std::string::npos)
+  {
+    vtkShaderProgram::Substitute(fragmentShader, "vec3 color = iblDiffuse + iblSpecular;",
+      "vec3 color = (iblDiffuse + iblSpecular) * IBLIntensity;");
+  }
+
 #ifdef F3D_USE_GLES
   vtkPolyDataMapper* polyMapper = vtkPolyDataMapper::SafeDownCast(mapper);
   vtkActor* actor = vtkActor::SafeDownCast(prop);

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -18,6 +18,8 @@
 #include "vtkF3DSolidBackgroundPass.h"
 #include "vtkF3DUserRenderPass.h"
 
+#include <vtkActor.h>
+#include <vtkActorCollection.h>
 #include <vtkAxesActor.h>
 #include <vtkBoundingBox.h>
 #include <vtkCamera.h>
@@ -2368,7 +2370,27 @@ int vtkF3DRenderer::UpdateLights()
 
       light->SetIntensity(originalIntensity * this->LightIntensity);
     }
+
     this->LightIntensitiesConfigured = true;
+  }
+
+  // Push IBLIntensity to every actor's custom uniforms so the HDRI ambient
+  // contribution (iblDiffuse + iblSpecular) scales with the same factor.
+  // This runs every frame (not just when intensity changes) to ensure that newly
+  // added actors always have the uniform set before their shader is compiled.
+  // VTK's //VTK::CustomUniforms::Dec mechanism then declares the uniform in the
+  // GLSL shader source. The actual GPU upload (glUniform1f) is already performed
+  // each frame by VTK's SetCustomUniforms, so this dict update is negligible.
+  // see https://github.com/f3d-app/f3d/issues/3312
+  {
+    vtkActorCollection* actors = this->GetActors();
+    vtkCollectionSimpleIterator ait;
+    vtkActor* actor;
+    for (actors->InitTraversal(ait); (actor = actors->GetNextActor(ait));)
+    {
+      actor->GetShaderProperty()->GetFragmentCustomUniforms()->SetUniformf(
+        "IBLIntensity", static_cast<float>(this->LightIntensity));
+    }
   }
 
   return lightCount;


### PR DESCRIPTION
### Describe your changes
When HDRI ambient lighting is enabled (`-f` / `render.hdri.ambient`), changing `render.light.intensity` (console, `L` / `Shift+L`) only scaled the explicit VTK lights. The HDRI image-based lighting contribution in the PBR shader was left unchanged, so at intensity `0` the model could still look lit by the HDRI.

This PR scales the IBL diffuse + specular terms by the same factor. The shader substitution is done in `vtkF3DRenderPass::PostReplaceShaderValues`. The `IBLIntensity` uniform is declared via VTK's `//VTK::CustomUniforms::Dec` mechanism and is pushed to every actor in `vtkF3DRenderer::UpdateLights` each frame, so newly added actors always have it before their shader is compiled.

**Tests**: Added `TestHDRILightIntensityZero` (`--light-intensity=0.0`) and `TestHDRILightIntensityBrighter` (`--light-intensity=5.0`), using the same `suzanne.ply` + `shanghai_bund_1k.hdr` setup as `TestHDRI`, with `DEPENDS TestHDRI` and threshold `0.07`.

### Before (`master`, bug)

| render.light.intensity 0 | render.light.intensity 1 |
| --- | --- |
| <img width="570" height="455" alt="before-light-intensity-0" src="https://github.com/user-attachments/assets/ba5079d5-d499-48a1-8111-c8e565942891" /> | <img width="568" height="454" alt="before-light-intensity-1" src="https://github.com/user-attachments/assets/9363942f-6a33-4652-a781-74bbd27be535" /> |

At intensity `0` the figure is still lit by the HDRI.

### After (this branch, fixed)

| render.light.intensity 0 | render.light.intensity 1 | render.light.intensity 5 |
| --- | --- | --- |
| <img width="528" height="402" alt="after-light-intensity-0" src="https://github.com/user-attachments/assets/19ab59cf-9e21-4586-8641-14b06330c05a" /> | <img width="526" height="403" alt="after-light-intensity-1" src="https://github.com/user-attachments/assets/acf62094-8163-4df7-b756-a82203f26169" />| <img width="528" height="404" alt="after-light-intensity-5" src="https://github.com/user-attachments/assets/ca7de2eb-5b56-4600-b5e8-b2f0400187fc" /> |

At intensity `0` the figure is black. At `1` it matches the previous default.
At `5` it is clearly brighter.

### How to test

```bash
./bin/f3d --no-config testing/data/RiggedFigure.glb \
  --hdri-file=testing/data/shanghai_bund_1k.hdr -f
```
open console(`Esc`):
```bash
set render.light.intensity 0
set render.light.intensity 1
set render.light.intensity 5
```
With the console closed, L / Shift+L also change HDRI lighting live (same as explicit lights). You can confirm the value with:
```bash
print render.light.intensity
```

### Issue ticket number and link if any
Fixes: #3312 

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [ ] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
