### PR TITLE
Optimize offscreen loading / 32-bit cells

### DIFF
--- a/library/src/init.cxx
+++ b/library/src/init.cxx
@@ -12,6 +12,7 @@
 #include "vtkF3DWebPReader.h"
 #endif
 
+#include <vtkCellArray.h>
 #include <vtkImageReader2Factory.h>
 #include <vtkLogger.h>
 #include <vtkNew.h>
@@ -44,6 +45,7 @@ init::init()
   vtkLogger::SetInternalVerbosityLevel(vtkLogger::VERBOSITY_OFF);
 
   vtkOpenGLVertexBufferObject::SetGlobalCoordShiftAndScaleEnabled(0);
+  vtkCellArray::SetDefaultStorageIs64Bit(false);
 
   // instantiate our own polydata mapper and output windows
   vtkNew<vtkF3DObjectFactory> factory;

--- a/library/src/scene_impl.cxx
+++ b/library/src/scene_impl.cxx
@@ -131,7 +131,7 @@ public:
     scene_impl::internals::ProgressDataStruct callbackData;
     callbackData.timer = timer;
     callbackData.widget = progressWidget;
-    if (this->Interactor)
+    if (this->Interactor && !this->Window.isOffscreen())
     {
       f3d::color_t color = this->Options.ui.loader_progress_color;
       scene_impl::internals::CreateProgressRepresentationAndCallback(


### PR DESCRIPTION
### Describe your changes

- Use 32-bits cells in order to skip IBO preprocess
- Do not observe progress when offscreen

### Issue ticket number and link if any

Related: #3446 

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [ ] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
