### PR TITLE
Install pkg-config files for libf3d and libf3d_c_api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib${output_postfix}")
 
 project(F3D
   DESCRIPTION "F3D - A fast and minimalist 3D viewer"
+  HOMEPAGE_URL "https://f3d.app"
   LANGUAGES C CXX)
 
 set(f3d_cmake_dir "${F3D_SOURCE_DIR}/cmake")

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -108,4 +108,13 @@ if (BUILD_SHARED_LIBS)
     DESTINATION
     "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
     COMPONENT sdk EXCLUDE_FROM_ALL)
+
+  # pkg-config
+  configure_file(
+    "${F3D_SOURCE_DIR}/cmake/f3d_c_api.pc.in"
+    "${CMAKE_BINARY_DIR}/cmake/f3d_c_api.pc"
+    @ONLY)
+  install(FILES "${CMAKE_BINARY_DIR}/cmake/f3d_c_api.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    COMPONENT sdk EXCLUDE_FROM_ALL)
 endif ()

--- a/cmake/f3d.pc.in
+++ b/cmake/f3d.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: f3d
+Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @F3D_VERSION@
+Libs: -L${libdir} -lf3d
+Cflags: -I${includedir}

--- a/cmake/f3d_c_api.pc.in
+++ b/cmake/f3d_c_api.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: f3d_c_api
+Description: C bindings for @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @F3D_VERSION@
+Requires.private: f3d
+Libs: -L${libdir} -lf3d_c_api
+Cflags: -I${includedir}

--- a/doc/dev/05-BUILD.md
+++ b/doc/dev/05-BUILD.md
@@ -161,7 +161,7 @@ Here is the list of all the components:
 | `library`       | YES                  | ALL              | libf3d library binaries.                                                                                                    |
 | `plugin`        | YES                  | ALL              | libf3d plugins.                                                                                                             |
 | `dependencies`  | NO                   | ALL              | libf3d runtime dependencies. Can be used to create a self-contained and relocatable package. System libraries are excluded. |
-| `sdk`           | NO                   | ALL              | libf3d SDK (headers and CMake config files) for `library` and `application` find_package components.                        |
+| `sdk`           | NO                   | ALL              | libf3d SDK (headers, CMake config files and pkg-config files) for `library` and `application` find_package components.      |
 | `plugin_sdk`    | NO                   | ALL              | libf3d plugin SDK (headers and CMake config files including macros) for `pluginsdk` find_package components.                |
 | `licenses`      | YES                  | ALL              | F3D and third party licenses.                                                                                               |
 | `documentation` | YES                  | Linux            | `man` documentation.                                                                                                        |

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -314,6 +314,16 @@ if(BUILD_SHARED_LIBS)
     COMPONENT sdk
     EXCLUDE_FROM_ALL)
 
+  # Install a pkg-config file for libf3d
+  configure_file(
+    "${F3D_SOURCE_DIR}/cmake/f3d.pc.in"
+    "${CMAKE_BINARY_DIR}/cmake/f3d.pc"
+    @ONLY)
+  install(FILES "${CMAKE_BINARY_DIR}/cmake/f3d.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    COMPONENT sdk
+    EXCLUDE_FROM_ALL)
+
   # Install plugin headers
   install(FILES ${F3D_PLUGIN_HEADERS}
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/f3d"


### PR DESCRIPTION
Closes #3432

## What

Adds `.pc` pkg-config files for `libf3d` (module name `f3d`) and `libf3d_c_api` (module name `f3d_c_api`), installed to `${CMAKE_INSTALL_LIBDIR}/pkgconfig` when `BUILD_SHARED_LIBS` is on, as part of the existing `sdk` install component.

- `cmake/f3d.pc.in` / `cmake/f3d_c_api.pc.in`: new templates, configured via `configure_file(... @ONLY)`.
- `library/CMakeLists.txt`, `c/CMakeLists.txt`: install the generated `.pc` files next to the existing CMake config file installs.
- `CMakeLists.txt`: added `HOMEPAGE_URL` to the top-level `project()` call so it can be reused as the `.pc` `URL:` field via `PROJECT_HOMEPAGE_URL`.
- `doc/dev/05-BUILD.md`: mention pkg-config files in the `sdk` component description.

`f3d_c_api.pc` marks its dependency on `libf3d` as `Requires.private`, matching the `PRIVATE` link between the two targets.

## Testing

Validated the rendered `.pc` output against real `pkg-config` (`pkg-config --validate`, `pkg-config --cflags --libs`) with a standalone CMake project exercising the same `configure_file()` call. Have not done a full F3D build (VTK not available in my environment); the rest of the CMake configure was verified to parse cleanly up to the VTK `find_package` call.

## AI disclosure (per AI_POLICY.md)

Used Claude (Anthropic, Claude Sonnet 5, via Claude Code) to help write the `.pc.in` templates and the CMake `configure_file()`/`install()` wiring in `library/CMakeLists.txt` and `c/CMakeLists.txt`, and the `HOMEPAGE_URL` addition in the top-level `CMakeLists.txt`. I reviewed and understand the changes and am happy to answer questions about any part of it.

## Checklist

- [ ] \ci fast
- [ ] \ci extended