### PR TITLE
RAII helpers for JNI strings and local refs

### DIFF
--- a/java/F3DCameraBindings.cxx
+++ b/java/F3DCameraBindings.cxx
@@ -67,16 +67,19 @@ extern "C"
 
   JNIEXPORT jobject JAVA_BIND(Camera, setState)(JNIEnv* env, jobject self, jobject state)
   {
-    jclass stateClass = env->GetObjectClass(state);
+    JniLocalRef<jclass> stateClass(env, env->GetObjectClass(state));
 
     jfieldID positionField = env->GetFieldID(stateClass, "position", "[D");
     jfieldID focalPointField = env->GetFieldID(stateClass, "focalPoint", "[D");
     jfieldID viewUpField = env->GetFieldID(stateClass, "viewUp", "[D");
     jfieldID viewAngleField = env->GetFieldID(stateClass, "viewAngle", "D");
 
-    jdoubleArray posArray = static_cast<jdoubleArray>(env->GetObjectField(state, positionField));
-    jdoubleArray focArray = static_cast<jdoubleArray>(env->GetObjectField(state, focalPointField));
-    jdoubleArray upArray = static_cast<jdoubleArray>(env->GetObjectField(state, viewUpField));
+    JniLocalRef<jdoubleArray> posArray(
+      env, static_cast<jdoubleArray>(env->GetObjectField(state, positionField)));
+    JniLocalRef<jdoubleArray> focArray(
+      env, static_cast<jdoubleArray>(env->GetObjectField(state, focalPointField)));
+    JniLocalRef<jdoubleArray> upArray(
+      env, static_cast<jdoubleArray>(env->GetObjectField(state, viewUpField)));
     jdouble angle = env->GetDoubleField(state, viewAngleField);
 
     double* pos = env->GetDoubleArrayElements(posArray, nullptr);
@@ -102,8 +105,10 @@ extern "C"
   {
     f3d::camera_state_t cppState = GetEngine(env, self)->getWindow().getCamera().getState();
 
-    jclass stateClass = env->FindClass("app/f3d/F3D/Camera$CameraState");
+    JniLocalRef<jclass> stateClass(env, env->FindClass("app/f3d/F3D/Camera$CameraState"));
     jmethodID constructor = env->GetMethodID(stateClass, "<init>", "()V");
+    // Not wrapped in JniLocalRef: this is the return value, and its local reference
+    // must remain valid until it crosses back into the JVM after this function returns.
     jobject state = env->NewObject(stateClass, constructor);
 
     jfieldID positionField = env->GetFieldID(stateClass, "position", "[D");
@@ -111,9 +116,9 @@ extern "C"
     jfieldID viewUpField = env->GetFieldID(stateClass, "viewUp", "[D");
     jfieldID viewAngleField = env->GetFieldID(stateClass, "viewAngle", "D");
 
-    jdoubleArray posArray = env->NewDoubleArray(3);
-    jdoubleArray focArray = env->NewDoubleArray(3);
-    jdoubleArray upArray = env->NewDoubleArray(3);
+    JniLocalRef<jdoubleArray> posArray(env, env->NewDoubleArray(3));
+    JniLocalRef<jdoubleArray> focArray(env, env->NewDoubleArray(3));
+    JniLocalRef<jdoubleArray> upArray(env, env->NewDoubleArray(3));
 
     env->SetDoubleArrayRegion(posArray, 0, 3, cppState.position.data());
     env->SetDoubleArrayRegion(focArray, 0, 3, cppState.focalPoint.data());

--- a/java/F3DContextBindings.cxx
+++ b/java/F3DContextBindings.cxx
@@ -103,14 +103,14 @@ extern "C"
 
   JNIEXPORT jlong JAVA_BIND(Context, getSymbol)(JNIEnv* env, jclass, jstring lib, jstring func)
   {
-    const char* libStr = env->GetStringUTFChars(lib, nullptr);
-    const char* funcStr = env->GetStringUTFChars(func, nullptr);
+    JniUTFString libStr(env, lib);
+    JniUTFString funcStr(env, func);
 
     jlong result = 0;
     try
     {
-      result =
-        reinterpret_cast<jlong>(new f3d_java_context(f3d::context::getSymbol(libStr, funcStr)));
+      result = reinterpret_cast<jlong>(
+        new f3d_java_context(f3d::context::getSymbol(libStr.c_str(), funcStr.c_str())));
     }
     catch (const f3d::context::loading_exception& e)
     {
@@ -120,8 +120,6 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Context$SymbolException", e.what());
     }
-    env->ReleaseStringUTFChars(lib, libStr);
-    env->ReleaseStringUTFChars(func, funcStr);
     return result;
   }
 

--- a/java/F3DEngineBindings.cxx
+++ b/java/F3DEngineBindings.cxx
@@ -161,15 +161,14 @@ extern "C"
 
     jobject globalRef = env->NewGlobalRef(getProcAddress);
 
-    jclass contextFunctionClass = env->GetObjectClass(getProcAddress);
+    JniLocalRef<jclass> contextFunctionClass(env, env->GetObjectClass(getProcAddress));
     jmethodID methodID =
       env->GetMethodID(contextFunctionClass, "getProcAddress", "(Ljava/lang/String;)J");
 
     f3d::context::function func = [env, globalRef, methodID](const char* name) -> f3d::context::fptr
     {
-      jstring jname = env->NewStringUTF(name);
-      jlong addr = env->CallLongMethod(globalRef, methodID, jname);
-      env->DeleteLocalRef(jname);
+      JniLocalRef<jstring> jname(env, env->NewStringUTF(name));
+      jlong addr = env->CallLongMethod(globalRef, methodID, jname.get());
       return reinterpret_cast<f3d::context::fptr>(addr);
     };
 
@@ -320,16 +319,15 @@ extern "C"
 
   JNIEXPORT void JAVA_BIND(Engine, loadPlugin)(JNIEnv* env, jclass, jstring str)
   {
-    const char* plugin = env->GetStringUTFChars(str, nullptr);
+    JniUTFString plugin(env, str);
     try
     {
-      f3d::engine::loadPlugin(plugin);
+      f3d::engine::loadPlugin(plugin.c_str());
     }
     catch (const f3d::engine::plugin_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Engine$PluginException", e.what());
     }
-    env->ReleaseStringUTFChars(str, plugin);
   }
 
   JNIEXPORT void JAVA_BIND(Engine, autoloadPlugins)(JNIEnv*, jclass)
@@ -339,16 +337,15 @@ extern "C"
 
   JNIEXPORT void JAVA_BIND(Engine, setCachePath)(JNIEnv* env, jobject self, jstring path)
   {
-    const char* str = env->GetStringUTFChars(path, nullptr);
+    JniUTFString str(env, path);
     try
     {
-      GetEngine(env, self)->setCachePath(fs::path(str));
+      GetEngine(env, self)->setCachePath(fs::path(str.c_str()));
     }
     catch (const f3d::engine::cache_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Engine$CacheException", e.what());
     }
-    env->ReleaseStringUTFChars(path, str);
   }
 
   JNIEXPORT jstring JAVA_BIND(Engine, getCachePath)(JNIEnv* env, jobject self)
@@ -364,7 +361,7 @@ extern "C"
     }
     catch (const f3d::engine::statefile_exception& e)
     {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+      F3DThrowJavaException(env, "java/lang/RuntimeException", e.what());
       return 0;
     }
   }
@@ -377,45 +374,44 @@ extern "C"
     }
     catch (const f3d::engine::statefile_exception& e)
     {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+      F3DThrowJavaException(env, "java/lang/RuntimeException", e.what());
     }
     catch (const f3d::scene::load_failure_exception& e)
     {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+      F3DThrowJavaException(env, "java/lang/RuntimeException", e.what());
     }
   }
 
   JNIEXPORT jlong JAVA_SCOPED_BIND(Engine, State, nativeFromString)(
     JNIEnv* env, jclass, jstring content)
   {
-    const char* str = env->GetStringUTFChars(content, nullptr);
+    JniUTFString str(env, content);
     jlong ptr = 0;
     try
     {
-      ptr = reinterpret_cast<jlong>(new f3d::engine::state(f3d::engine::state::fromString(str)));
+      ptr = reinterpret_cast<jlong>(
+        new f3d::engine::state(f3d::engine::state::fromString(str.c_str())));
     }
     catch (const f3d::engine::statefile_exception& e)
     {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+      F3DThrowJavaException(env, "java/lang/RuntimeException", e.what());
     }
-    env->ReleaseStringUTFChars(content, str);
     return ptr;
   }
 
   JNIEXPORT jlong JAVA_SCOPED_BIND(Engine, State, nativeFromFile)(JNIEnv* env, jclass, jstring path)
   {
-    const char* str = env->GetStringUTFChars(path, nullptr);
+    JniUTFString str(env, path);
     jlong ptr = 0;
     try
     {
       ptr = reinterpret_cast<jlong>(
-        new f3d::engine::state(f3d::engine::state::fromFile(fs::path(str))));
+        new f3d::engine::state(f3d::engine::state::fromFile(fs::path(str.c_str()))));
     }
     catch (const f3d::engine::statefile_exception& e)
     {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+      F3DThrowJavaException(env, "java/lang/RuntimeException", e.what());
     }
-    env->ReleaseStringUTFChars(path, str);
     return ptr;
   }
 
@@ -427,7 +423,7 @@ extern "C"
     }
     catch (const f3d::engine::statefile_exception& e)
     {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+      F3DThrowJavaException(env, "java/lang/RuntimeException", e.what());
       return 0;
     }
   }
@@ -439,16 +435,15 @@ extern "C"
 
   JNIEXPORT void JAVA_SCOPED_BIND(Engine, State, toFile)(JNIEnv* env, jobject self, jstring path)
   {
-    const char* str = env->GetStringUTFChars(path, nullptr);
+    JniUTFString str(env, path);
     try
     {
-      GetState(env, self)->toFile(fs::path(str));
+      GetState(env, self)->toFile(fs::path(str.c_str()));
     }
     catch (const f3d::engine::statefile_exception& e)
     {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+      F3DThrowJavaException(env, "java/lang/RuntimeException", e.what());
     }
-    env->ReleaseStringUTFChars(path, str);
   }
 
   JNIEXPORT void JAVA_SCOPED_BIND(Engine, State, toClipboard)(JNIEnv* env, jobject self)
@@ -459,7 +454,7 @@ extern "C"
     }
     catch (const f3d::engine::statefile_exception& e)
     {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+      F3DThrowJavaException(env, "java/lang/RuntimeException", e.what());
     }
   }
 
