### PR TITLE
add grid opacity option

### DIFF
--- a/application/F3DOptionsTools.h
+++ b/application/F3DOptionsTools.h
@@ -116,6 +116,7 @@ static inline const std::map<std::string_view, std::string_view> LibOptionsNames
   { "grid", "render.grid.enable" },
   { "grid-absolute", "render.grid.absolute" },
   { "grid-color", "render.grid.color" },
+  { "grid-opacity", "render.grid.opacity" },
   { "grid-reflection", "render.grid.reflection" },
   { "grid-subdivisions", "render.grid.subdivisions" },
   { "grid-unit", "render.grid.unit" },

--- a/application/testing/tests.documentation.cmake
+++ b/application/testing/tests.documentation.cmake
@@ -143,6 +143,7 @@ f3d_test_doc(NAME TestDocGridColorCyan DATA DamagedHelmet.glb REF_IMAGE grid_col
 ## --grid-reflection
 f3d_test_doc(NAME TestDocGridReflectionOFF DATA DamagedHelmet.glb REF_IMAGE grid_reflection_off.png ROTATE ARGS -gf)
 f3d_test_doc(NAME TestDocGridReflectionON DATA DamagedHelmet.glb REF_IMAGE grid_reflection_on.png ROTATE ARGS -gf --grid-reflection=0.5)
+f3d_test_doc(NAME TestDocGridReflectionNoLines DATA DamagedHelmet.glb REF_IMAGE grid_reflection_no_lines.png ROTATE ARGS -gf --grid-reflection=0.5 --grid-opacity=0)
 
 ## --grid-absolute
 f3d_test_doc(NAME TestDocGridAbsoluteOFF DATA DamagedHelmet.glb REF_IMAGE grid_absolute_off.png ROTATE ARGS -gf)

--- a/application/testing/tests.features.cmake
+++ b/application/testing/tests.features.cmake
@@ -15,7 +15,9 @@ f3d_test(NAME TestGridColor DATA suzanne.ply ARGS -g --grid-color=1,1,1)
 f3d_test(NAME TestGridWithDepthPeeling DATA suzanne.ply ARGS -gp --opacity=0.2)
 f3d_test(NAME TestGridReflection DATA suzanne.ply ARGS -g --grid-reflection=0.8)
 f3d_test(NAME TestGridAbsoluteReflection DATA suzanne.ply ARGS -g --grid-absolute --grid-reflection=0.8 --camera-elevation-angle=40)
+f3d_test(NAME TestGridOpacity DATA suzanne.ply ARGS -g --grid-opacity=.25 --anti-aliasing=ssaa)
 f3d_test(NAME TestGridSSAAReflection DATA suzanne.ply ARGS -g --grid-reflection=0.8 --anti-aliasing=ssaa)
+f3d_test(NAME TestGridReflectionOnly DATA suzanne.ply ARGS -g --grid-reflection=0.5 --grid-opacity=0 --anti-aliasing=ssaa)
 
 # Backface
 f3d_test(NAME TestBackfaceVisible DATA backface.vtp ARGS --backface-type=visible)

--- a/doc/libf3d/03-OPTIONS.md
+++ b/doc/libf3d/03-OPTIONS.md
@@ -364,6 +364,12 @@ Set the color of grid lines.
 
 CLI: `--grid-color`.
 
+### `render.grid.opacity` (_ratio_, default: `1.0`)
+
+Set the opacity for the grid lines. Can be set to `0` to show reflection only.
+
+CLI: `--grid-opacity`.
+
 ### `render.grid.reflection` (_ratio_, default: `0.0`)
 
 Set the reflection strength on the grid.

--- a/doc/user/03-OPTIONS.md
+++ b/doc/user/03-OPTIONS.md
@@ -223,6 +223,16 @@ Set the color grid lines.
 | ------------------------------------ | --------------------------------- |
 | ![](./images/grid_color_default.png) | ![](./images/grid_color_cyan.png) |
 
+### `--grid-opacity=<opacity>` (_double_, default: `1`)
+
+Set the opacity for grid lines. Can be set to `0` to show reflection only.
+
+#### compare
+
+| 100% (default)                       | 0%                                         |
+| ------------------------------------ | ------------------------------------------ |
+| ![](./images/grid_reflection_on.png) | ![](./images/grid_reflection_no_lines.png) |
+
 ### `--grid-reflection=<strength>` (_double_, default: `0`)
 
 Set the reflection strength on the grid.

--- a/doc/user/images/grid_reflection_no_lines.png
+++ b/doc/user/images/grid_reflection_no_lines.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be8c795a2bdb29d74cf1061cc4eabf9fff55ab25067bceb0c71fd99c3186e80c
+size 256747

--- a/library/options.json
+++ b/library/options.json
@@ -93,6 +93,10 @@
         "type": "color",
         "default_value": "0.0, 0.0, 0.0"
       },
