### PR TITLE
#3233 : Re-added support to dxf r12 format. Now ignores leading whitespaces

### DIFF
--- a/plugins/assimp/module/vtkF3DAssimpImporter.cxx
+++ b/plugins/assimp/module/vtkF3DAssimpImporter.cxx
@@ -45,6 +45,9 @@
 #include <regex>
 #include <set>
 #include <unordered_map>
+#include <string>
+#include <algorithm>
+#include <cctype>
 
 vtkStandardNewMacro(vtkF3DAssimpImporter);
 
@@ -1474,8 +1477,14 @@ bool vtkF3DAssimpImporter::CanReadFile(vtkResourceStream* stream, std::string& h
     parser->ReadLine(line3) == vtkParseResult::EndOfLine &&
     parser->ReadLine(line4) == vtkParseResult::EndOfLine)
   {
+    
+    line1.erase(line1.begin(), std::find_if(line1.begin(),line1.end(), [] (unsigned char ch) {return !std::isspace(ch);}));
+    line2.erase(line2.begin(), std::find_if(line2.begin(),line2.end(), [] (unsigned char ch) {return !std::isspace(ch);}));
+    line3.erase(line3.begin(), std::find_if(line3.begin(),line3.end(), [] (unsigned char ch) {return !std::isspace(ch);}));
+    line4.erase(line4.begin(), std::find_if(line4.begin(),line4.end(), [] (unsigned char ch) {return !std::isspace(ch);}));
+
     if (line1.starts_with("0") && line2.starts_with("SECTION") && line3.starts_with("2") &&
-      line4.starts_with("HEADER"))
+      ((line4.starts_with("HEADER")) || line4.starts_with("ENTITIES")))
     {
       hint = "dxf";
       return true;


### PR DESCRIPTION
…spaces

### Describe your changes
Added support for .dxf r12 structure to pass vtkF3DAssimpImporter::CanReadFile function. In addition to it, the function now also ignores leading whitespaces in the file.   

### Issue ticket number and link if any
https://github.com/f3d-app/f3d/issues/3233 - Issue : 3233

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I have not used AI to generate any of the content of this pull request
- [] I have used AI to generate code in this pull request:
  - [x] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:

...

### Continuous integration
\ci fast
Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