@@ -470,7 +465,7 @@ extern "C"
 
   JNIEXPORT void JAVA_BIND(Engine, setOptions)(JNIEnv* env, jobject self, jobject options)
   {
-    jclass optionsClass = env->GetObjectClass(options);
+    JniLocalRef<jclass> optionsClass(env, env->GetObjectClass(options));
     jfieldID fid = env->GetFieldID(optionsClass, "mNativeAddress", "J");
     jlong optionsPtr = env->GetLongField(options, fid);
 
@@ -483,7 +478,7 @@ extern "C"
     {
       f3d::interactor& interactor = GetEngine(env, self)->getInteractor();
 
-      jclass interactorClass = env->FindClass("app/f3d/F3D/Interactor");
+      JniLocalRef<jclass> interactorClass(env, env->FindClass("app/f3d/F3D/Interactor"));
       jmethodID constructor = env->GetMethodID(interactorClass, "<init>", "(J)V");
 
       return env->NewObject(interactorClass, constructor, reinterpret_cast<jlong>(&interactor));
@@ -497,9 +492,8 @@ extern "C"
 
   JNIEXPORT jobject JAVA_BIND(Engine, getPluginsList)(JNIEnv* env, jclass, jstring path)
   {
-    const char* str = env->GetStringUTFChars(path, nullptr);
-    std::vector<std::string> plugins = f3d::engine::getPluginsList(fs::path(str));
-    env->ReleaseStringUTFChars(path, str);
+    JniUTFString str(env, path);
+    std::vector<std::string> plugins = f3d::engine::getPluginsList(fs::path(str.c_str()));
 
     return CreateStringList(env, plugins);
   }
@@ -508,33 +502,24 @@ extern "C"
   {
     const f3d::engine::libInformation& info = f3d::engine::getLibInfo();
 
-    jclass libInfoClass = env->FindClass("app/f3d/F3D/Engine$LibInfo");
+    JniLocalRef<jclass> libInfoClass(env, env->FindClass("app/f3d/F3D/Engine$LibInfo"));
     jmethodID constructor = env->GetMethodID(libInfoClass, "<init>",
       "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;"
       "Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V");
 
-    jstring version = env->NewStringUTF(info.Version.c_str());
-    jstring versionFull = env->NewStringUTF(info.VersionFull.c_str());
-    jstring buildDate = env->NewStringUTF(info.BuildDate.c_str());
-    jstring buildSystem = env->NewStringUTF(info.BuildSystem.c_str());
-    jstring compiler = env->NewStringUTF(info.Compiler.c_str());
-    jobject modules = CreateStringBooleanMap(env, info.Modules);
-    jstring vtkVersion = env->NewStringUTF(info.VTKVersion.c_str());
-    jobject copyrights = CreateStringList(env, info.Copyrights);
-    jstring license = env->NewStringUTF(info.License.c_str());
+    JniLocalRef<jstring> version(env, env->NewStringUTF(info.Version.c_str()));
+    JniLocalRef<jstring> versionFull(env, env->NewStringUTF(info.VersionFull.c_str()));
+    JniLocalRef<jstring> buildDate(env, env->NewStringUTF(info.BuildDate.c_str()));
+    JniLocalRef<jstring> buildSystem(env, env->NewStringUTF(info.BuildSystem.c_str()));
+    JniLocalRef<jstring> compiler(env, env->NewStringUTF(info.Compiler.c_str()));
+    JniLocalRef<jobject> modules(env, CreateStringBooleanMap(env, info.Modules));
+    JniLocalRef<jstring> vtkVersion(env, env->NewStringUTF(info.VTKVersion.c_str()));
+    JniLocalRef<jobject> copyrights(env, CreateStringList(env, info.Copyrights));
+    JniLocalRef<jstring> license(env, env->NewStringUTF(info.License.c_str()));
 
-    jobject libInfo = env->NewObject(libInfoClass, constructor, version, versionFull, buildDate,
-      buildSystem, compiler, modules, vtkVersion, copyrights, license);
-
-    env->DeleteLocalRef(version);
-    env->DeleteLocalRef(versionFull);
-    env->DeleteLocalRef(buildDate);
-    env->DeleteLocalRef(buildSystem);
-    env->DeleteLocalRef(compiler);
-    env->DeleteLocalRef(modules);
-    env->DeleteLocalRef(vtkVersion);
-    env->DeleteLocalRef(copyrights);
-    env->DeleteLocalRef(license);
+    jobject libInfo = env->NewObject(libInfoClass, constructor, version.get(), versionFull.get(),
+      buildDate.get(), buildSystem.get(), compiler.get(), modules.get(), vtkVersion.get(),
+      copyrights.get(), license.get());
 
     return libInfo;
   }
@@ -543,38 +528,32 @@ extern "C"
   {
     const std::vector<f3d::engine::readerInformation>& readers = f3d::engine::getReadersInfo();
 
-    jclass arrayListClass = env->FindClass("java/util/ArrayList");
+    JniLocalRef<jclass> arrayListClass(env, env->FindClass("java/util/ArrayList"));
     jmethodID arrayListConstructor = env->GetMethodID(arrayListClass, "<init>", "()V");
     jmethodID addMethod = env->GetMethodID(arrayListClass, "add", "(Ljava/lang/Object;)Z");
 
     jobject list = env->NewObject(arrayListClass, arrayListConstructor);
 
-    jclass readerInfoClass = env->FindClass("app/f3d/F3D/Engine$ReaderInfo");
+    JniLocalRef<jclass> readerInfoClass(env, env->FindClass("app/f3d/F3D/Engine$ReaderInfo"));
     jmethodID readerInfoConstructor = env->GetMethodID(readerInfoClass, "<init>",
       "(Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/"
       "String;ZZ)V");
 
     for (const auto& reader : readers)
     {
-      jstring name = env->NewStringUTF(reader.Name.c_str());
-      jstring description = env->NewStringUTF(reader.Description.c_str());
-      jobject extensions = CreateStringList(env, reader.Extensions);
-      jobject mimeTypes = CreateStringList(env, reader.MimeTypes);
-      jstring pluginName = env->NewStringUTF(reader.PluginName.c_str());
+      JniLocalRef<jstring> name(env, env->NewStringUTF(reader.Name.c_str()));
+      JniLocalRef<jstring> description(env, env->NewStringUTF(reader.Description.c_str()));
+      JniLocalRef<jobject> extensions(env, CreateStringList(env, reader.Extensions));
+      JniLocalRef<jobject> mimeTypes(env, CreateStringList(env, reader.MimeTypes));
+      JniLocalRef<jstring> pluginName(env, env->NewStringUTF(reader.PluginName.c_str()));
       jboolean hasSceneReader = reader.HasSceneReader;
       jboolean hasGeometryReader = reader.HasGeometryReader;
 
-      jobject readerInfo = env->NewObject(readerInfoClass, readerInfoConstructor, name, description,
-        extensions, mimeTypes, pluginName, hasSceneReader, hasGeometryReader);
+      JniLocalRef<jobject> readerInfo(env,
+        env->NewObject(readerInfoClass, readerInfoConstructor, name.get(), description.get(),
+          extensions.get(), mimeTypes.get(), pluginName.get(), hasSceneReader, hasGeometryReader));
 
-      env->CallBooleanMethod(list, addMethod, readerInfo);
-
-      env->DeleteLocalRef(name);
-      env->DeleteLocalRef(description);
-      env->DeleteLocalRef(extensions);
-      env->DeleteLocalRef(mimeTypes);
-      env->DeleteLocalRef(pluginName);
-      env->DeleteLocalRef(readerInfo);
+      env->CallBooleanMethod(list, addMethod, readerInfo.get());
     }
 
     return list;
@@ -589,20 +568,17 @@ extern "C"
   JNIEXPORT void JAVA_BIND(Engine, setReaderOption)(
     JNIEnv* env, jclass, jstring name, jstring value)
   {
-    const char* nameStr = env->GetStringUTFChars(name, nullptr);
-    const char* valueStr = env->GetStringUTFChars(value, nullptr);
+    JniUTFString nameStr(env, name);
+    JniUTFString valueStr(env, value);
 
     try
     {
-      f3d::engine::setReaderOption(nameStr, valueStr);
+      f3d::engine::setReaderOption(nameStr.c_str(), valueStr.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-
-    env->ReleaseStringUTFChars(name, nameStr);
-    env->ReleaseStringUTFChars(value, valueStr);
   }
 
   JNIEXPORT jobject JAVA_BIND(Engine, getAllReaderOptionNames)(JNIEnv* env, jclass)

--- a/java/F3DImageBindings.cxx
+++ b/java/F3DImageBindings.cxx
@@ -13,17 +13,16 @@ extern "C"
 
   JNIEXPORT jlong JAVA_BIND(Image, nativeCreateFromFile)(JNIEnv* env, jclass, jstring filePath)
   {
-    const char* path = env->GetStringUTFChars(filePath, nullptr);
+    JniUTFString path(env, filePath);
     jlong result = 0;
     try
     {
-      result = reinterpret_cast<jlong>(new f3d::image(path));
+      result = reinterpret_cast<jlong>(new f3d::image(path.c_str()));
     }
     catch (const f3d::image::read_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Image$ReadException", e.what());
     }
-    env->ReleaseStringUTFChars(filePath, path);
     return result;
   }
 
@@ -43,41 +42,24 @@ extern "C"
 
   JNIEXPORT jint JAVA_BIND(Image, getWidth)(JNIEnv* env, jobject self)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
-    return img->getWidth();
+    return GetImage(env, self)->getWidth();
   }
 
   JNIEXPORT jint JAVA_BIND(Image, getHeight)(JNIEnv* env, jobject self)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
-    return img->getHeight();
+    return GetImage(env, self)->getHeight();
   }
 
   JNIEXPORT jint JAVA_BIND(Image, getChannelCount)(JNIEnv* env, jobject self)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
-    return img->getChannelCount();
+    return GetImage(env, self)->getChannelCount();
   }
 
   JNIEXPORT jobject JAVA_BIND(Image, getChannelType)(JNIEnv* env, jobject self)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
+    f3d::image::ChannelType type = GetImage(env, self)->getChannelType();
 
-    f3d::image::ChannelType type = img->getChannelType();
-
-    jclass enumClass = env->FindClass("app/f3d/F3D/Image$ChannelType");
+    JniLocalRef<jclass> enumClass(env, env->FindClass("app/f3d/F3D/Image$ChannelType"));
     jfieldID fieldID;
 
     switch (type)
@@ -101,19 +83,12 @@ extern "C"
 
   JNIEXPORT jint JAVA_BIND(Image, getChannelTypeSize)(JNIEnv* env, jobject self)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
-    return img->getChannelTypeSize();
+    return GetImage(env, self)->getChannelTypeSize();
   }
 
   JNIEXPORT jobject JAVA_BIND(Image, setContent)(JNIEnv* env, jobject self, jbyteArray buffer)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
+    f3d::image* img = GetImage(env, self);
 
     jbyte* bufferData = env->GetByteArrayElements(buffer, nullptr);
     img->setContent(bufferData);
@@ -124,10 +99,7 @@ extern "C"
 
   JNIEXPORT jbyteArray JAVA_BIND(Image, getContent)(JNIEnv* env, jobject self)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
+    f3d::image* img = GetImage(env, self);
 
     void* content = img->getContent();
     unsigned int size =
@@ -142,12 +114,7 @@ extern "C"
   JNIEXPORT jdoubleArray JAVA_BIND(Image, getNormalizedPixel)(
     JNIEnv* env, jobject self, jint x, jint y)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
-
-    std::vector<double> pixel = img->getNormalizedPixel({ x, y });
+    std::vector<double> pixel = GetImage(env, self)->getNormalizedPixel({ x, y });
 
     jdoubleArray result = env->NewDoubleArray(pixel.size());
     env->SetDoubleArrayRegion(result, 0, pixel.size(), pixel.data());
@@ -157,55 +124,38 @@ extern "C"
 
   JNIEXPORT jdouble JAVA_BIND(Image, compare)(JNIEnv* env, jobject self, jobject reference)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
-
-    jclass refCls = env->GetObjectClass(reference);
-    jfieldID refFid = env->GetFieldID(refCls, "mNativeAddress", "J");
-    jlong refPtr = env->GetLongField(reference, refFid);
-    f3d::image* refImg = reinterpret_cast<f3d::image*>(refPtr);
-
-    return img->compare(*refImg);
+    return GetImage(env, self)->compare(*GetImage(env, reference));
   }
 
   JNIEXPORT jobject JAVA_BIND(Image, save)(
     JNIEnv* env, jobject self, jstring filePath, jobject format)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
+    f3d::image* img = GetImage(env, self);
 
-    const char* path = env->GetStringUTFChars(filePath, nullptr);
+    JniUTFString path(env, filePath);
 
-    jclass formatEnum = env->GetObjectClass(format);
+    JniLocalRef<jclass> formatEnum(env, env->GetObjectClass(format));
     jmethodID ordinalMethod = env->GetMethodID(formatEnum, "ordinal", "()I");
     jint formatOrdinal = env->CallIntMethod(format, ordinalMethod);
 
     f3d::image::SaveFormat saveFormat = static_cast<f3d::image::SaveFormat>(formatOrdinal);
     try
     {
-      img->save(path, saveFormat);
+      img->save(path.c_str(), saveFormat);
     }
     catch (const f3d::image::write_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Image$WriteException", e.what());
     }
 
-    env->ReleaseStringUTFChars(filePath, path);
     return self;
   }
 
   JNIEXPORT jbyteArray JAVA_BIND(Image, saveBuffer)(JNIEnv* env, jobject self, jobject format)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
+    f3d::image* img = GetImage(env, self);
 
-    jclass formatEnum = env->GetObjectClass(format);
+    JniLocalRef<jclass> formatEnum(env, env->GetObjectClass(format));
     jmethodID ordinalMethod = env->GetMethodID(formatEnum, "ordinal", "()I");
     jint formatOrdinal = env->CallIntMethod(format, ordinalMethod);
 
@@ -228,62 +178,42 @@ extern "C"
 
   JNIEXPORT jstring JAVA_BIND(Image, toTerminalText)(JNIEnv* env, jobject self)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
-
-    std::string text = img->toTerminalText();
+    std::string text = GetImage(env, self)->toTerminalText();
     return env->NewStringUTF(text.c_str());
   }
 
   JNIEXPORT jobject JAVA_BIND(Image, setMetadata)(
     JNIEnv* env, jobject self, jstring key, jstring value)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
+    f3d::image* img = GetImage(env, self);
 
-    const char* keyStr = env->GetStringUTFChars(key, nullptr);
-    const char* valueStr = env->GetStringUTFChars(value, nullptr);
+    JniUTFString keyStr(env, key);
+    JniUTFString valueStr(env, value);
 
-    img->setMetadata(keyStr, valueStr);
-
-    env->ReleaseStringUTFChars(key, keyStr);
-    env->ReleaseStringUTFChars(value, valueStr);
+    img->setMetadata(keyStr.c_str(), valueStr.c_str());
 
     return self;
   }
 
   JNIEXPORT jstring JAVA_BIND(Image, getMetadata)(JNIEnv* env, jobject self, jstring key)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
