### PR TITLE
Support for multiple arrays per texture

### DIFF
--- a/vtkext/private/module/vtkF3DRenderPass.cxx
+++ b/vtkext/private/module/vtkF3DRenderPass.cxx
@@ -166,14 +166,25 @@ void vtkF3DRenderPass::Initialize(const vtkRenderState* s)
                   break;
                 }
 
+#ifdef F3D_USE_GLES
+                // with GLES, we append all morphing targets into a single texture
+                polyMapper->MapDataArrayToVertexAttribute(
+                  "target_position", namePosition.c_str(), vtkDataObject::FIELD_ASSOCIATION_POINTS);
+#else
                 polyMapper->MapDataArrayToVertexAttribute(namePosition.c_str(),
                   namePosition.c_str(), vtkDataObject::FIELD_ASSOCIATION_POINTS);
+#endif
 
                 std::string nameNormal = "target" + std::to_string(j) + "_normal";
                 if (input->GetPointData()->GetArray(nameNormal.c_str()) != nullptr)
                 {
+#ifdef F3D_USE_GLES
+                  polyMapper->MapDataArrayToVertexAttribute(
+                    "target_normal", nameNormal.c_str(), vtkDataObject::FIELD_ASSOCIATION_POINTS);
+#else
                   polyMapper->MapDataArrayToVertexAttribute(nameNormal.c_str(), nameNormal.c_str(),
                     vtkDataObject::FIELD_ASSOCIATION_POINTS);
+#endif
                 }
               }
             }
@@ -460,6 +471,11 @@ void vtkF3DRenderPass::ReplaceSkinningMorphing(
       // morphing
       if (hasMorphing)
       {
+#ifdef F3D_USE_GLES
+        customDecl += "uniform sampler2D target_position;\n";
+        customDecl += "uniform sampler2D target_normal;\n";
+#endif
+
         for (int i = 0; i < 4; i++)
         {
           std::string name = "target" + std::to_string(i) + "_position";
@@ -468,15 +484,11 @@ void vtkF3DRenderPass::ReplaceSkinningMorphing(
           if (polyData->GetPointData()->GetArray(name.c_str()) != nullptr)
           {
 #ifdef F3D_USE_GLES
-            customDecl += "uniform sampler2D ";
-            customDecl += name;
-            customDecl += ";\n";
-
             posImpl += " posMC += morphWeights[";
             posImpl += std::to_string(i);
-            posImpl += "] * vec4(texelFetchBuffer(";
-            posImpl += name;
-            posImpl += ", pointId).xyz, 0);\n";
+            posImpl += "] * vec4(texelFetchBuffer(target_position, ";
+            posImpl += std::to_string(i);
+            posImpl += " * pointCount + pointId).xyz, 0);\n";
 #else
             customDecl += "in vec3 ";
             customDecl += name;
@@ -496,17 +508,13 @@ void vtkF3DRenderPass::ReplaceSkinningMorphing(
           if (polyData->GetPointData()->GetArray(name.c_str()) != nullptr)
           {
 #ifdef F3D_USE_GLES
-            customDecl += "uniform sampler2D ";
-            customDecl += name;
-            customDecl += ";\n";
-
             if (hasNormals)
             {
               normalImpl += " normalVCVSOutput += morphWeights[";
               normalImpl += std::to_string(i);
-              normalImpl += "] * texelFetchBuffer(";
-              normalImpl += name;
-              normalImpl += ", pointId).xyz;\n";
+              normalImpl += "] * texelFetchBuffer(target_normal, ";
+              normalImpl += std::to_string(i);
+              normalImpl += " * pointCount + pointId).xyz;\n";
             }
 #else
             customDecl += "in vec3 ";
@@ -695,7 +703,8 @@ bool vtkF3DRenderPass::PostReplaceShaderValues([[maybe_unused]] std::string& ver
           }
 
           replacementLines += "  p" + index + "MC += morphWeights[" + std::to_string(j) +
-            "] * vec4(texelFetchBuffer(" + namePosition + ", p" + index + ").xyz, 0);\n";
+            "] * vec4(texelFetchBuffer(target_position, " + std::to_string(j) +
+            " * pointCount + p" + index + ").xyz, 0);\n";
         }
       }
 


### PR DESCRIPTION
### Describe your changes

Reduce the number of used texture in the GLES mapper by appending morph targets to the same texture.  
This fixes the crash of `dota` model on Android.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [ ] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
