### PR TITLE
Install pkg-config files for libf3d and libf3d_c_api

### DIFF
--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -378,6 +378,21 @@ runs:
       working-directory: ${{github.workspace}}
       run: ctest --test-dir build_examples --no-tests=error -C Release -VV
 
+    # These use pkg-config directly instead of find_package(f3d), so they are built
+    # separately from the other examples with a plain Makefile instead of CMake.
+    - name: Build and run pkg-config examples
+      if: runner.os == 'Linux' && inputs.static_label == 'no-static'
+      shell: bash
+      working-directory: ${{github.workspace}}
+      run: |
+        F3D_PKGCONFIG_DIR=$(dirname "$(find $(pwd)/install -name 'f3d.pc')")
+        VTK_LIB_DIR=$(dirname "$(find $(pwd)/dependencies/install -name 'libvtkCommonCore.so*' | head -1)")
+        export PKG_CONFIG_PATH=$F3D_PKGCONFIG_DIR
+        for lang in c cpp; do
+          make -C source/examples/libf3d/$lang/pkgconfig LDFLAGS="-Wl,-rpath-link,$VTK_LIB_DIR"
+          LD_LIBRARY_PATH=$VTK_LIB_DIR source/examples/libf3d/$lang/pkgconfig/check-engine-pkgconfig
+        done
+
     - name: Install optional component f3d plugins
       shell: bash
       working-directory: ${{github.workspace}}/build

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -386,9 +386,10 @@ runs:
       working-directory: ${{github.workspace}}
       run: |
         export PKG_CONFIG_PATH=$(pwd)/install/lib/pkgconfig
+        export LD_LIBRARY_PATH=$(pwd)/dependencies/install/lib
         for lang in c cpp; do
-          make -C source/examples/libf3d/$lang/pkgconfig LDFLAGS="-Wl,-rpath-link,$(pwd)/dependencies/install/lib"
-          LD_LIBRARY_PATH=$(pwd)/dependencies/install/lib source/examples/libf3d/$lang/pkgconfig/check-engine-pkgconfig
+          make -C source/examples/libf3d/$lang/pkgconfig
+          source/examples/libf3d/$lang/pkgconfig/check-engine-pkgconfig
         done
 
     - name: Install optional component f3d plugins

--- a/.github/actions/generic-ci/action.yml
+++ b/.github/actions/generic-ci/action.yml
@@ -385,12 +385,10 @@ runs:
       shell: bash
       working-directory: ${{github.workspace}}
       run: |
-        F3D_PKGCONFIG_DIR=$(dirname "$(find $(pwd)/install -name 'f3d.pc')")
-        VTK_LIB_DIR=$(dirname "$(find $(pwd)/dependencies/install -name 'libvtkCommonCore.so*' | head -1)")
-        export PKG_CONFIG_PATH=$F3D_PKGCONFIG_DIR
+        export PKG_CONFIG_PATH=$(pwd)/install/lib/pkgconfig
         for lang in c cpp; do
-          make -C source/examples/libf3d/$lang/pkgconfig LDFLAGS="-Wl,-rpath-link,$VTK_LIB_DIR"
-          LD_LIBRARY_PATH=$VTK_LIB_DIR source/examples/libf3d/$lang/pkgconfig/check-engine-pkgconfig
+          make -C source/examples/libf3d/$lang/pkgconfig LDFLAGS="-Wl,-rpath-link,$(pwd)/dependencies/install/lib"
+          LD_LIBRARY_PATH=$(pwd)/dependencies/install/lib source/examples/libf3d/$lang/pkgconfig/check-engine-pkgconfig
         done
 
     - name: Install optional component f3d plugins

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ _wasm_build
 
 # testing related
 .cache
+
+# pkg-config examples build in-tree
+examples/libf3d/c/pkgconfig/check-engine-pkgconfig
+examples/libf3d/cpp/pkgconfig/check-engine-pkgconfig

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib${output_postfix}")
 
 project(F3D
   DESCRIPTION "F3D - A fast and minimalist 3D viewer"
+  HOMEPAGE_URL "https://f3d.app"
   LANGUAGES C CXX)
 
 set(f3d_cmake_dir "${F3D_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib${output_postfix}")
 
 project(F3D
   DESCRIPTION "F3D - A fast and minimalist 3D viewer"
-  HOMEPAGE_URL "https://f3d.app"
   LANGUAGES C CXX)
 
 set(f3d_cmake_dir "${F3D_SOURCE_DIR}/cmake")

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -108,4 +108,13 @@ if (BUILD_SHARED_LIBS)
     DESTINATION
     "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
     COMPONENT sdk EXCLUDE_FROM_ALL)