+    f3d::image* img = GetImage(env, self);
 
-    const char* keyStr = env->GetStringUTFChars(key, nullptr);
+    JniUTFString keyStr(env, key);
     std::string value;
     try
     {
-      value = img->getMetadata(keyStr);
+      value = img->getMetadata(keyStr.c_str());
     }
     catch (const f3d::image::metadata_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Image$MetadataException", e.what());
     }
-    env->ReleaseStringUTFChars(key, keyStr);
     return env->ExceptionCheck() ? nullptr : env->NewStringUTF(value.c_str());
   }
 
   JNIEXPORT jobject JAVA_BIND(Image, allMetadata)(JNIEnv* env, jobject self)
   {
-    jclass cls = env->GetObjectClass(self);
-    jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
-    jlong ptr = env->GetLongField(self, fid);
-    f3d::image* img = reinterpret_cast<f3d::image*>(ptr);
-
-    return CreateStringList(env, img->allMetadata());
+    return CreateStringList(env, GetImage(env, self)->allMetadata());
   }
 }

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -15,7 +15,7 @@ JavaVM* g_jvm = nullptr;
 
 f3d::interactor& GetInteractor(JNIEnv* env, jobject self)
 {
-  jclass cls = env->GetObjectClass(self);
+  JniLocalRef<jclass> cls(env, env->GetObjectClass(self));
   jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
   jlong ptr = env->GetLongField(self, fid);
 
@@ -68,42 +68,45 @@ jint NativeModToJava(f3d::interaction_bind_t::ModifierKeys mod)
 f3d::interaction_bind_t JavaBindToNative(JNIEnv* env, jobject bind)
 {
   f3d::interaction_bind_t nativeBind;
-  jclass bindClass = env->GetObjectClass(bind);
+  JniLocalRef<jclass> bindClass(env, env->GetObjectClass(bind));
 
   jfieldID modField = env->GetFieldID(bindClass, "mod", "Lapp/f3d/F3D/Interactor$ModifierKeys;");
-  jobject modObj = env->GetObjectField(bind, modField);
-  jclass modEnum = env->GetObjectClass(modObj);
+  JniLocalRef<jobject> modObj(env, env->GetObjectField(bind, modField));
+  JniLocalRef<jclass> modEnum(env, env->GetObjectClass(modObj));
   jmethodID ordinalMethod = env->GetMethodID(modEnum, "ordinal", "()I");
   jint modOrdinal = env->CallIntMethod(modObj, ordinalMethod);
   nativeBind.mod = JavaModToNative(modOrdinal);
 
   jfieldID interField = env->GetFieldID(bindClass, "inter", "Ljava/lang/String;");
-  jstring interStr = static_cast<jstring>(env->GetObjectField(bind, interField));
-  const char* interCStr = env->GetStringUTFChars(interStr, nullptr);
-  nativeBind.inter = interCStr;
-  env->ReleaseStringUTFChars(interStr, interCStr);
+  JniLocalRef<jstring> interStr(
+    env, static_cast<jstring>(env->GetObjectField(bind, interField)));
+  JniUTFString interCStr(env, interStr);
+  nativeBind.inter = interCStr.c_str();
 
   return nativeBind;
 }
 
 jobject NativeBindToJava(JNIEnv* env, const f3d::interaction_bind_t& bind)
 {
-  jclass bindClass = env->FindClass("app/f3d/F3D/Interactor$InteractionBind");
+  JniLocalRef<jclass> bindClass(env, env->FindClass("app/f3d/F3D/Interactor$InteractionBind"));
   jmethodID constructor = env->GetMethodID(bindClass, "<init>", "()V");
+  // Not wrapped in JniLocalRef: this is the return value, and its local reference
+  // must remain valid until it crosses back into the JVM after this function returns.
   jobject bindObj = env->NewObject(bindClass, constructor);
 
-  jclass modEnum = env->FindClass("app/f3d/F3D/Interactor$ModifierKeys");
+  JniLocalRef<jclass> modEnum(env, env->FindClass("app/f3d/F3D/Interactor$ModifierKeys"));
   jmethodID valuesMethod =
     env->GetStaticMethodID(modEnum, "values", "()[Lapp/f3d/F3D/Interactor$ModifierKeys;");
-  jobjectArray modsArray =
-    static_cast<jobjectArray>(env->CallStaticObjectMethod(modEnum, valuesMethod));
-  jobject modObj = env->GetObjectArrayElement(modsArray, NativeModToJava(bind.mod));
+  JniLocalRef<jobjectArray> modsArray(
+    env, static_cast<jobjectArray>(env->CallStaticObjectMethod(modEnum, valuesMethod)));
+  JniLocalRef<jobject> modObj(
+    env, env->GetObjectArrayElement(modsArray, NativeModToJava(bind.mod)));
 
   jfieldID modField = env->GetFieldID(bindClass, "mod", "Lapp/f3d/F3D/Interactor$ModifierKeys;");
   env->SetObjectField(bindObj, modField, modObj);
 
   jfieldID interField = env->GetFieldID(bindClass, "inter", "Ljava/lang/String;");
-  jstring interStr = env->NewStringUTF(bind.inter.c_str());
+  JniLocalRef<jstring> interStr(env, env->NewStringUTF(bind.inter.c_str()));
   env->SetObjectField(bindObj, interField, interStr);
 
   return bindObj;
@@ -121,9 +124,8 @@ extern "C"
   JNIEXPORT jobject JAVA_BIND(Interactor, addCommand)(
     JNIEnv* env, jobject self, jstring action, jobject callback)
   {
-    const char* actionStr = env->GetStringUTFChars(action, nullptr);
-    std::string actionCpp = actionStr;
-    env->ReleaseStringUTFChars(action, actionStr);
+    JniUTFString actionStr(env, action);
+    std::string actionCpp = actionStr.c_str();
 
     g_commandCallbacks[actionCpp] = env->NewGlobalRef(callback);
 
@@ -147,23 +149,20 @@ extern "C"
         return;
       }
 
-      jclass arrayListClass = env->FindClass("java/util/ArrayList");
+      JniLocalRef<jclass> arrayListClass(env, env->FindClass("java/util/ArrayList"));
       jmethodID arrayListConstructor = env->GetMethodID(arrayListClass, "<init>", "()V");
       jmethodID addMethod = env->GetMethodID(arrayListClass, "add", "(Ljava/lang/Object;)Z");
-      jobject argsList = env->NewObject(arrayListClass, arrayListConstructor);
+      JniLocalRef<jobject> argsList(env, env->NewObject(arrayListClass, arrayListConstructor));
 
       for (const auto& arg : args)
       {
-        jstring jstr = env->NewStringUTF(arg.c_str());
-        env->CallBooleanMethod(argsList, addMethod, jstr);
-        env->DeleteLocalRef(jstr);
+        JniLocalRef<jstring> jstr(env, env->NewStringUTF(arg.c_str()));
+        env->CallBooleanMethod(argsList, addMethod, jstr.get());
       }
 
-      jclass callbackClass = env->GetObjectClass(callback);
+      JniLocalRef<jclass> callbackClass(env, env->GetObjectClass(callback));
       jmethodID executeMethod = env->GetMethodID(callbackClass, "execute", "(Ljava/util/List;)V");
-      env->CallVoidMethod(callback, executeMethod, argsList);
-
-      env->DeleteLocalRef(argsList);
+      env->CallVoidMethod(callback, executeMethod, argsList.get());
 
       g_jvm->DetachCurrentThread();
     };
@@ -181,9 +180,8 @@ extern "C"
 
   JNIEXPORT jobject JAVA_BIND(Interactor, removeCommand)(JNIEnv* env, jobject self, jstring action)
   {
-    const char* actionStr = env->GetStringUTFChars(action, nullptr);
-    std::string actionCpp = actionStr;
-    env->ReleaseStringUTFChars(action, actionStr);
+    JniUTFString actionStr(env, action);
+    std::string actionCpp = actionStr.c_str();
 
     auto it = g_commandCallbacks.find(actionCpp);
     if (it != g_commandCallbacks.end())
@@ -204,11 +202,11 @@ extern "C"
   JNIEXPORT jboolean JAVA_BIND(Interactor, triggerCommand)(
     JNIEnv* env, jobject self, jstring command, jboolean keepComments)
   {
-    const char* commandStr = env->GetStringUTFChars(command, nullptr);
+    JniUTFString commandStr(env, command);
     bool result = false;
     try
     {
-      result = GetInteractor(env, self).triggerCommand(commandStr, keepComments);
+      result = GetInteractor(env, self).triggerCommand(commandStr.c_str(), keepComments);
     }
     catch (const f3d::interactor::command_runtime_exception& e)
     {
@@ -218,7 +216,6 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Interactor$InvalidArgsException", e.what());
     }
-    env->ReleaseStringUTFChars(command, commandStr);
     return result;
   }
 
@@ -233,7 +230,7 @@ extern "C"
   {
     f3d::interaction_bind_t nativeBind = JavaBindToNative(env, bind);
 
-    jclass listClass = env->GetObjectClass(commands);
+    JniLocalRef<jclass> listClass(env, env->GetObjectClass(commands));
     jmethodID sizeMethod = env->GetMethodID(listClass, "size", "()I");
     jmethodID getMethod = env->GetMethodID(listClass, "get", "(I)Ljava/lang/Object;");
     jint size = env->CallIntMethod(commands, sizeMethod);
@@ -241,17 +238,16 @@ extern "C"
     std::vector<std::string> commandsVec;
     for (jint i = 0; i < size; i++)
     {
-      jstring cmdStr = static_cast<jstring>(env->CallObjectMethod(commands, getMethod, i));
-      const char* cmdCStr = env->GetStringUTFChars(cmdStr, nullptr);
-      commandsVec.push_back(cmdCStr);
-      env->ReleaseStringUTFChars(cmdStr, cmdCStr);
+      JniLocalRef<jstring> cmdStr(
+        env, static_cast<jstring>(env->CallObjectMethod(commands, getMethod, i)));
+      JniUTFString cmdCStr(env, cmdStr);
+      commandsVec.push_back(cmdCStr.c_str());
     }
 
-    const char* groupStr = env->GetStringUTFChars(group, nullptr);
-    std::string groupCpp = groupStr;
-    env->ReleaseStringUTFChars(group, groupStr);
+    JniUTFString groupStr(env, group);
+    std::string groupCpp = groupStr.c_str();
 
-    jclass typeEnum = env->GetObjectClass(type);
+    JniLocalRef<jclass> typeEnum(env, env->GetObjectClass(type));
     jmethodID ordinalMethod = env->GetMethodID(typeEnum, "ordinal", "()I");
     jint typeOrdinal = env->CallIntMethod(type, ordinalMethod);
 
@@ -290,15 +286,13 @@ extern "C"
   {
     f3d::interaction_bind_t nativeBind = JavaBindToNative(env, bind);
 
-    const char* commandStr = env->GetStringUTFChars(command, nullptr);
-    std::string commandCpp = commandStr;
-    env->ReleaseStringUTFChars(command, commandStr);
+    JniUTFString commandStr(env, command);
+    std::string commandCpp = commandStr.c_str();
 
-    const char* groupStr = env->GetStringUTFChars(group, nullptr);
-    std::string groupCpp = groupStr;
-    env->ReleaseStringUTFChars(group, groupStr);
+    JniUTFString groupStr(env, group);
+    std::string groupCpp = groupStr.c_str();
 
-    jclass typeEnum = env->GetObjectClass(type);
+    JniLocalRef<jclass> typeEnum(env, env->GetObjectClass(type));
     jmethodID ordinalMethod = env->GetMethodID(typeEnum, "ordinal", "()I");
     jint typeOrdinal = env->CallIntMethod(type, ordinalMethod);
 
@@ -354,21 +348,19 @@ extern "C"
   JNIEXPORT jobject JAVA_BIND(Interactor, getBindsForGroup)(
     JNIEnv* env, jobject self, jstring group)
   {
-    const char* groupStr = env->GetStringUTFChars(group, nullptr);
+    JniUTFString groupStr(env, group);
     std::vector<f3d::interaction_bind_t> binds =
-      GetInteractor(env, self).getBindsForGroup(groupStr);
-    env->ReleaseStringUTFChars(group, groupStr);
+      GetInteractor(env, self).getBindsForGroup(groupStr.c_str());
 
-    jclass arrayListClass = env->FindClass("java/util/ArrayList");
+    JniLocalRef<jclass> arrayListClass(env, env->FindClass("java/util/ArrayList"));
     jmethodID arrayListConstructor = env->GetMethodID(arrayListClass, "<init>", "()V");
     jmethodID addMethod = env->GetMethodID(arrayListClass, "add", "(Ljava/lang/Object;)Z");
     jobject list = env->NewObject(arrayListClass, arrayListConstructor);
 
     for (const auto& bind : binds)
     {
-      jobject bindObj = NativeBindToJava(env, bind);
-      env->CallBooleanMethod(list, addMethod, bindObj);
-      env->DeleteLocalRef(bindObj);
+      JniLocalRef<jobject> bindObj(env, NativeBindToJava(env, bind));
+      env->CallBooleanMethod(list, addMethod, bindObj.get());
     }
 
     return list;
@@ -378,16 +370,15 @@ extern "C"
   {
     std::vector<f3d::interaction_bind_t> binds = GetInteractor(env, self).getBinds();
 
-    jclass arrayListClass = env->FindClass("java/util/ArrayList");
+    JniLocalRef<jclass> arrayListClass(env, env->FindClass("java/util/ArrayList"));
     jmethodID arrayListConstructor = env->GetMethodID(arrayListClass, "<init>", "()V");
     jmethodID addMethod = env->GetMethodID(arrayListClass, "add", "(Ljava/lang/Object;)Z");
     jobject list = env->NewObject(arrayListClass, arrayListConstructor);
 
     for (const auto& bind : binds)
     {
-      jobject bindObj = NativeBindToJava(env, bind);
-      env->CallBooleanMethod(list, addMethod, bindObj);
-      env->DeleteLocalRef(bindObj);
+      JniLocalRef<jobject> bindObj(env, NativeBindToJava(env, bind));
+      env->CallBooleanMethod(list, addMethod, bindObj.get());
     }
 
     return list;
@@ -399,17 +390,15 @@ extern "C"
     f3d::interaction_bind_t nativeBind = JavaBindToNative(env, bind);
     auto doc = GetInteractor(env, self).getBindingDocumentation(nativeBind);
 
-    jclass docClass = env->FindClass("app/f3d/F3D/Interactor$BindingDocumentation");
+    JniLocalRef<jclass> docClass(
+      env, env->FindClass("app/f3d/F3D/Interactor$BindingDocumentation"));
     jmethodID constructor =
       env->GetMethodID(docClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
 
-    jstring docStr = env->NewStringUTF(doc.first.c_str());
-    jstring valueStr = env->NewStringUTF(doc.second.c_str());
+    JniLocalRef<jstring> docStr(env, env->NewStringUTF(doc.first.c_str()));
+    JniLocalRef<jstring> valueStr(env, env->NewStringUTF(doc.second.c_str()));
 
-    jobject docObj = env->NewObject(docClass, constructor, docStr, valueStr);
-
-    env->DeleteLocalRef(docStr);
-    env->DeleteLocalRef(valueStr);
+    jobject docObj = env->NewObject(docClass, constructor, docStr.get(), valueStr.get());
 
     return docObj;
   }
@@ -419,7 +408,7 @@ extern "C"
     f3d::interaction_bind_t nativeBind = JavaBindToNative(env, bind);
     f3d::interactor::BindingType type = GetInteractor(env, self).getBindingType(nativeBind);
 
-    jclass enumClass = env->FindClass("app/f3d/F3D/Interactor$BindingType");
+    JniLocalRef<jclass> enumClass(env, env->FindClass("app/f3d/F3D/Interactor$BindingType"));
     jfieldID fieldID;
 
     switch (type)
@@ -448,7 +437,7 @@ extern "C"
   JNIEXPORT jobject JAVA_BIND(Interactor, toggleAnimation)(
     JNIEnv* env, jobject self, jobject direction)
   {
-    jclass directionEnum = env->GetObjectClass(direction);
+    JniLocalRef<jclass> directionEnum(env, env->GetObjectClass(direction));
     jmethodID getValueMethod = env->GetMethodID(directionEnum, "getValue", "()I");
     jint directionValue = env->CallIntMethod(direction, getValueMethod);
 
@@ -462,7 +451,7 @@ extern "C"
   JNIEXPORT jobject JAVA_BIND(Interactor, startAnimation)(
     JNIEnv* env, jobject self, jobject direction)
   {
-    jclass directionEnum = env->GetObjectClass(direction);
+    JniLocalRef<jclass> directionEnum(env, env->GetObjectClass(direction));
     jmethodID getValueMethod = env->GetMethodID(directionEnum, "getValue", "()I");
     jint directionValue = env->CallIntMethod(direction, getValueMethod);
 
@@ -489,7 +478,7 @@ extern "C"
     f3d::interactor::AnimationDirection nativeDirection =
       GetInteractor(env, self).getAnimationDirection();
 
-    jclass enumClass = env->FindClass("app/f3d/F3D/Interactor$AnimationDirection");
+    JniLocalRef<jclass> enumClass(env, env->FindClass("app/f3d/F3D/Interactor$AnimationDirection"));
     jmethodID fromValueMethod = env->GetStaticMethodID(
       enumClass, "fromValue", "(I)Lapp/f3d/F3D/Interactor$AnimationDirection;");
 
@@ -511,7 +500,7 @@ extern "C"
 
   JNIEXPORT jobject JAVA_BIND(Interactor, triggerModUpdate)(JNIEnv* env, jobject self, jobject mod)
   {
-    jclass modEnum = env->GetObjectClass(mod);
+    JniLocalRef<jclass> modEnum(env, env->GetObjectClass(mod));
     jmethodID ordinalMethod = env->GetMethodID(modEnum, "ordinal", "()I");
     jint modOrdinal = env->CallIntMethod(mod, ordinalMethod);
 
@@ -542,11 +531,11 @@ extern "C"
   JNIEXPORT jobject JAVA_BIND(Interactor, triggerMouseButton)(
     JNIEnv* env, jobject self, jobject action, jobject button)
   {
-    jclass actionEnum = env->GetObjectClass(action);
+    JniLocalRef<jclass> actionEnum(env, env->GetObjectClass(action));
     jmethodID actionOrdinalMethod = env->GetMethodID(actionEnum, "ordinal", "()I");
     jint actionOrdinal = env->CallIntMethod(action, actionOrdinalMethod);
 
-    jclass buttonEnum = env->GetObjectClass(button);
+    JniLocalRef<jclass> buttonEnum(env, env->GetObjectClass(button));
     jmethodID buttonOrdinalMethod = env->GetMethodID(buttonEnum, "ordinal", "()I");
     jint buttonOrdinal = env->CallIntMethod(button, buttonOrdinalMethod);
 
@@ -585,7 +574,7 @@ extern "C"
   JNIEXPORT jobject JAVA_BIND(Interactor, triggerMouseWheel)(
     JNIEnv* env, jobject self, jobject direction)
   {
-    jclass directionEnum = env->GetObjectClass(direction);
+    JniLocalRef<jclass> directionEnum(env, env->GetObjectClass(direction));
     jmethodID ordinalMethod = env->GetMethodID(directionEnum, "ordinal", "()I");
     jint directionOrdinal = env->CallIntMethod(direction, ordinalMethod);
 
@@ -616,7 +605,7 @@ extern "C"
   JNIEXPORT jobject JAVA_BIND(Interactor, triggerKeyboardKey)(
     JNIEnv* env, jobject self, jobject action, jstring keySym)
   {
-    jclass actionEnum = env->GetObjectClass(action);
+    JniLocalRef<jclass> actionEnum(env, env->GetObjectClass(action));
     jmethodID ordinalMethod = env->GetMethodID(actionEnum, "ordinal", "()I");
     jint actionOrdinal = env->CallIntMethod(action, ordinalMethod);
 
@@ -624,9 +613,8 @@ extern "C"
       ? f3d::interactor::InputAction::PRESS
       : f3d::interactor::InputAction::RELEASE;
 
-    const char* keySymStr = env->GetStringUTFChars(keySym, nullptr);
-    GetInteractor(env, self).triggerKeyboardKey(nativeAction, keySymStr);
-    env->ReleaseStringUTFChars(keySym, keySymStr);
+    JniUTFString keySymStr(env, keySym);
+    GetInteractor(env, self).triggerKeyboardKey(nativeAction, keySymStr.c_str());
 
     return self;
   }
@@ -675,19 +663,19 @@ extern "C"
           return;
         }
 
-        jclass callbackClass = env->GetObjectClass(g_eventLoopCallback);
+        JniLocalRef<jclass> callbackClass(env, env->GetObjectClass(g_eventLoopCallback));
         jmethodID executeMethod =
           env->GetMethodID(callbackClass, "execute", "(Lapp/f3d/F3D/Interactor$InteractorState;)V");
 
-        jclass stateClass = env->FindClass("app/f3d/F3D/Interactor$InteractorState");
+        JniLocalRef<jclass> stateClass(
+          env, env->FindClass("app/f3d/F3D/Interactor$InteractorState"));
         jmethodID stateConstructor = env->GetMethodID(stateClass, "<init>", "()V");
-        jobject stateObj = env->NewObject(stateClass, stateConstructor);
+        JniLocalRef<jobject> stateObj(env, env->NewObject(stateClass, stateConstructor));
         jfieldID animationTimeField = env->GetFieldID(stateClass, "animationTime", "D");
         env->SetDoubleField(stateObj, animationTimeField, state.animationTime);
 
-        env->CallVoidMethod(g_eventLoopCallback, executeMethod, stateObj);
+        env->CallVoidMethod(g_eventLoopCallback, executeMethod, stateObj.get());
 
-        env->DeleteLocalRef(stateObj);
         g_jvm->DetachCurrentThread();
       });
     return self;
@@ -696,19 +684,15 @@ extern "C"
   JNIEXPORT jboolean JAVA_BIND(Interactor, playInteraction)(
     JNIEnv* env, jobject self, jstring file, jdouble deltaTime)
   {
-    const char* fileStr = env->GetStringUTFChars(file, nullptr);
-    bool result = GetInteractor(env, self).playInteraction(fileStr, deltaTime);
-    env->ReleaseStringUTFChars(file, fileStr);
-    return result;
+    JniUTFString fileStr(env, file);
+    return GetInteractor(env, self).playInteraction(fileStr.c_str(), deltaTime);
   }
 
   JNIEXPORT jboolean JAVA_BIND(Interactor, recordInteraction)(
     JNIEnv* env, jobject self, jstring file)
   {
-    const char* fileStr = env->GetStringUTFChars(file, nullptr);
-    bool result = GetInteractor(env, self).recordInteraction(fileStr);
-    env->ReleaseStringUTFChars(file, fileStr);
-    return result;
+    JniUTFString fileStr(env, file);
+    return GetInteractor(env, self).recordInteraction(fileStr.c_str());
   }
 
   JNIEXPORT jobject JAVA_BIND(Interactor, start)(JNIEnv* env, jobject self, jdouble deltaTime)
@@ -738,13 +722,11 @@ extern "C"
   JNIEXPORT jobject JAVA_BIND(Interactor, triggerNotification)(
     JNIEnv* env, jobject self, jstring desc, jstring value, jdouble duration)
   {
-    const char* descStr = env->GetStringUTFChars(desc, nullptr);
-    std::string descCpp = descStr;
-    env->ReleaseStringUTFChars(desc, descStr);
+    JniUTFString descStr(env, desc);
+    std::string descCpp = descStr.c_str();
 
-    const char* valueStr = env->GetStringUTFChars(value, nullptr);
-    std::string valueCpp = valueStr;
-    env->ReleaseStringUTFChars(value, valueStr);
+    JniUTFString valueStr(env, value);
+    std::string valueCpp = valueStr.c_str();
 
     GetInteractor(env, self).triggerNotification(valueCpp, valueCpp, duration);
     return self;
@@ -781,20 +763,16 @@ extern "C"
           return true;
         }
 
-        jclass callbackClass = env->GetObjectClass(g_notificationCallback);
+        JniLocalRef<jclass> callbackClass(env, env->GetObjectClass(g_notificationCallback));
         jmethodID callMethod = env->GetMethodID(
           callbackClass, "execute", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;D)Z");
 
-        jstring jdesc = env->NewStringUTF(desc.c_str());
-        jstring jvalue = env->NewStringUTF(value.c_str());
-        jstring jbind = env->NewStringUTF(bind.c_str());
+        JniLocalRef<jstring> jdesc(env, env->NewStringUTF(desc.c_str()));
+        JniLocalRef<jstring> jvalue(env, env->NewStringUTF(value.c_str()));
+        JniLocalRef<jstring> jbind(env, env->NewStringUTF(bind.c_str()));
 
         jboolean result = env->CallBooleanMethod(
-          g_notificationCallback, callMethod, jdesc, jvalue, jbind, duration);
-
-        env->DeleteLocalRef(jdesc);
-        env->DeleteLocalRef(jvalue);
-        env->DeleteLocalRef(jbind);
+          g_notificationCallback, callMethod, jdesc.get(), jvalue.get(), jbind.get(), duration);
 
         g_jvm->DetachCurrentThread();
 

--- a/java/F3DInteractorBindings.cxx
+++ b/java/F3DInteractorBindings.cxx
@@ -78,8 +78,7 @@ f3d::interaction_bind_t JavaBindToNative(JNIEnv* env, jobject bind)
   nativeBind.mod = JavaModToNative(modOrdinal);
 
   jfieldID interField = env->GetFieldID(bindClass, "inter", "Ljava/lang/String;");
-  JniLocalRef<jstring> interStr(
-    env, static_cast<jstring>(env->GetObjectField(bind, interField)));
+  JniLocalRef<jstring> interStr(env, static_cast<jstring>(env->GetObjectField(bind, interField)));
   JniUTFString interCStr(env, interStr);
   nativeBind.inter = interCStr.c_str();
 

--- a/java/F3DJavaBindings.h
+++ b/java/F3DJavaBindings.h
@@ -4,6 +4,7 @@
 #include <jni.h>
 
 #include <engine.h>
+#include <image.h>
 
 #include <map>
 #include <string>
@@ -18,6 +19,86 @@
 namespace fs = std::filesystem;
 
 /**
+ * RAII helper wrapping GetStringUTFChars/ReleaseStringUTFChars.
+ * The underlying C string is released automatically when the wrapper goes
+ * out of scope, including on early returns or exceptions, so call sites can
+ * no longer leak a UTF-8 string by forgetting (or being unable, due to an
+ * exception) to call ReleaseStringUTFChars.
+ *
+ * A null jstring is handled gracefully: c_str() returns nullptr and no JNI
+ * call is made.
+ */
+class JniUTFString
+{
+public:
+  JniUTFString(JNIEnv* env, jstring jstr)
+    : Env(env)
+    , JStr(jstr)
+    , CStr(jstr ? env->GetStringUTFChars(jstr, nullptr) : nullptr)
+  {
+  }
+
+  ~JniUTFString()
+  {
+    if (this->CStr)
+    {
+      this->Env->ReleaseStringUTFChars(this->JStr, this->CStr);
+    }
+  }
+
+  JniUTFString(const JniUTFString&) = delete;
+  JniUTFString& operator=(const JniUTFString&) = delete;
+  JniUTFString(JniUTFString&&) = delete;
+  JniUTFString& operator=(JniUTFString&&) = delete;
+
+  operator const char*() const { return this->CStr; }
+  const char* c_str() const { return this->CStr; }
+
+private:
+  JNIEnv* Env;
+  jstring JStr;
+  const char* CStr;
+};
+
+/**
+ * RAII helper for a local JNI reference (jclass, jobject, jstring, ...)
+ * that must eventually be released with DeleteLocalRef. Deletes the local
+ * reference automatically when the wrapper goes out of scope.
+ *
+ * A null reference is handled gracefully: no JNI call is made on destruction.
+ */
+template <typename T>
+class JniLocalRef
+{
+public:
+  JniLocalRef(JNIEnv* env, T ref)
+    : Env(env)
+    , Ref(ref)
+  {
+  }
+
+  ~JniLocalRef()
+  {
+    if (this->Ref)
+    {
+      this->Env->DeleteLocalRef(this->Ref);
+    }
+  }
+
+  JniLocalRef(const JniLocalRef&) = delete;
+  JniLocalRef& operator=(const JniLocalRef&) = delete;
+  JniLocalRef(JniLocalRef&&) = delete;
+  JniLocalRef& operator=(JniLocalRef&&) = delete;
+
+  operator T() const { return this->Ref; }
+  T get() const { return this->Ref; }
+
+private:
+  JNIEnv* Env;
+  T Ref;
+};
+
+/**
  * Throw a Java exception of the given class name with the given message.
  * Call this from a catch block, then immediately return from the JNI function
  * so that the pending Java exception is delivered to the caller.
@@ -28,11 +109,10 @@ namespace fs = std::filesystem;
  */
 inline void F3DThrowJavaException(JNIEnv* env, const char* className, const char* msg)
 {
-  jclass cls = env->FindClass(className);
-  if (cls)
+  JniLocalRef<jclass> cls(env, env->FindClass(className));
+  if (cls.get())
   {
     env->ThrowNew(cls, msg);
-    env->DeleteLocalRef(cls);
   }
 }
 
@@ -56,6 +136,16 @@ inline f3d::engine::state* GetState(JNIEnv* env, jobject self)
   return reinterpret_cast<f3d::engine::state*>(ptr);
 }
 
+// Helper function to get the f3d::image pointer from a Java object
+inline f3d::image* GetImage(JNIEnv* env, jobject self)
+{
+  JniLocalRef<jclass> cls(env, env->GetObjectClass(self));
+  jfieldID fid = env->GetFieldID(cls, "mNativeAddress", "J");
+  jlong ptr = env->GetLongField(self, fid);
+
+  return reinterpret_cast<f3d::image*>(ptr);
+}
+
 // Helper function to convert std::vector<std::string> to Java List
 inline jobject CreateStringList(JNIEnv* env, const std::vector<std::string>& vec)
 {
@@ -67,9 +157,8 @@ inline jobject CreateStringList(JNIEnv* env, const std::vector<std::string>& vec
 
   for (const auto& str : vec)
   {
-    jstring jstr = env->NewStringUTF(str.c_str());
-    env->CallBooleanMethod(list, addMethod, jstr);
-    env->DeleteLocalRef(jstr);
+    JniLocalRef<jstring> jstr(env, env->NewStringUTF(str.c_str()));
+    env->CallBooleanMethod(list, addMethod, jstr.get());
   }
 
   return list;
@@ -90,11 +179,9 @@ inline jobject CreateStringBooleanMap(JNIEnv* env, const std::map<std::string, b
 
   for (const auto& [key, value] : map)
   {
-    jstring jkey = env->NewStringUTF(key.c_str());
-    jobject jvalue = env->NewObject(booleanClass, booleanConstructor, value);
-    env->CallObjectMethod(jmap, putMethod, jkey, jvalue);
-    env->DeleteLocalRef(jkey);
-    env->DeleteLocalRef(jvalue);
+    JniLocalRef<jstring> jkey(env, env->NewStringUTF(key.c_str()));
+    JniLocalRef<jobject> jvalue(env, env->NewObject(booleanClass, booleanConstructor, value));
+    env->CallObjectMethod(jmap, putMethod, jkey.get(), jvalue.get());
   }
 
   return jmap;

--- a/java/F3DJavaBindings.h
+++ b/java/F3DJavaBindings.h
@@ -51,8 +51,14 @@ public:
   JniUTFString(JniUTFString&&) = delete;
   JniUTFString& operator=(JniUTFString&&) = delete;
 
-  operator const char*() const { return this->CStr; }
-  const char* c_str() const { return this->CStr; }
+  operator const char*() const
+  {
+    return this->CStr;
+  }
+  const char* c_str() const
+  {
+    return this->CStr;
+  }
 
 private:
   JNIEnv* Env;
@@ -67,7 +73,7 @@ private:
  *
  * A null reference is handled gracefully: no JNI call is made on destruction.
  */
-template <typename T>
+template<typename T>
 class JniLocalRef
 {
 public:
@@ -90,8 +96,14 @@ public:
   JniLocalRef(JniLocalRef&&) = delete;
   JniLocalRef& operator=(JniLocalRef&&) = delete;
 
-  operator T() const { return this->Ref; }
-  T get() const { return this->Ref; }
+  operator T() const
+  {
+    return this->Ref;
+  }
+  T get() const
+  {
+    return this->Ref;
+  }
 
 private:
   JNIEnv* Env;

--- a/java/F3DLogBindings.cxx
+++ b/java/F3DLogBindings.cxx
@@ -35,21 +35,19 @@ static void cpp_log_forwarder(f3d::log::VerboseLevel level, const std::string& m
     return;
   }
 
-  jclass enumClass = env->FindClass("app/f3d/F3D/Log$VerboseLevel");
+  JniLocalRef<jclass> enumClass(env, env->FindClass("app/f3d/F3D/Log$VerboseLevel"));
   jmethodID fromValueMethod =
     env->GetStaticMethodID(enumClass, "fromValue", "(I)Lapp/f3d/F3D/Log$VerboseLevel;");
-  jobject jLevel = env->CallStaticObjectMethod(enumClass, fromValueMethod, static_cast<int>(level));
+  JniLocalRef<jobject> jLevel(
+    env, env->CallStaticObjectMethod(enumClass, fromValueMethod, static_cast<int>(level)));
 
-  jstring jMessage = env->NewStringUTF(message.c_str());
+  JniLocalRef<jstring> jMessage(env, env->NewStringUTF(message.c_str()));
 
-  jclass callbackClass = env->GetObjectClass(g_callback_ref);
+  JniLocalRef<jclass> callbackClass(env, env->GetObjectClass(g_callback_ref));
   jmethodID onLogMessageMethod = env->GetMethodID(
     callbackClass, "onLogMessage", "(Lapp/f3d/F3D/Log$VerboseLevel;Ljava/lang/String;)V");
 
-  env->CallVoidMethod(g_callback_ref, onLogMessageMethod, jLevel, jMessage);
-
-  env->DeleteLocalRef(jLevel);
-  env->DeleteLocalRef(jMessage);
+  env->CallVoidMethod(g_callback_ref, onLogMessageMethod, jLevel.get(), jMessage.get());
 
   if (needsDetach)
   {
@@ -66,16 +64,14 @@ extern "C"
       return;
     }
 
-    jclass enumClass = env->GetObjectClass(level);
+    JniLocalRef<jclass> enumClass(env, env->GetObjectClass(level));
     jmethodID getValueMethod = env->GetMethodID(enumClass, "getValue", "()I");
     jint levelValue = env->CallIntMethod(level, getValueMethod);
 
-    const char* messageStr = env->GetStringUTFChars(message, nullptr);
+    JniUTFString messageStr(env, message);
 
     f3d::log::VerboseLevel cppLevel = static_cast<f3d::log::VerboseLevel>(levelValue);
-    f3d::log::print(cppLevel, messageStr);
-
-    env->ReleaseStringUTFChars(message, messageStr);
+    f3d::log::print(cppLevel, messageStr.c_str());
   }
 
   JNIEXPORT void JAVA_BIND(Log, debug)(JNIEnv* env, jclass, jstring message)
@@ -85,9 +81,8 @@ extern "C"
       return;
     }
 
-    const char* messageStr = env->GetStringUTFChars(message, nullptr);
-    f3d::log::debug(messageStr);
-    env->ReleaseStringUTFChars(message, messageStr);
+    JniUTFString messageStr(env, message);
+    f3d::log::debug(messageStr.c_str());
   }
 
   JNIEXPORT void JAVA_BIND(Log, info)(JNIEnv* env, jclass, jstring message)
@@ -97,9 +92,8 @@ extern "C"
       return;
     }
 
-    const char* messageStr = env->GetStringUTFChars(message, nullptr);
-    f3d::log::info(messageStr);
-    env->ReleaseStringUTFChars(message, messageStr);
+    JniUTFString messageStr(env, message);
+    f3d::log::info(messageStr.c_str());
   }
 
   JNIEXPORT void JAVA_BIND(Log, warn)(JNIEnv* env, jclass, jstring message)
@@ -109,9 +103,8 @@ extern "C"
       return;
     }
 
-    const char* messageStr = env->GetStringUTFChars(message, nullptr);
-    f3d::log::warn(messageStr);
-    env->ReleaseStringUTFChars(message, messageStr);
+    JniUTFString messageStr(env, message);
+    f3d::log::warn(messageStr.c_str());
   }
 
   JNIEXPORT void JAVA_BIND(Log, error)(JNIEnv* env, jclass, jstring message)
@@ -121,9 +114,8 @@ extern "C"
       return;
     }
 
-    const char* messageStr = env->GetStringUTFChars(message, nullptr);
-    f3d::log::error(messageStr);
-    env->ReleaseStringUTFChars(message, messageStr);
+    JniUTFString messageStr(env, message);
+    f3d::log::error(messageStr.c_str());
   }
 
   JNIEXPORT void JAVA_BIND(Log, setUseColoring)(JNIEnv*, jclass, jboolean use)
@@ -139,7 +131,7 @@ extern "C"
       return;
     }
 
