### PR TITLE
Divide window geometry by dpi scale when saving

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -1304,14 +1304,17 @@ public:
   }
 
   /* Record the current window geometry, which can only be queried while the window is still
-   * alive.
+   * alive. The size is recorded in the same unit as the resolution option, which is scaled by the
+   * DPI when applied, so that restoring it does not scale it a second time.
    */
   void RecordWindowGeometry()
   {
-    const f3d::window& window = this->Engine->getWindow();
+    f3d::window& window = this->Engine->getWindow();
     const auto [width, height] = window.getSize();
     const auto [left, top] = window.getPosition();
-    this->LastWindowGeometry = { width, height, left, top };
+    const double dpiScale = window.getDPIScale();
+    this->LastWindowGeometry = { static_cast<int>(std::lround(width / dpiScale)),
+      static_cast<int>(std::lround(height / dpiScale)), left, top };
   }
 
   /* Store the last recorded window geometry in the cache so that the next run can restore it */
@@ -1339,7 +1342,9 @@ public:
     root["window"] = windowJson;
 
     stream << root.dump(2);
-    f3d::log::debug("Window geometry cached in ", cachePath.string());
+    f3d::log::debug("Window geometry ", this->LastWindowGeometry.Width, "x",
+      this->LastWindowGeometry.Height, " at ", this->LastWindowGeometry.Left, ",",
+      this->LastWindowGeometry.Top, " cached in ", cachePath.string());
   }
 
   struct WindowGeometry


### PR DESCRIPTION
### Describe your changes

Fix window geometry saving bug by dividing window geometry by dpi scale when saving

### Issue ticket number and link if any

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [x] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [ ] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
