### PR TITLE
Fix Non-PBR unlit model does not convert to PBR

### DIFF
--- a/vtkext/private/module/vtkF3DMetaImporter.cxx
+++ b/vtkext/private/module/vtkF3DMetaImporter.cxx
@@ -496,30 +496,29 @@ bool vtkF3DMetaImporter::Update()
           diffuseTex->SetColorModeToDirectScalars();
         }
 
-        if (actor->GetProperty()->GetLighting())
+        // if (actor->GetProperty()->GetLighting())
+        
+        actor->GetProperty()->SetInterpolationToPBR();
+
+        // Convert to linear space
+        auto toLinear = [](double c) { return std::pow(c, 2.2); };
+        double diffuseColor[3];
+        actor->GetProperty()->GetDiffuseColor(diffuseColor);
+        actor->GetProperty()->SetDiffuseColor(
+          toLinear(diffuseColor[0]), toLinear(diffuseColor[1]), toLinear(diffuseColor[2]));
+
+        // restore diffuse/specular to 1 and ambient to 0
+        actor->GetProperty()->SetSpecular(1.0);
+        actor->GetProperty()->SetDiffuse(1.0);
+        actor->GetProperty()->SetAmbient(0.0);
+
+        if (diffuseTex)
         {
-          actor->GetProperty()->SetInterpolationToPBR();
-
-          // Convert to linear space
-          auto toLinear = [](double c) { return std::pow(c, 2.2); };
-          double diffuseColor[3];
-          actor->GetProperty()->GetDiffuseColor(diffuseColor);
-          actor->GetProperty()->SetDiffuseColor(
-            toLinear(diffuseColor[0]), toLinear(diffuseColor[1]), toLinear(diffuseColor[2]));
-
-          // restore diffuse/specular to 1 and ambient to 0
-          actor->GetProperty()->SetSpecular(1.0);
-          actor->GetProperty()->SetDiffuse(1.0);
-          actor->GetProperty()->SetAmbient(0.0);
-
-          if (diffuseTex)
-          {
-            actor->SetTexture(nullptr);
-            actor->GetProperty()->SetColor(1.0, 1.0, 1.0);
-            actor->GetProperty()->SetBaseColorTexture(diffuseTex);
-            actor->GetProperty()->SetTexture("diffuseTex", nullptr);
-          }
+          actor->SetTexture(nullptr);
+          actor->GetProperty()->SetColor(1.0, 1.0, 1.0);
+          actor->GetProperty()->SetBaseColorTexture(diffuseTex);
         }
+        
       }
 
       // Increase bounding box size if needed


### PR DESCRIPTION
### Describe your changes
I changed the check in vtkF3DMetaImporter.cxx that converts to PBR model. This ensures that the model gets converted to PBR when loaded and so after doing `toggle.model` twice, the model is PBR.

### Issue ticket number and link if any
2995. https://github.com/f3d-app/f3d/issues/2995

### Checklist for finalizing the PR

- [ ] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [ ] I have not used AI to generate any of the content of this pull request
- [ ] I have used AI to generate code in this pull request:
  - [ ] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [ ] I have carefully reviewed and completely understood every generated line.
  - [ ] I disclose below which parts of the code were generated and with which AI model:

...

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