-    jclass enumClass = env->GetObjectClass(level);
+    JniLocalRef<jclass> enumClass(env, env->GetObjectClass(level));
     jmethodID getValueMethod = env->GetMethodID(enumClass, "getValue", "()I");
     jint levelValue = env->CallIntMethod(level, getValueMethod);
 
@@ -151,7 +143,7 @@ extern "C"
   {
     f3d::log::VerboseLevel cppLevel = f3d::log::getVerboseLevel();
 
-    jclass enumClass = env->FindClass("app/f3d/F3D/Log$VerboseLevel");
+    JniLocalRef<jclass> enumClass(env, env->FindClass("app/f3d/F3D/Log$VerboseLevel"));
     jmethodID fromValueMethod =
       env->GetStaticMethodID(enumClass, "fromValue", "(I)Lapp/f3d/F3D/Log$VerboseLevel;");
 

--- a/java/F3DOptionsBindings.cxx
+++ b/java/F3DOptionsBindings.cxx
@@ -348,8 +348,8 @@ extern "C"
     bool result = false;
     try
     {
-      result = GetOptionsFromEngine(env, self)
-                 .isSame(reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str.c_str());
+      result = GetOptionsFromEngine(env, self).isSame(
+        reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -382,8 +382,8 @@ extern "C"
     JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self)
-        .copy(reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str.c_str());
+      GetOptionsFromEngine(env, self).copy(
+        reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {

--- a/java/F3DOptionsBindings.cxx
+++ b/java/F3DOptionsBindings.cxx
@@ -21,10 +21,10 @@ extern "C"
   JNIEXPORT void JAVA_BIND(Options, setAsBool)(
     JNIEnv* env, jobject self, jstring name, jboolean value)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self).set(str, static_cast<bool>(value));
+      GetOptionsFromEngine(env, self).set(str.c_str(), static_cast<bool>(value));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -34,15 +34,14 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, setAsInt)(JNIEnv* env, jobject self, jstring name, jint value)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self).set(str, static_cast<int>(value));
+      GetOptionsFromEngine(env, self).set(str.c_str(), static_cast<int>(value));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -52,16 +51,15 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, setAsDouble)(
     JNIEnv* env, jobject self, jstring name, jdouble value)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self).set(str, static_cast<double>(value));