+      "opacity": {
+        "type": "ratio",
+        "default_value": "1.0"
+      },
       "reflection": {
         "type": "ratio",
         "default_value": "0.0"

--- a/library/src/window_impl.cxx
+++ b/library/src/window_impl.cxx
@@ -703,6 +703,7 @@ void window_impl::UpdateDynamicOptions()
   renderer->SetGridUnitSquare(opt.render.grid.unit);
   renderer->SetGridSubdivisions(opt.render.grid.subdivisions);
   renderer->SetGridAbsolute(opt.render.grid.absolute);
+  renderer->SetGridOpacity(opt.render.grid.opacity);
   renderer->SetGridReflection(opt.render.grid.reflection);
   renderer->ShowGrid(opt.render.grid.enable);
   renderer->SetGridColor(opt.render.grid.color);

--- a/resources/cli-options.json
+++ b/resources/cli-options.json
@@ -238,6 +238,11 @@
           "valueHelper": "<color>"
         },
         {
+          "longName": "grid-opacity",
+          "helpText": "Opacity of the grid lines",
+          "valueHelper": "<value>"
+        },
+        {
           "longName": "grid-reflection",
           "helpText": "Reflection strength of the grid",
           "valueHelper": "<value>"

--- a/testing/baselines/TestGridOpacity.png
+++ b/testing/baselines/TestGridOpacity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42697d7905b0f566d57ceb2208aab74f7c7a9771214f81a2c3a0ecc18ac38582
+size 29096

--- a/testing/baselines/TestGridReflectionOnly.png
+++ b/testing/baselines/TestGridReflectionOnly.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7807990f6dac1a81802fbef5c1406bcbda36c7e6e94ff3a04741cc1e4a0a0b3
+size 27837

--- a/vtkext/private/module/vtkF3DOpenGLGridMapper.cxx
+++ b/vtkext/private/module/vtkF3DOpenGLGridMapper.cxx
@@ -68,6 +68,7 @@ void vtkF3DOpenGLGridMapper::ReplaceShaderValues(
     "in vec3 normalVC;\n"
     "uniform vec2 gridOffset;\n"
     "uniform vec2 pixelSize;\n"
+    "uniform float lineOpacity;\n"
     "//VTK::Reflection::Dec\n"
 
     "float antialias(float dist, float linewidth){\n"
@@ -101,12 +102,12 @@ void vtkF3DOpenGLGridMapper::ReplaceShaderValues(
     "  float majorAlpha = antialias(min(majorGrid.x, majorGrid.y), gridLineWidth);\n"
     "  float minorAlpha = antialias(min(minorGrid.x, minorGrid.y), gridLineWidth);\n"
     "  float zoomFadeFactor = 1.0 - clamp(fwidth(majorCoord.x / unitSquare * fadeDist), 0.0, 1.0);\n"
-    "  float alpha = max(majorAlpha, minorAlpha * minorOpacity * zoomFadeFactor);\n"
+    "  float alpha = max(majorAlpha, minorAlpha * minorOpacity * zoomFadeFactor) * lineOpacity;\n"
 
     "  vec4 color = vec4(diffuseColorUniform, alpha);\n"
 
-    "  float axis1Weight = abs(majorCoord.y) < 0.5 ? antialias(majorGrid.y, axesLineWidth) : 0.0;\n"
-    "  float axis2Weight = abs(majorCoord.x) < 0.5 ? antialias(majorGrid.x, axesLineWidth) : 0.0;\n"
+    "  float axis1Weight = abs(majorCoord.y) < 0.5 ? antialias(majorGrid.y, axesLineWidth) * lineOpacity : 0.0;\n"
+    "  float axis2Weight = abs(majorCoord.x) < 0.5 ? antialias(majorGrid.x, axesLineWidth) * lineOpacity : 0.0;\n"
     "  color = mix(color, axis2Color, axis2Weight);\n"
     "  color = mix(color, axis1Color, axis1Weight);\n"
     "  //VTK::Reflection::Impl\n"
@@ -204,6 +205,7 @@ void vtkF3DOpenGLGridMapper::SetMapperShaderParameters(
   cellBO.Program->SetUniformf("lineAntialias", scaling);
   cellBO.Program->SetUniform4f("axis1Color", this->Axis1Color);
   cellBO.Program->SetUniform4f("axis2Color", this->Axis2Color);
+  cellBO.Program->SetUniformf("lineOpacity", this->LineOpacity);
 
   if (this->ReflectionStrength > 0.0)
   {

--- a/vtkext/private/module/vtkF3DOpenGLGridMapper.h
+++ b/vtkext/private/module/vtkF3DOpenGLGridMapper.h
@@ -49,6 +49,10 @@ public:
   vtkSetVector4Macro(Axis2Color, float);
 
   /**
+   * Set the opacity of the lines
+   */
+  vtkSetMacro(LineOpacity, float);
+  /**
    * Set the strength of the reflection
    */
   vtkSetMacro(ReflectionStrength, float);
@@ -89,6 +93,7 @@ protected:
   int Subdivisions = 10;
   float Axis1Color[4] = { 0.0, 0.0, 0.0, 1.0 };
   float Axis2Color[4] = { 0.0, 0.0, 0.0, 1.0 };
+  float LineOpacity = 1.0f;
   float ReflectionStrength = 0.0f;
   bool ShaderBuiltWithReflection = false;
   vtkSmartPointer<vtkTextureObject> ReflectionColorTexture;

--- a/vtkext/private/module/vtkF3DRenderer.cxx
+++ b/vtkext/private/module/vtkF3DRenderer.cxx
@@ -765,6 +765,17 @@ void vtkF3DRenderer::SetGridColor(const std::vector<double>& color)
 }
 
 //----------------------------------------------------------------------------
+void vtkF3DRenderer::SetGridOpacity(const double opacity)
+{
+  if (this->GridOpacity != opacity)
+  {
+    this->GridOpacity = opacity;
+    this->GridConfigured = false;
+    this->RenderPassesConfigured = false;
+  }
+}
+
+//----------------------------------------------------------------------------
 void vtkF3DRenderer::SetGridReflection(const double strength)
 {
   if (this->GridReflection != strength)
@@ -883,6 +894,7 @@ void vtkF3DRenderer::ConfigureGridUsingCurrentActors()
       this->GridMapper->SetFadeDistance(diag);
       this->GridMapper->SetUnitSquare(tmpUnitSquare);
       this->GridMapper->SetSubdivisions(this->GridSubdivisions);
+      this->GridMapper->SetLineOpacity(this->GridOpacity);
       this->GridMapper->SetReflectionStrength(this->GridReflection);
 
       if (this->GridAbsolute)

--- a/vtkext/private/module/vtkF3DRenderer.h
+++ b/vtkext/private/module/vtkF3DRenderer.h
@@ -130,6 +130,7 @@ public:
   void SetGridUnitSquare(const std::optional<double>& unitSquare);
   void SetGridSubdivisions(int subdivisions);
   void SetGridColor(const std::vector<double>& color);
+  void SetGridOpacity(const double strength);
   void SetGridReflection(const double strength);
   void SetAxesColor(const std::vector<double>& colorXAxis, const std::vector<double>& colorYAxis,
     const std::vector<double>& colorZAxis);
@@ -819,6 +820,7 @@ private:
   std::optional<double> GridUnitSquare;
   int GridSubdivisions = 10;
   double GridColor[3] = { 0.0, 0.0, 0.0 };
+  double GridOpacity = 1.0;
   double GridReflection = 0.0;
 
   double ColorAxisX[3] = { 0.0, 0.0, 0.0 };


### PR DESCRIPTION
### Describe your changes

Add an option to change the line opacity on the grid. Can be set to `0` to show reflections only.

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [x] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [ ] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:


### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