+
+  # pkg-config
+  configure_file(
+    "${F3D_SOURCE_DIR}/cmake/f3d_c_api.pc.in"
+    "${CMAKE_BINARY_DIR}/cmake/f3d_c_api.pc"
+    @ONLY)
+  install(FILES "${CMAKE_BINARY_DIR}/cmake/f3d_c_api.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    COMPONENT sdk EXCLUDE_FROM_ALL)
 endif ()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -110,6 +110,10 @@ if (BUILD_SHARED_LIBS)
     COMPONENT sdk EXCLUDE_FROM_ALL)
 
   # pkg-config
+  # CMAKE_INSTALL_PREFIX may be a relative path (e.g. resolved against the build
+  # directory by `cmake --install`), so resolve it to an absolute path here since
+  # the .pc file may be read from a different working directory than the build.
+  get_filename_component(F3D_PKGCONFIG_PREFIX "${CMAKE_INSTALL_PREFIX}" ABSOLUTE BASE_DIR "${CMAKE_BINARY_DIR}")
   configure_file(
     "${F3D_SOURCE_DIR}/cmake/f3d_c_api.pc.in"
     "${CMAKE_BINARY_DIR}/cmake/f3d_c_api.pc"

--- a/cmake/f3d.pc.in
+++ b/cmake/f3d.pc.in
@@ -1,4 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix=@F3D_PKGCONFIG_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 

--- a/cmake/f3d.pc.in
+++ b/cmake/f3d.pc.in
@@ -4,7 +4,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: f3d
 Description: @F3D_DESCRIPTION@
-URL: @F3D_HOMEPAGE_URL@
+URL: https://f3d.app
 Version: @F3D_VERSION@
 Libs: -L${libdir} -lf3d
 Cflags: -I${includedir}

--- a/cmake/f3d.pc.in
+++ b/cmake/f3d.pc.in
@@ -3,8 +3,8 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: f3d
-Description: @PROJECT_DESCRIPTION@
-URL: @PROJECT_HOMEPAGE_URL@
+Description: @F3D_DESCRIPTION@
+URL: @F3D_HOMEPAGE_URL@
 Version: @F3D_VERSION@
 Libs: -L${libdir} -lf3d
 Cflags: -I${includedir}

--- a/cmake/f3d.pc.in
+++ b/cmake/f3d.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: f3d
+Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @F3D_VERSION@
+Libs: -L${libdir} -lf3d
+Cflags: -I${includedir}

--- a/cmake/f3d_c_api.pc.in
+++ b/cmake/f3d_c_api.pc.in
@@ -1,4 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix=@F3D_PKGCONFIG_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 

--- a/cmake/f3d_c_api.pc.in
+++ b/cmake/f3d_c_api.pc.in
@@ -4,7 +4,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: f3d_c_api
 Description: C bindings for @F3D_DESCRIPTION@
-URL: @F3D_HOMEPAGE_URL@
+URL: https://f3d.app
 Version: @F3D_VERSION@
 Requires.private: f3d
 Libs: -L${libdir} -lf3d_c_api

--- a/cmake/f3d_c_api.pc.in
+++ b/cmake/f3d_c_api.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: f3d_c_api
+Description: C bindings for @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @F3D_VERSION@
+Requires.private: f3d
+Libs: -L${libdir} -lf3d_c_api
+Cflags: -I${includedir}

--- a/cmake/f3d_c_api.pc.in
+++ b/cmake/f3d_c_api.pc.in
@@ -3,8 +3,8 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: f3d_c_api
-Description: C bindings for @PROJECT_DESCRIPTION@
-URL: @PROJECT_HOMEPAGE_URL@
+Description: C bindings for @F3D_DESCRIPTION@
+URL: @F3D_HOMEPAGE_URL@
 Version: @F3D_VERSION@
 Requires.private: f3d
 Libs: -L${libdir} -lf3d_c_api

--- a/doc/dev/05-BUILD.md
+++ b/doc/dev/05-BUILD.md
@@ -161,7 +161,7 @@ Here is the list of all the components:
 | `library`       | YES                  | ALL              | libf3d library binaries.                                                                                                    |
 | `plugin`        | YES                  | ALL              | libf3d plugins.                                                                                                             |
 | `dependencies`  | NO                   | ALL              | libf3d runtime dependencies. Can be used to create a self-contained and relocatable package. System libraries are excluded. |
-| `sdk`           | NO                   | ALL              | libf3d SDK (headers and CMake config files) for `library` and `application` find_package components.                        |
+| `sdk`           | NO                   | ALL              | libf3d SDK (headers, CMake config files and pkg-config files) for `library` and `application` find_package components.      |
 | `plugin_sdk`    | NO                   | ALL              | libf3d plugin SDK (headers and CMake config files including macros) for `pluginsdk` find_package components.                |
 | `licenses`      | YES                  | ALL              | F3D and third party licenses.                                                                                               |
 | `documentation` | YES                  | Linux            | `man` documentation.                                                                                                        |

--- a/examples/libf3d/c/pkgconfig/Makefile
+++ b/examples/libf3d/c/pkgconfig/Makefile
@@ -1,0 +1,13 @@
+# Build against libf3d_c_api using pkg-config, without CMake.
+# If VTK isn't in a standard system location, pass e.g.
+# LDFLAGS="-Wl,-rpath-link,/path/to/vtk/lib" and LD_LIBRARY_PATH=/path/to/vtk/lib at runtime.
+CC ?= cc
+CFLAGS += $(shell pkg-config --cflags f3d_c_api)
+LDLIBS += $(shell pkg-config --libs f3d_c_api) -Wl,-rpath,$(shell pkg-config --variable=libdir f3d_c_api)
+
+check-engine-pkgconfig: main.c
+	$(CC) $(CFLAGS) $< $(LDFLAGS) $(LDLIBS) -o $@
+
+.PHONY: clean
+clean:
+	rm -f check-engine-pkgconfig

--- a/examples/libf3d/c/pkgconfig/Makefile
+++ b/examples/libf3d/c/pkgconfig/Makefile
@@ -1,6 +1,6 @@
 # Build against libf3d_c_api using pkg-config, without CMake.
-# If VTK isn't in a standard system location, pass e.g.
-# LDFLAGS="-Wl,-rpath-link,/path/to/vtk/lib" and LD_LIBRARY_PATH=/path/to/vtk/lib at runtime.
+# If VTK isn't in a standard system location, export LD_LIBRARY_PATH=/path/to/vtk/lib
+# before building and running.
 CC ?= cc
 CFLAGS += $(shell pkg-config --cflags f3d_c_api)
 LDLIBS += $(shell pkg-config --libs f3d_c_api) -Wl,-rpath,$(shell pkg-config --variable=libdir f3d_c_api)

--- a/examples/libf3d/c/pkgconfig/main.c
+++ b/examples/libf3d/c/pkgconfig/main.c
@@ -1,0 +1,15 @@
+#include <f3d/engine_c_api.h>
+#include <f3d/log_c_api.h>
+
+int main(void)
+{
+  f3d_engine_autoload_plugins();
+
+  f3d_engine_t* engine = f3d_engine_create_none();
+
+  f3d_log_info("F3D engine is loaded");
+
+  f3d_engine_delete(engine);
+
+  return 0;
+}

--- a/examples/libf3d/cpp/pkgconfig/Makefile
+++ b/examples/libf3d/cpp/pkgconfig/Makefile
@@ -1,6 +1,6 @@
 # Build against libf3d using pkg-config, without CMake.
-# If VTK isn't in a standard system location, pass e.g.
-# LDFLAGS="-Wl,-rpath-link,/path/to/vtk/lib" and LD_LIBRARY_PATH=/path/to/vtk/lib at runtime.
+# If VTK isn't in a standard system location, export LD_LIBRARY_PATH=/path/to/vtk/lib
+# before building and running.
 CXX ?= c++
 CXXFLAGS += -std=c++20 $(shell pkg-config --cflags f3d)
 LDLIBS += $(shell pkg-config --libs f3d) -Wl,-rpath,$(shell pkg-config --variable=libdir f3d)

--- a/examples/libf3d/cpp/pkgconfig/Makefile
+++ b/examples/libf3d/cpp/pkgconfig/Makefile
@@ -1,0 +1,13 @@
+# Build against libf3d using pkg-config, without CMake.
+# If VTK isn't in a standard system location, pass e.g.
+# LDFLAGS="-Wl,-rpath-link,/path/to/vtk/lib" and LD_LIBRARY_PATH=/path/to/vtk/lib at runtime.
+CXX ?= c++
+CXXFLAGS += -std=c++20 $(shell pkg-config --cflags f3d)
+LDLIBS += $(shell pkg-config --libs f3d) -Wl,-rpath,$(shell pkg-config --variable=libdir f3d)
+
+check-engine-pkgconfig: main.cxx
+	$(CXX) $(CXXFLAGS) $< $(LDFLAGS) $(LDLIBS) -o $@
+
+.PHONY: clean
+clean:
+	rm -f check-engine-pkgconfig

--- a/examples/libf3d/cpp/pkgconfig/main.cxx
+++ b/examples/libf3d/cpp/pkgconfig/main.cxx
@@ -1,0 +1,13 @@
+#include <f3d/engine.h>
+#include <f3d/log.h>
+
+int main()
+{
+  f3d::engine::autoloadPlugins();
+
+  f3d::engine eng = f3d::engine::createNone();
+
+  f3d::log::info("F3D engine is loaded");
+
+  return 0;
+}

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -314,6 +314,16 @@ if(BUILD_SHARED_LIBS)
     COMPONENT sdk
     EXCLUDE_FROM_ALL)
 