+      GetOptionsFromEngine(env, self).set(str.c_str(), static_cast<double>(value));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -71,17 +69,16 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, setAsString)(
     JNIEnv* env, jobject self, jstring name, jstring value)
   {
-    const char* nameStr = env->GetStringUTFChars(name, nullptr);
-    const char* valueStr = env->GetStringUTFChars(value, nullptr);
+    JniUTFString nameStr(env, name);
+    JniUTFString valueStr(env, value);
     try
     {
-      GetOptionsFromEngine(env, self).set(nameStr, std::string(valueStr));
+      GetOptionsFromEngine(env, self).set(nameStr.c_str(), std::string(valueStr.c_str()));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -91,14 +88,12 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, nameStr);
-    env->ReleaseStringUTFChars(value, valueStr);
   }
 
   JNIEXPORT void JAVA_BIND(Options, setAsDoubleVector)(
     JNIEnv* env, jobject self, jstring name, jdoubleArray values)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     jsize len = env->GetArrayLength(values);
     double* arr = env->GetDoubleArrayElements(values, nullptr);
     std::vector<double> vec(arr, arr + len);
@@ -106,7 +101,7 @@ extern "C"
 
     try
     {
-      GetOptionsFromEngine(env, self).set(str, vec);
+      GetOptionsFromEngine(env, self).set(str.c_str(), vec);
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -116,13 +111,12 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, setAsIntVector)(
     JNIEnv* env, jobject self, jstring name, jintArray values)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     jsize len = env->GetArrayLength(values);
     int* arr = env->GetIntArrayElements(values, nullptr);
     std::vector<int> vec(arr, arr + len);
@@ -130,7 +124,7 @@ extern "C"
 
     try
     {
-      GetOptionsFromEngine(env, self).set(str, vec);
+      GetOptionsFromEngine(env, self).set(str.c_str(), vec);
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -140,16 +134,15 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT jboolean JAVA_BIND(Options, getAsBool)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     bool value = false;
     try
     {
-      value = std::get<bool>(GetOptionsFromEngine(env, self).get(str));
+      value = std::get<bool>(GetOptionsFromEngine(env, self).get(str.c_str()));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -163,17 +156,16 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return value;
   }
 
   JNIEXPORT jint JAVA_BIND(Options, getAsInt)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     int value = 0;
     try
     {
-      value = std::get<int>(GetOptionsFromEngine(env, self).get(str));
+      value = std::get<int>(GetOptionsFromEngine(env, self).get(str.c_str()));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -187,17 +179,16 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return value;
   }
 
   JNIEXPORT jdouble JAVA_BIND(Options, getAsDouble)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     double value = 0.0;
     try
     {
-      value = std::get<double>(GetOptionsFromEngine(env, self).get(str));
+      value = std::get<double>(GetOptionsFromEngine(env, self).get(str.c_str()));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -211,17 +202,16 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return value;
   }
 
   JNIEXPORT jstring JAVA_BIND(Options, getAsString)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     std::string value;
     try
     {
-      value = std::get<std::string>(GetOptionsFromEngine(env, self).get(str));
+      value = std::get<std::string>(GetOptionsFromEngine(env, self).get(str.c_str()));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -235,18 +225,17 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return env->ExceptionCheck() ? nullptr : env->NewStringUTF(value.c_str());
   }
 
   JNIEXPORT jstring JAVA_BIND(Options, getAsStringRepresentation)(
     JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     std::string value;
     try
     {
-      value = GetOptionsFromEngine(env, self).getAsString(str);
+      value = GetOptionsFromEngine(env, self).getAsString(str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -256,18 +245,17 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$NoValueException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return env->ExceptionCheck() ? nullptr : env->NewStringUTF(value.c_str());
   }
 
   JNIEXPORT void JAVA_BIND(Options, setAsStringRepresentation)(
     JNIEnv* env, jobject self, jstring name, jstring str)
   {
-    const char* nameStr = env->GetStringUTFChars(name, nullptr);
-    const char* valueStr = env->GetStringUTFChars(str, nullptr);
+    JniUTFString nameStr(env, name);
+    JniUTFString valueStr(env, str);
     try
     {
-      GetOptionsFromEngine(env, self).setAsString(nameStr, valueStr);
+      GetOptionsFromEngine(env, self).setAsString(nameStr.c_str(), valueStr.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -277,19 +265,17 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$ParsingException", e.what());
     }
-    env->ReleaseStringUTFChars(name, nameStr);
-    env->ReleaseStringUTFChars(str, valueStr);
   }
 
   JNIEXPORT jdoubleArray JAVA_BIND(Options, getAsDoubleVector)(
     JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     jdoubleArray result = nullptr;
     try
     {
       std::vector<double> vec =
-        std::get<std::vector<double>>(GetOptionsFromEngine(env, self).get(str));
+        std::get<std::vector<double>>(GetOptionsFromEngine(env, self).get(str.c_str()));
       result = env->NewDoubleArray(vec.size());
       env->SetDoubleArrayRegion(result, 0, vec.size(), vec.data());
     }
@@ -305,17 +291,17 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return result;
   }
 
   JNIEXPORT jintArray JAVA_BIND(Options, getAsIntVector)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     jintArray result = nullptr;
     try
     {
-      std::vector<int> vec = std::get<std::vector<int>>(GetOptionsFromEngine(env, self).get(str));
+      std::vector<int> vec =
+        std::get<std::vector<int>>(GetOptionsFromEngine(env, self).get(str.c_str()));
       result = env->NewIntArray(vec.size());
       env->SetIntArrayRegion(result, 0, vec.size(), vec.data());
     }
@@ -331,16 +317,15 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return result;
   }
 
   JNIEXPORT void JAVA_BIND(Options, toggle)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self).toggle(str);
+      GetOptionsFromEngine(env, self).toggle(str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -350,64 +335,60 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT jboolean JAVA_BIND(Options, isSame)(
     JNIEnv* env, jobject self, jobject other, jstring name)
   {
-    jclass otherClass = env->GetObjectClass(other);
+    JniLocalRef<jclass> otherClass(env, env->GetObjectClass(other));
     jfieldID fid = env->GetFieldID(otherClass, "mNativeAddress", "J");
     jlong otherPtr = env->GetLongField(other, fid);
 
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     bool result = false;
     try
     {
-      result = GetOptionsFromEngine(env, self).isSame(
-        reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str);
+      result = GetOptionsFromEngine(env, self)
+                 .isSame(reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return result;
   }
 
   JNIEXPORT jboolean JAVA_BIND(Options, hasValue)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     bool result = false;
     try
     {
-      result = GetOptionsFromEngine(env, self).hasValue(str);
+      result = GetOptionsFromEngine(env, self).hasValue(str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return result;
   }
 
   JNIEXPORT void JAVA_BIND(Options, copy)(JNIEnv* env, jobject self, jobject other, jstring name)
   {
-    jclass otherClass = env->GetObjectClass(other);
+    JniLocalRef<jclass> otherClass(env, env->GetObjectClass(other));
     jfieldID fid = env->GetFieldID(otherClass, "mNativeAddress", "J");
     jlong otherPtr = env->GetLongField(other, fid);
 
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self).copy(
-        reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str);
+      GetOptionsFromEngine(env, self)
+        .copy(reinterpret_cast<f3d::engine*>(otherPtr)->getOptions(), str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getAllNames)(JNIEnv* env, jclass)
@@ -425,43 +406,41 @@ extern "C"
 
   JNIEXPORT jobject JAVA_BIND(Options, getClosestOption)(JNIEnv* env, jobject self, jstring option)
   {
-    const char* str = env->GetStringUTFChars(option, nullptr);
-    auto [name, distance] = GetOptionsFromEngine(env, self).getClosestOption(str);
-    env->ReleaseStringUTFChars(option, str);
+    JniUTFString str(env, option);
+    auto [name, distance] = GetOptionsFromEngine(env, self).getClosestOption(str.c_str());
 
-    jclass resultClass = env->FindClass("app/f3d/F3D/Options$ClosestOptionResult");
+    JniLocalRef<jclass> resultClass(env, env->FindClass("app/f3d/F3D/Options$ClosestOptionResult"));
     jmethodID constructor = env->GetMethodID(resultClass, "<init>", "(Ljava/lang/String;I)V");
 
-    jstring jname = env->NewStringUTF(name.c_str());
-    jobject result = env->NewObject(resultClass, constructor, jname, static_cast<jint>(distance));
-    env->DeleteLocalRef(jname);
+    JniLocalRef<jstring> jname(env, env->NewStringUTF(name.c_str()));
+    jobject result =
+      env->NewObject(resultClass, constructor, jname.get(), static_cast<jint>(distance));
 
     return result;
   }
 
   JNIEXPORT jboolean JAVA_BIND(Options, isOptional)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     bool result = false;
     try
     {
-      result = GetOptionsFromEngine(env, self).isOptional(str);
+      result = GetOptionsFromEngine(env, self).isOptional(str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return result;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getType)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     jobject result = nullptr;
     try
     {
-      f3d::options::option_type type = GetOptionsFromEngine(env, self).getType(str);
+      f3d::options::option_type type = GetOptionsFromEngine(env, self).getType(str.c_str());
 
       const char* enumName = nullptr;
       switch (type)
@@ -507,7 +486,7 @@ extern "C"
           assert(false);
       }
 
-      jclass typeClass = env->FindClass("app/f3d/F3D/Options$OptionType");
+      JniLocalRef<jclass> typeClass(env, env->FindClass("app/f3d/F3D/Options$OptionType"));
       jfieldID fid = env->GetStaticFieldID(typeClass, enumName, "Lapp/f3d/F3D/Options$OptionType;");
       result = env->GetStaticObjectField(typeClass, fid);
     }
@@ -515,30 +494,28 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return result;
   }
 
   JNIEXPORT void JAVA_BIND(Options, reset)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self).reset(str);
+      GetOptionsFromEngine(env, self).reset(str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, removeValue)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self).removeValue(str);
+      GetOptionsFromEngine(env, self).removeValue(str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -548,34 +525,32 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT jboolean JAVA_BIND(Options, hasDomain)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     bool result = false;
     try
     {
-      result = GetOptionsFromEngine(env, self).hasDomain(str);
+      result = GetOptionsFromEngine(env, self).hasDomain(str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return result;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getDomainStyle)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     jobject result = nullptr;
     try
     {
-      f3d::options::domain_style ds = GetOptionsFromEngine(env, self).getDomainStyle(str);
+      f3d::options::domain_style ds = GetOptionsFromEngine(env, self).getDomainStyle(str.c_str());
 
-      jclass enumClass = env->FindClass("app/f3d/F3D/Options$DomainStyle");
+      JniLocalRef<jclass> enumClass(env, env->FindClass("app/f3d/F3D/Options$DomainStyle"));
       jfieldID fieldID;
 
       switch (ds)
@@ -597,17 +572,16 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return result;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getEnumDomain)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     jobject result = nullptr;
     try
     {
-      result = CreateStringList(env, GetOptionsFromEngine(env, self).getEnumDomain(str));
+      result = CreateStringList(env, GetOptionsFromEngine(env, self).getEnumDomain(str.c_str()));
     }
     catch (const f3d::options::inexistent_exception& e)
     {
@@ -617,18 +591,16 @@ extern "C"
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$IncompatibleException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
     return result;
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getRangeDomainAsDouble)(
     JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
-    const std::string nameStr = str;
-    env->ReleaseStringUTFChars(name, str);
+    JniUTFString str(env, name);
+    const std::string nameStr = str.c_str();
 
-    jclass rangeClass = env->FindClass("app/f3d/F3D/Options$DomainRange");
+    JniLocalRef<jclass> rangeClass(env, env->FindClass("app/f3d/F3D/Options$DomainRange"));
     jmethodID rangeCtor = env->GetMethodID(
       rangeClass, "<init>", "(Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V");
 
@@ -644,7 +616,7 @@ extern "C"
           "Trying to get range domain of " + nameStr + " as a Double but it is an Integer domain");
       }
 
-      jclass doubleClass = env->FindClass("java/lang/Double");
+      JniLocalRef<jclass> doubleClass(env, env->FindClass("java/lang/Double"));
       jmethodID valueOf = env->GetStaticMethodID(doubleClass, "valueOf", "(D)Ljava/lang/Double;");
       return env->NewObject(rangeClass, rangeCtor,
         env->CallStaticObjectMethod(doubleClass, valueOf, std::get<double>(range.min)),
@@ -653,18 +625,17 @@ extern "C"
     }
     catch (const std::exception& e)
     {
-      env->ThrowNew(env->FindClass("java/lang/IllegalArgumentException"), e.what());
+      F3DThrowJavaException(env, "java/lang/IllegalArgumentException", e.what());
       return nullptr;
     }
   }
 
   JNIEXPORT jobject JAVA_BIND(Options, getRangeDomainAsInt)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
-    const std::string nameStr = str;
-    env->ReleaseStringUTFChars(name, str);
+    JniUTFString str(env, name);
+    const std::string nameStr = str.c_str();
 
-    jclass rangeClass = env->FindClass("app/f3d/F3D/Options$DomainRange");
+    JniLocalRef<jclass> rangeClass(env, env->FindClass("app/f3d/F3D/Options$DomainRange"));
     jmethodID rangeCtor = env->GetMethodID(
       rangeClass, "<init>", "(Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V");
 
@@ -679,7 +650,7 @@ extern "C"
           " as an Integer but it is not an Integer domain");
       }
 
-      jclass integerClass = env->FindClass("java/lang/Integer");
+      JniLocalRef<jclass> integerClass(env, env->FindClass("java/lang/Integer"));
       jmethodID valueOf = env->GetStaticMethodID(integerClass, "valueOf", "(I)Ljava/lang/Integer;");
       return env->NewObject(rangeClass, rangeCtor,
         env->CallStaticObjectMethod(integerClass, valueOf, std::get<int>(range.min)),
@@ -688,50 +659,47 @@ extern "C"
     }
     catch (const std::exception& e)
     {
-      env->ThrowNew(env->FindClass("java/lang/IllegalArgumentException"), e.what());
+      F3DThrowJavaException(env, "java/lang/IllegalArgumentException", e.what());
       return nullptr;
     }
   }
 
   JNIEXPORT void JAVA_BIND(Options, increase)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self).increase(str);