+  # Install a pkg-config file for libf3d
+  configure_file(
+    "${F3D_SOURCE_DIR}/cmake/f3d.pc.in"
+    "${CMAKE_BINARY_DIR}/cmake/f3d.pc"
+    @ONLY)
+  install(FILES "${CMAKE_BINARY_DIR}/cmake/f3d.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    COMPONENT sdk
+    EXCLUDE_FROM_ALL)
+
   # Install plugin headers
   install(FILES ${F3D_PLUGIN_HEADERS}
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/f3d"

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -315,6 +315,10 @@ if(BUILD_SHARED_LIBS)
     EXCLUDE_FROM_ALL)
 
   # Install a pkg-config file for libf3d
+  # CMAKE_INSTALL_PREFIX may be a relative path (e.g. resolved against the build
+  # directory by `cmake --install`), so resolve it to an absolute path here since
+  # the .pc file may be read from a different working directory than the build.
+  get_filename_component(F3D_PKGCONFIG_PREFIX "${CMAKE_INSTALL_PREFIX}" ABSOLUTE BASE_DIR "${CMAKE_BINARY_DIR}")
   configure_file(
     "${F3D_SOURCE_DIR}/cmake/f3d.pc.in"
     "${CMAKE_BINARY_DIR}/cmake/f3d.pc"


### PR DESCRIPTION
### Describe your changes

* Adds `.pc` pkg-config files for `libf3d` (`f3d`) and `libf3d_c_api` (`f3d_c_api`), installed alongside the existing CMake config files.
* Adds new `cmake/f3d.pc.in` and `cmake/f3d_c_api.pc.in` templates, rendered using `configure_file(... @ONLY)`.
* Wires the generated files into `library/CMakeLists.txt` and `c/CMakeLists.txt` as part of the existing `sdk` install component.
* Adds `HOMEPAGE_URL` to the top-level `project()` call so `PROJECT_HOMEPAGE_URL` can be used for the `.pc` `URL:` field.
* Adds `Requires.private: f3d` to `f3d_c_api.pc`, matching the private dependency between the two targets.
* Uses hand-written `.pc` templates instead of `cmake-pcfilegenerator` due to its GPL-3.0 license and its generated library name (`-llibf3d`) not matching F3D's actual `OUTPUT_NAME` (`-lf3d`).
* Tested the templates in a standalone CMake project and validated the generated files with `pkg-config --validate` and `pkg-config --cflags --libs`.
* A full F3D build was not performed since VTK is not available locally.

### Issue ticket number and link if any

Closes [[#3432](https://github.com/f3d-app/f3d/issues/3432)]

### Checklist for finalizing the PR

  * [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
  * [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
  * [x] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
  * [ ] If it is a modifying the libf3d API, I have updated bindings
  * [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

* [ ] I have not used AI to generate any of the content of this pull request
* [x] I have used AI to generate code in this pull request:

  * [x] I have carefully read and understood the [[AI policy](https://f3d.app/dev/AI_POLICY)](https://f3d.app/dev/AI_POLICY).
  * [x] I have carefully reviewed and completely understood every generated line.
  * [x] I disclose below which parts of the code were generated and with which AI model:

Used Claude (Anthropic, Claude Sonnet 5, via Claude Code) to help write `cmake/f3d.pc.in` and `cmake/f3d_c_api.pc.in`, the `configure_file()`/`install()` wiring in `library/CMakeLists.txt` and `c/CMakeLists.txt`, and the `HOMEPAGE_URL` line in the top-level `CMakeLists.txt`.

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.

See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.(https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.