+      GetOptionsFromEngine(env, self).increase(str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, decrease)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self).decrease(str);
+      GetOptionsFromEngine(env, self).decrease(str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 
   JNIEXPORT void JAVA_BIND(Options, cycle)(JNIEnv* env, jobject self, jstring name)
   {
-    const char* str = env->GetStringUTFChars(name, nullptr);
+    JniUTFString str(env, name);
     try
     {
-      GetOptionsFromEngine(env, self).cycle(str);
+      GetOptionsFromEngine(env, self).cycle(str.c_str());
     }
     catch (const f3d::options::inexistent_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Options$InexistentException", e.what());
     }
-    env->ReleaseStringUTFChars(name, str);
   }
 }

--- a/java/F3DSceneBindings.cxx
+++ b/java/F3DSceneBindings.cxx
@@ -19,8 +19,7 @@ static std::vector<std::string> JavaListToStringVector(JNIEnv* env, jobject list
 
   for (jint i = 0; i < size; i++)
   {
-    JniLocalRef<jstring> jstr(
-      env, static_cast<jstring>(env->CallObjectMethod(list, getMethod, i)));
+    JniLocalRef<jstring> jstr(env, static_cast<jstring>(env->CallObjectMethod(list, getMethod, i)));
     if (jstr.get())
     {
       JniUTFString str(env, jstr);

--- a/java/F3DSceneBindings.cxx
+++ b/java/F3DSceneBindings.cxx
@@ -11,7 +11,7 @@ static std::vector<std::string> JavaListToStringVector(JNIEnv* env, jobject list
 {
   std::vector<std::string> vec;
 
-  jclass listClass = env->GetObjectClass(list);
+  JniLocalRef<jclass> listClass(env, env->GetObjectClass(list));
   jmethodID sizeMethod = env->GetMethodID(listClass, "size", "()I");
   jmethodID getMethod = env->GetMethodID(listClass, "get", "(I)Ljava/lang/Object;");
 
@@ -19,12 +19,12 @@ static std::vector<std::string> JavaListToStringVector(JNIEnv* env, jobject list
 
   for (jint i = 0; i < size; i++)
   {
-    if (jstring jstr = static_cast<jstring>(env->CallObjectMethod(list, getMethod, i)))
+    JniLocalRef<jstring> jstr(
+      env, static_cast<jstring>(env->CallObjectMethod(list, getMethod, i)));
+    if (jstr.get())
     {
-      const char* str = env->GetStringUTFChars(jstr, nullptr);
-      vec.push_back(str);
-      env->ReleaseStringUTFChars(jstr, str);
-      env->DeleteLocalRef(jstr);
+      JniUTFString str(env, jstr);
+      vec.push_back(str.c_str());
     }
   }
 
@@ -35,7 +35,7 @@ static f3d::mesh_t JavaMeshToCppMesh(JNIEnv* env, jobject jmesh)
 {
   f3d::mesh_t cppMesh;
 
-  jclass meshClass = env->GetObjectClass(jmesh);
+  JniLocalRef<jclass> meshClass(env, env->GetObjectClass(jmesh));
 
   jfieldID pointsField = env->GetFieldID(meshClass, "points", "[F");
   jfieldID normalsField = env->GetFieldID(meshClass, "normals", "[F");
@@ -97,7 +97,7 @@ static f3d::light_state_t JavaLightStateToCppLightState(JNIEnv* env, jobject jli
 {
   f3d::light_state_t cppLightState;
 
-  jclass lightStateClass = env->GetObjectClass(jlightState);
+  JniLocalRef<jclass> lightStateClass(env, env->GetObjectClass(jlightState));
 
   jfieldID typeField = env->GetFieldID(lightStateClass, "type", "Lapp/f3d/F3D/Types$LightType;");
   jfieldID positionField = env->GetFieldID(lightStateClass, "position", "[D");
@@ -107,29 +107,33 @@ static f3d::light_state_t JavaLightStateToCppLightState(JNIEnv* env, jobject jli
   jfieldID intensityField = env->GetFieldID(lightStateClass, "intensity", "D");
   jfieldID switchStateField = env->GetFieldID(lightStateClass, "switchState", "Z");
 
-  jobject jtype = env->GetObjectField(jlightState, typeField);
-  jclass typeEnumClass = env->GetObjectClass(jtype);
+  JniLocalRef<jobject> jtype(env, env->GetObjectField(jlightState, typeField));
+  JniLocalRef<jclass> typeEnumClass(env, env->GetObjectClass(jtype));
   jmethodID getValueMethod = env->GetMethodID(typeEnumClass, "getValue", "()I");
   jint typeValue = env->CallIntMethod(jtype, getValueMethod);
   cppLightState.type = static_cast<f3d::light_type>(typeValue);
 
-  if (jdoubleArray jposition =
-        static_cast<jdoubleArray>(env->GetObjectField(jlightState, positionField)))
+  JniLocalRef<jdoubleArray> jposition(
+    env, static_cast<jdoubleArray>(env->GetObjectField(jlightState, positionField)));
+  if (jposition.get())
   {
     double* posData = env->GetDoubleArrayElements(jposition, nullptr);
     cppLightState.position = { posData[0], posData[1], posData[2] };
     env->ReleaseDoubleArrayElements(jposition, posData, 0);
   }
 
-  if (jdoubleArray jcolor = static_cast<jdoubleArray>(env->GetObjectField(jlightState, colorField)))
+  JniLocalRef<jdoubleArray> jcolor(
+    env, static_cast<jdoubleArray>(env->GetObjectField(jlightState, colorField)));
+  if (jcolor.get())
   {
     double* colorData = env->GetDoubleArrayElements(jcolor, nullptr);
     cppLightState.color = { colorData[0], colorData[1], colorData[2] };
     env->ReleaseDoubleArrayElements(jcolor, colorData, 0);
   }
 
-  if (jdoubleArray jdirection =
-        static_cast<jdoubleArray>(env->GetObjectField(jlightState, directionField)))
+  JniLocalRef<jdoubleArray> jdirection(
+    env, static_cast<jdoubleArray>(env->GetObjectField(jlightState, directionField)));
+  if (jdirection.get())
   {
     double* dirData = env->GetDoubleArrayElements(jdirection, nullptr);
     cppLightState.direction = { dirData[0], dirData[1], dirData[2] };
@@ -152,16 +156,15 @@ extern "C"
       return self;
     }
 
-    const char* str = env->GetStringUTFChars(path, nullptr);
+    JniUTFString str(env, path);
     try
     {
-      GetEngine(env, self)->getScene().add(str);
+      GetEngine(env, self)->getScene().add(str.c_str());
     }
     catch (const f3d::scene::load_failure_exception& e)
     {
       F3DThrowJavaException(env, "app/f3d/F3D/Scene$LoadFailureException", e.what());
     }
-    env->ReleaseStringUTFChars(path, str);
     return self;
   }
 
@@ -261,34 +264,37 @@ extern "C"
     {
       f3d::light_state_t cppLightState = GetEngine(env, self)->getScene().getLight(index);
 
-      jclass lightStateClass = env->FindClass("app/f3d/F3D/Types$LightState");
+      JniLocalRef<jclass> lightStateClass(env, env->FindClass("app/f3d/F3D/Types$LightState"));
       jmethodID constructor = env->GetMethodID(lightStateClass, "<init>", "()V");
+      // Not wrapped in JniLocalRef: this is the return value, and its local reference
+      // must remain valid until it crosses back into the JVM after this function returns.
       jobject jlightState = env->NewObject(lightStateClass, constructor);
 
-      jclass typeEnumClass = env->FindClass("app/f3d/F3D/Types$LightType");
+      JniLocalRef<jclass> typeEnumClass(env, env->FindClass("app/f3d/F3D/Types$LightType"));
       jmethodID fromValueMethod =
         env->GetStaticMethodID(typeEnumClass, "fromValue", "(I)Lapp/f3d/F3D/Types$LightType;");
-      jobject jtype = env->CallStaticObjectMethod(
-        typeEnumClass, fromValueMethod, static_cast<int>(cppLightState.type));
+      JniLocalRef<jobject> jtype(env,
+        env->CallStaticObjectMethod(
+          typeEnumClass, fromValueMethod, static_cast<int>(cppLightState.type)));
       jfieldID typeField =
         env->GetFieldID(lightStateClass, "type", "Lapp/f3d/F3D/Types$LightType;");
       env->SetObjectField(jlightState, typeField, jtype);
 
-      jdoubleArray jposition = env->NewDoubleArray(3);
+      JniLocalRef<jdoubleArray> jposition(env, env->NewDoubleArray(3));
       double posData[] = { cppLightState.position[0], cppLightState.position[1],
         cppLightState.position[2] };
       env->SetDoubleArrayRegion(jposition, 0, 3, posData);
       jfieldID positionField = env->GetFieldID(lightStateClass, "position", "[D");
       env->SetObjectField(jlightState, positionField, jposition);
 
-      jdoubleArray jcolor = env->NewDoubleArray(3);
+      JniLocalRef<jdoubleArray> jcolor(env, env->NewDoubleArray(3));
       double colorData[] = { cppLightState.color[0], cppLightState.color[1],
         cppLightState.color[2] };
       env->SetDoubleArrayRegion(jcolor, 0, 3, colorData);
       jfieldID colorField = env->GetFieldID(lightStateClass, "color", "[D");
       env->SetObjectField(jlightState, colorField, jcolor);
 
-      jdoubleArray jdirection = env->NewDoubleArray(3);
+      JniLocalRef<jdoubleArray> jdirection(env, env->NewDoubleArray(3));
       double dirData[] = { cppLightState.direction[0], cppLightState.direction[1],
         cppLightState.direction[2] };
       env->SetDoubleArrayRegion(jdirection, 0, 3, dirData);
@@ -357,12 +363,12 @@ extern "C"
     const std::vector<f3d::node_state_t> cppNodeStates =
       GetEngine(env, self)->getScene().getSceneHierarchy();
 
-    jclass arrayListClass = env->FindClass("java/util/ArrayList");
+    JniLocalRef<jclass> arrayListClass(env, env->FindClass("java/util/ArrayList"));
     jmethodID arrayListConstructor = env->GetMethodID(arrayListClass, "<init>", "()V");
     jmethodID addMethod = env->GetMethodID(arrayListClass, "add", "(Ljava/lang/Object;)Z");
     jobject list = env->NewObject(arrayListClass, arrayListConstructor);
 
-    jclass nodeStateClass = env->FindClass("app/f3d/F3D/Types$NodeState");
+    JniLocalRef<jclass> nodeStateClass(env, env->FindClass("app/f3d/F3D/Types$NodeState"));
     jmethodID nodeStateConstructor = env->GetMethodID(nodeStateClass, "<init>", "()V");
 
     jfieldID idField = env->GetFieldID(nodeStateClass, "id", "I");
@@ -375,22 +381,20 @@ extern "C"
 
     for (const f3d::node_state_t& cppNodeState : cppNodeStates)
     {
-      jobject jnodeState = env->NewObject(nodeStateClass, nodeStateConstructor);
+      JniLocalRef<jobject> jnodeState(env, env->NewObject(nodeStateClass, nodeStateConstructor));
 
       env->SetIntField(jnodeState, idField, cppNodeState.id);
       env->SetIntField(jnodeState, parentIdField, cppNodeState.parentId);
       env->SetIntField(jnodeState, levelField, cppNodeState.level);
 
-      jstring jlabel = env->NewStringUTF(cppNodeState.label.c_str());
+      JniLocalRef<jstring> jlabel(env, env->NewStringUTF(cppNodeState.label.c_str()));
       env->SetObjectField(jnodeState, labelField, jlabel);
-      env->DeleteLocalRef(jlabel);
 
       env->SetBooleanField(jnodeState, visibleField, cppNodeState.visible);
       env->SetBooleanField(jnodeState, hasChildrenField, cppNodeState.hasChildren);
       env->SetBooleanField(jnodeState, collapsedField, cppNodeState.collapsed);
 
-      env->CallBooleanMethod(list, addMethod, jnodeState);
-      env->DeleteLocalRef(jnodeState);
+      env->CallBooleanMethod(list, addMethod, jnodeState.get());
     }
 
     return list;
@@ -417,10 +421,8 @@ extern "C"
       return false;
     }
 
-    const char* str = env->GetStringUTFChars(filePath, nullptr);
-    bool result = GetEngine(env, self)->getScene().supports(str);
-    env->ReleaseStringUTFChars(filePath, str);
-    return result;
+    JniUTFString str(env, filePath);
+    return GetEngine(env, self)->getScene().supports(str.c_str());
   }
 
   JNIEXPORT jobject JAVA_BIND(Scene, loadAnimationTime)(

--- a/java/F3DTypesBindings.cxx
+++ b/java/F3DTypesBindings.cxx
@@ -20,8 +20,8 @@ extern "C"
 
     if (scaleLen != 2 || translateLen != 2)
     {
-      jclass exceptionClass = env->FindClass("java/lang/IllegalArgumentException");
-      env->ThrowNew(exceptionClass, "Scale and translate arrays must have exactly 2 elements");
+      F3DThrowJavaException(env, "java/lang/IllegalArgumentException",
+        "Scale and translate arrays must have exactly 2 elements");
       return nullptr;
     }
 
@@ -35,12 +35,14 @@ extern "C"
     env->ReleaseDoubleArrayElements(scale, scaleData, 0);
     env->ReleaseDoubleArrayElements(translate, translateData, 0);
 
-    jclass transform2DClass = env->FindClass("app/f3d/F3D/Transform2D");
+    JniLocalRef<jclass> transform2DClass(env, env->FindClass("app/f3d/F3D/Transform2D"));
     jmethodID constructor = env->GetMethodID(transform2DClass, "<init>", "()V");
+    // Not wrapped in JniLocalRef: this is the return value, and its local reference
+    // must remain valid until it crosses back into the JVM after this function returns.
     jobject result = env->NewObject(transform2DClass, constructor);
 
     jfieldID dataField = env->GetFieldID(transform2DClass, "data", "[D");
-    jdoubleArray dataArray = env->NewDoubleArray(9);
+    JniLocalRef<jdoubleArray> dataArray(env, env->NewDoubleArray(9));
     std::vector<double> vec = cppTransform;
     env->SetDoubleArrayRegion(dataArray, 0, 9, vec.data());
     env->SetObjectField(result, dataField, dataArray);
@@ -49,7 +51,7 @@ extern "C"
   }
   JNIEXPORT jobject JAVA_BIND(Types_00024Mesh, isValid)(JNIEnv* env, jobject self)
   {
-    jclass meshClass = env->GetObjectClass(self);
+    JniLocalRef<jclass> meshClass(env, env->GetObjectClass(self));
 
     jfieldID pointsField = env->GetFieldID(meshClass, "points", "[F");
     jfieldID normalsField = env->GetFieldID(meshClass, "normals", "[F");
@@ -120,14 +122,14 @@ extern "C"
 
     auto [valid, errorMessage] = cppMesh.isValid();
 
-    jclass validationResultClass = env->FindClass("app/f3d/F3D/Types$Mesh$ValidationResult");
+    JniLocalRef<jclass> validationResultClass(
+      env, env->FindClass("app/f3d/F3D/Types$Mesh$ValidationResult"));
     jmethodID constructor =
       env->GetMethodID(validationResultClass, "<init>", "(ZLjava/lang/String;)V");
 
-    jstring jErrorMessage = env->NewStringUTF(errorMessage.c_str());
-    jobject result = env->NewObject(validationResultClass, constructor, valid, jErrorMessage);
-
-    env->DeleteLocalRef(jErrorMessage);
+    JniLocalRef<jstring> jErrorMessage(env, env->NewStringUTF(errorMessage.c_str()));
+    jobject result =
+      env->NewObject(validationResultClass, constructor, valid, jErrorMessage.get());
 
     return result;
   }

--- a/java/F3DTypesBindings.cxx
+++ b/java/F3DTypesBindings.cxx
@@ -128,8 +128,7 @@ extern "C"
       env->GetMethodID(validationResultClass, "<init>", "(ZLjava/lang/String;)V");
 
     JniLocalRef<jstring> jErrorMessage(env, env->NewStringUTF(errorMessage.c_str()));
-    jobject result =
-      env->NewObject(validationResultClass, constructor, valid, jErrorMessage.get());
+    jobject result = env->NewObject(validationResultClass, constructor, valid, jErrorMessage.get());
 
     return result;
   }

--- a/java/F3DUtilsBindings.cxx
+++ b/java/F3DUtilsBindings.cxx
@@ -13,13 +13,10 @@ extern "C"
       return 0;
     }
 
-    const char* strAChars = env->GetStringUTFChars(strA, nullptr);
-    const char* strBChars = env->GetStringUTFChars(strB, nullptr);
+    JniUTFString strAChars(env, strA);
+    JniUTFString strBChars(env, strB);
 
-    unsigned int distance = f3d::utils::textDistance(strAChars, strBChars);
-
-    env->ReleaseStringUTFChars(strA, strAChars);
-    env->ReleaseStringUTFChars(strB, strBChars);
+    unsigned int distance = f3d::utils::textDistance(strAChars.c_str(), strBChars.c_str());
 
     return static_cast<jint>(distance);
   }
@@ -32,18 +29,17 @@ extern "C"
       return CreateStringList(env, std::vector<std::string>());
     }
 
-    const char* strChars = env->GetStringUTFChars(str, nullptr);
+    JniUTFString strChars(env, str);
     jobject result = nullptr;
     try
     {
-      result = CreateStringList(env, f3d::utils::tokenize(strChars, keepComments != 0));
+      result = CreateStringList(env, f3d::utils::tokenize(strChars.c_str(), keepComments != 0));
     }
     catch (const std::exception& e)
     {
-      jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
+      JniLocalRef<jclass> exceptionClass(env, env->FindClass("java/lang/RuntimeException"));
       env->ThrowNew(exceptionClass, e.what());
     }
-    env->ReleaseStringUTFChars(str, strChars);
     return result;
   }
 
@@ -55,16 +51,14 @@ extern "C"
       return env->NewStringUTF("");
     }
 
-    const char* pathChars = env->GetStringUTFChars(path, nullptr);
-    std::string pathStr = pathChars;
-    env->ReleaseStringUTFChars(path, pathChars);
+    JniUTFString pathChars(env, path);
+    std::string pathStr = pathChars.c_str();
 
     std::filesystem::path basePath;
     if (baseDirectory)
     {
-      const char* baseDirChars = env->GetStringUTFChars(baseDirectory, nullptr);
-      basePath = baseDirChars;
-      env->ReleaseStringUTFChars(baseDirectory, baseDirChars);
+      JniUTFString baseDirChars(env, baseDirectory);
+      basePath = baseDirChars.c_str();
     }
 
     std::filesystem::path result = f3d::utils::collapsePath(pathStr, basePath);
@@ -79,18 +73,17 @@ extern "C"
       return env->NewStringUTF("");
     }
 
-    const char* globChars = env->GetStringUTFChars(glob, nullptr);
+    JniUTFString globChars(env, glob);
     std::string result;
     try
     {
-      result = f3d::utils::globToRegex(globChars, static_cast<char>(pathSeparator));
+      result = f3d::utils::globToRegex(globChars.c_str(), static_cast<char>(pathSeparator));
     }
     catch (const std::exception& e)
     {
-      jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
+      JniLocalRef<jclass> exceptionClass(env, env->FindClass("java/lang/RuntimeException"));
       env->ThrowNew(exceptionClass, e.what());
     }
-    env->ReleaseStringUTFChars(glob, globChars);
     return env->ExceptionCheck() ? nullptr : env->NewStringUTF(result.c_str());
   }
 
@@ -101,9 +94,8 @@ extern "C"
       return nullptr;
     }
 
-    const char* envVarChars = env->GetStringUTFChars(envVar, nullptr);
-    std::optional<std::string> result = f3d::utils::getEnv(envVarChars);
-    env->ReleaseStringUTFChars(envVar, envVarChars);
+    JniUTFString envVarChars(env, envVar);
+    std::optional<std::string> result = f3d::utils::getEnv(envVarChars.c_str());
 
     return result.has_value() ? env->NewStringUTF(result.value().c_str()) : nullptr;
   }
@@ -115,7 +107,7 @@ extern "C"
       return nullptr;
     }
 
-    jclass enumClass = env->GetObjectClass(knownFolder);
+    JniLocalRef<jclass> enumClass(env, env->GetObjectClass(knownFolder));
     jmethodID getValueMethod = env->GetMethodID(enumClass, "getValue", "()I");
     jint folderValue = env->CallIntMethod(knownFolder, getValueMethod);
 

--- a/java/F3DWindowBindings.cxx
+++ b/java/F3DWindowBindings.cxx
@@ -11,7 +11,7 @@ extern "C"
   {
     f3d::window::Type type = GetEngine(env, self)->getWindow().getType();
 
-    jclass enumClass = env->FindClass("app/f3d/F3D/Window$Type");
+    JniLocalRef<jclass> enumClass(env, env->FindClass("app/f3d/F3D/Window$Type"));
     jfieldID fieldID;
 
     switch (type)
@@ -63,7 +63,7 @@ extern "C"
   {
     f3d::image* img = new f3d::image(GetEngine(env, self)->getWindow().renderToImage(noBackground));
 
-    jclass imageClass = env->FindClass("app/f3d/F3D/Image");
+    JniLocalRef<jclass> imageClass(env, env->FindClass("app/f3d/F3D/Image"));
     jmethodID constructor = env->GetMethodID(imageClass, "<init>", "(J)V");
 
     jobject result = env->NewObject(imageClass, constructor, reinterpret_cast<jlong>(img));
@@ -134,9 +134,8 @@ extern "C"
 
   JNIEXPORT jobject JAVA_BIND(Window, setWindowName)(JNIEnv* env, jobject self, jstring windowName)
   {
-    const char* name = env->GetStringUTFChars(windowName, nullptr);
-    GetEngine(env, self)->getWindow().setWindowName(name);
-    env->ReleaseStringUTFChars(windowName, name);
+    JniUTFString name(env, windowName);
+    GetEngine(env, self)->getWindow().setWindowName(name.c_str());
     return self;
   }
 


### PR DESCRIPTION
### Describe your changes
**Problem**: Java bindings manually managed JNI strings/local refs (GetStringUTFChars / ReleaseStringUTFChars, DeleteLocalRef), which was easy to get wrong and could leak.

Added RAII helpers JniUTFString and JniLocalRef in F3DJavaBindings.h. Updated all java/*.cxx binding files to use those helpers instead of manual allocate/release. 
This also releases some local refs that were never freed before.
### Issue ticket number and link if any
Fixes #3398 
### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [ ] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
