### PR TITLE
Add missing wasm bindings

### DIFF
--- a/doc/libf3d/04-LANGUAGE_BINDINGS.md
+++ b/doc/libf3d/04-LANGUAGE_BINDINGS.md
@@ -142,14 +142,6 @@ f3d(settings)
   });
 ```
 
-Some advanced libf3d API are not bound yet, here's the exhaustive list:
-
-- `f3d::scene`: light related functions
-- `f3d::scene`: `scene& add(const mesh_t& mesh)`
-- `f3d::camera`: state management
-- `f3d::interactor`: bindings related functions
-- `f3d::interactor`: `playInteraction` and `recordInteraction`
-
 ## Java
 
 If the Java bindings have been generated using the `F3D_BINDINGS_JAVA` CMake option, the libf3d can be used directly from Java >= 17.

--- a/library/src/interactor_impl.cxx
+++ b/library/src/interactor_impl.cxx
@@ -613,6 +613,7 @@ public:
       this->CommandBuffer.reset();
     }
 
+    this->AnimationManager->UpdateDynamicOptions();
     this->AnimationManager->SetDeltaTime(deltaTime);
     this->AnimationManager->Tick();
 

--- a/testing/baselines/TestWasmAnimation.png
+++ b/testing/baselines/TestWasmAnimation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81a9fe70dbe440beb51aa59b3c5cb8dc4f57f0742c63a1f84d76c37c1df4780b
-size 35160
+oid sha256:9d5af7030c0e4b831fc57afd023da6a4b64e37a26263e9f95a3cf8f3d57c781e
+size 23259

--- a/testing/baselines/TestWasmInteraction.png
+++ b/testing/baselines/TestWasmInteraction.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54646d78614adc1a14a12d053748da225eda888d49693243a8f440f99eff3061
-size 11866
+oid sha256:9912965d51ca3009f69156ceaf5ce3f8f259df2b23d1cc5e95a94b10bd9c0d3c
+size 14556

--- a/testing/baselines/TestWasmMeshView.png
+++ b/testing/baselines/TestWasmMeshView.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6e90afbfc13ac7e32ef71c418608a7d0dd6ace0605c4f6437373aa87a6119de
+size 17676

--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -1,6 +1,7 @@
 #include <emscripten/bind.h>
 
 #include <array>
+#include <memory>
 #include <stdexcept>
 
 #include "camera.h"
@@ -53,6 +54,77 @@ emscripten::val pairToJSArray(const std::pair<U, V>& p)
   jsArray.call<void>("push", p.second);
   return jsArray;
 }
+
+struct wasm_mesh_view : public f3d::mesh_view
+{
+  // not time support with wasm
+  std::array<double, 2> getTimeRange() const override
+  {
+    return { 0.0, 0.0 };
+  }
+
+  std::string getName() const override
+  {
+    return this->Name;
+  }
+
+  memory_view_t getMemoryView(double) const override
+  {
+    memory_view_t view;
+
+    view.pointCount = this->PointCount;
+
+    view.points.name = "points";
+    view.points.type = data_type::F32;
+    view.points.data = this->Points.empty() ? nullptr : this->Points.data();
+    view.points.components = 3;
+    view.points.stride = 3;
+    view.points.timeDependent = false;
+
+    view.normals.name = "normals";
+    view.normals.type = data_type::F32;
+    view.normals.data = this->Normals.empty() ? nullptr : this->Normals.data();
+    view.normals.components = 3;
+    view.normals.stride = 3;
+    view.normals.timeDependent = false;
+
+    view.textureCoordinates.name = "textureCoordinates";
+    view.textureCoordinates.type = data_type::F32;
+    view.textureCoordinates.data =
+      this->TextureCoordinates.empty() ? nullptr : this->TextureCoordinates.data();
+    view.textureCoordinates.components = 2;
+    view.textureCoordinates.stride = 2;
+    view.textureCoordinates.timeDependent = false;
+
+    view.polygons.offsetCount = this->PolygonOffsets.empty() ? 1 : this->PolygonOffsets.size();
+    view.polygons.offsets.name = "polygonOffsets";
+    view.polygons.offsets.type = data_type::U32;
+    view.polygons.offsets.data =
+      this->PolygonOffsets.empty() ? nullptr : this->PolygonOffsets.data();
+    view.polygons.offsets.components = 1;
+    view.polygons.offsets.stride = 1;
+    view.polygons.offsets.timeDependent = false;
+
+    view.polygons.indexCount = this->PolygonIndices.size();
+    view.polygons.indices.name = "polygonIndices";
+    view.polygons.indices.type = data_type::U32;
+    view.polygons.indices.data =
+      this->PolygonIndices.empty() ? nullptr : this->PolygonIndices.data();
+    view.polygons.indices.components = 1;
+    view.polygons.indices.stride = 1;
+    view.polygons.indices.timeDependent = false;
+
+    return view;
+  }
+
+  std::string Name;
+  size_t PointCount = 0;
+  std::vector<float> Points;
+  std::vector<float> Normals;
+  std::vector<float> TextureCoordinates;
+  std::vector<unsigned int> PolygonOffsets;
+  std::vector<unsigned int> PolygonIndices;
+};
 
 EMSCRIPTEN_BINDINGS(f3d)
 {
@@ -305,6 +377,45 @@ EMSCRIPTEN_BINDINGS(f3d)
     .function(
       "addMesh", +[](f3d::scene& scene, f3d::mesh_t& mesh) -> f3d::scene&
       { return scene.add(mesh); }, emscripten::return_value_policy::reference())
+    .function(
+      "addMeshView",
+      +[](f3d::scene& scene, emscripten::val mesh) -> f3d::scene&
+      {
+        auto wrapped = std::make_shared<wasm_mesh_view>();
+        if (mesh.hasOwnProperty("name"))
+        {
+          wrapped->Name = mesh["name"].as<std::string>();
+        }
+        if (mesh.hasOwnProperty("pointCount"))
+        {
+          wrapped->PointCount = mesh["pointCount"].as<size_t>();
+        }
+        if (mesh.hasOwnProperty("points"))
+        {
+          wrapped->Points = emscripten::vecFromJSArray<float>(mesh["points"]);
+        }
+        if (mesh.hasOwnProperty("normals"))
+        {
+          wrapped->Normals = emscripten::vecFromJSArray<float>(mesh["normals"]);
+        }
+        if (mesh.hasOwnProperty("textureCoordinates"))
+        {
+          wrapped->TextureCoordinates =
+            emscripten::vecFromJSArray<float>(mesh["textureCoordinates"]);
+        }
+        if (mesh.hasOwnProperty("polygonOffsets"))
+        {
+          wrapped->PolygonOffsets =
+            emscripten::vecFromJSArray<unsigned int>(mesh["polygonOffsets"]);
+        }
+        if (mesh.hasOwnProperty("polygonIndices"))
+        {
+          wrapped->PolygonIndices =
+            emscripten::vecFromJSArray<unsigned int>(mesh["polygonIndices"]);
+        }
+        return scene.add(wrapped);
+      },
+      emscripten::return_value_policy::reference())
     .function(
       "addBuffer",
       +[](f3d::scene& scene, emscripten::val jsbuf) -> f3d::scene&

--- a/webassembly/F3DEmscriptenBindings.cxx
+++ b/webassembly/F3DEmscriptenBindings.cxx
@@ -56,6 +56,85 @@ emscripten::val pairToJSArray(const std::pair<U, V>& p)
 
 EMSCRIPTEN_BINDINGS(f3d)
 {
+  // types
+  emscripten::value_array<f3d::point3_t>("Point3")
+    .element(emscripten::index<0>())
+    .element(emscripten::index<1>())
+    .element(emscripten::index<2>());
+
+  emscripten::value_array<f3d::vector3_t>("Vector3")
+    .element(emscripten::index<0>())
+    .element(emscripten::index<1>())
+    .element(emscripten::index<2>());
+
+  emscripten::class_<f3d::color_t>("Color")
+    .constructor<double, double, double>()
+    .property("r", &f3d::color_t::r)
+    .property("g", &f3d::color_t::g)
+    .property("b", &f3d::color_t::b);
+
+  emscripten::enum_<f3d::light_type>("LightType")
+    .value("HEADLIGHT", f3d::light_type::HEADLIGHT)
+    .value("CAMERA_LIGHT", f3d::light_type::CAMERA_LIGHT)
+    .value("SCENE_LIGHT", f3d::light_type::SCENE_LIGHT);
+
+  emscripten::class_<f3d::light_state_t>("LightState")
+    .constructor<>()
+    .property("type", &f3d::light_state_t::type)
+    .property("position", &f3d::light_state_t::position)
+    .property("color", &f3d::light_state_t::color)
+    .property("direction", &f3d::light_state_t::direction)
+    .property("positionalLight", &f3d::light_state_t::positionalLight)
+    .property("intensity", &f3d::light_state_t::intensity)
+    .property("switchState", &f3d::light_state_t::switchState);
+
+  emscripten::class_<f3d::mesh_t>("Mesh")
+    .constructor<>()
+    .property(
+      "points",
+      +[](const f3d::mesh_t& mesh) -> emscripten::val {
+        return emscripten::val(
+          emscripten::typed_memory_view(mesh.points.size(), mesh.points.data()));
+      },
+      +[](f3d::mesh_t& mesh, emscripten::val jsArray)
+      { mesh.points = emscripten::convertJSArrayToNumberVector<float>(jsArray); })
+    .property(
+      "normals",
+      +[](const f3d::mesh_t& mesh) -> emscripten::val
+      {
+        return emscripten::val(
+          emscripten::typed_memory_view(mesh.normals.size(), mesh.normals.data()));
+      },
+      +[](f3d::mesh_t& mesh, emscripten::val jsArray)
+      { mesh.normals = emscripten::convertJSArrayToNumberVector<float>(jsArray); })
+    .property(
+      "textureCoordinates",
+      +[](const f3d::mesh_t& mesh) -> emscripten::val
+      {
+        return emscripten::val(emscripten::typed_memory_view(
+          mesh.texture_coordinates.size(), mesh.texture_coordinates.data()));
+      },
+      +[](f3d::mesh_t& mesh, emscripten::val jsArray)
+      { mesh.texture_coordinates = emscripten::convertJSArrayToNumberVector<float>(jsArray); })
+    .property(
+      "faceSides",
+      +[](const f3d::mesh_t& mesh) -> emscripten::val
+      {
+        return emscripten::val(
+          emscripten::typed_memory_view(mesh.face_sides.size(), mesh.face_sides.data()));
+      },
+      +[](f3d::mesh_t& mesh, emscripten::val jsArray)
+      { mesh.face_sides = emscripten::convertJSArrayToNumberVector<unsigned int>(jsArray); })
+    .property(
+      "faceIndices",
+      +[](const f3d::mesh_t& mesh) -> emscripten::val
+      {
+        return emscripten::val(
+          emscripten::typed_memory_view(mesh.face_indices.size(), mesh.face_indices.data()));
+      },
+      +[](f3d::mesh_t& mesh, emscripten::val jsArray)
+      { mesh.face_indices = emscripten::convertJSArrayToNumberVector<unsigned int>(jsArray); });
+
   // f3d::options
   emscripten::enum_<f3d::options::domain_style>("OptionsDomainStyle")
     .value("RANGE", f3d::options::domain_style::RANGE)
@@ -200,9 +279,6 @@ EMSCRIPTEN_BINDINGS(f3d)
       { return o.cycle(name); }, emscripten::return_value_policy::reference());
 
   // f3d::scene
-  // TODO:
-  // - add lights support
-  // - add f3d::mesh_t support
   emscripten::enum_<f3d::file_availability>("FileAvailability")
     .value("SUPPORTED", f3d::file_availability::SUPPORTED)
     .value("UNSUPPORTED_EXTENSION", f3d::file_availability::UNSUPPORTED_EXTENSION)
@@ -227,6 +303,9 @@ EMSCRIPTEN_BINDINGS(f3d)
       },
       emscripten::return_value_policy::reference())
     .function(
+      "addMesh", +[](f3d::scene& scene, f3d::mesh_t& mesh) -> f3d::scene&
+      { return scene.add(mesh); }, emscripten::return_value_policy::reference())
+    .function(
       "addBuffer",
       +[](f3d::scene& scene, emscripten::val jsbuf) -> f3d::scene&
       {
@@ -246,6 +325,13 @@ EMSCRIPTEN_BINDINGS(f3d)
         }
         return containerToJSArray(files);
       })
+    .function("addLight", &f3d::scene::addLight)
+    .function("getLightCount", &f3d::scene::getLightCount)
+    .function("getLight", &f3d::scene::getLight)
+    .function("updateLight", &f3d::scene::updateLight, emscripten::return_value_policy::reference())
+    .function("removeLight", &f3d::scene::removeLight, emscripten::return_value_policy::reference())
+    .function(
+      "removeAllLights", &f3d::scene::removeAllLights, emscripten::return_value_policy::reference())
     .function("loadAnimationTime", &f3d::scene::loadAnimationTime,
       emscripten::return_value_policy::reference())
     .function(
@@ -369,31 +455,30 @@ EMSCRIPTEN_BINDINGS(f3d)
       { return containerToJSArray(img.allMetadata()); });
 
   // f3d::camera
-  // TODO:
-  // - camera state
+  emscripten::class_<f3d::camera_state_t>("CameraState")
+    .constructor<>()
+    .property("position", &f3d::camera_state_t::position)
+    .property("focalPoint", &f3d::camera_state_t::focalPoint)
+    .property("viewUp", &f3d::camera_state_t::viewUp)
+    .property("viewAngle", &f3d::camera_state_t::viewAngle);
+
   emscripten::class_<f3d::camera>("Camera")
     .property(
-      "position", +[](const f3d::camera& cam) -> emscripten::val
-      { return containerToJSArray(cam.getPosition()); },
-      +[](f3d::camera& cam, emscripten::val jsArray) {
-        cam.setPosition({ jsArray[0].as<float>(), jsArray[1].as<float>(), jsArray[2].as<float>() });
-      })
+      "position", +[](const f3d::camera& cam) -> f3d::point3_t { return cam.getPosition(); },
+      +[](f3d::camera& cam, const f3d::point3_t& position) { cam.setPosition(position); })
     .property(
-      "focalPoint", +[](const f3d::camera& cam) -> emscripten::val
-      { return containerToJSArray(cam.getFocalPoint()); },
-      +[](f3d::camera& cam, emscripten::val jsArray) {
-        cam.setFocalPoint(
-          { jsArray[0].as<float>(), jsArray[1].as<float>(), jsArray[2].as<float>() });
-      })
+      "focalPoint", +[](const f3d::camera& cam) -> f3d::point3_t { return cam.getFocalPoint(); },
+      +[](f3d::camera& cam, const f3d::point3_t& focalPoint) { cam.setFocalPoint(focalPoint); })
     .property(
-      "viewUp", +[](const f3d::camera& cam) -> emscripten::val
-      { return containerToJSArray(cam.getViewUp()); },
-      +[](f3d::camera& cam, emscripten::val jsArray) {
-        cam.setViewUp({ jsArray[0].as<float>(), jsArray[1].as<float>(), jsArray[2].as<float>() });
-      })
+      "viewUp", +[](const f3d::camera& cam) -> f3d::vector3_t { return cam.getViewUp(); },
+      +[](f3d::camera& cam, f3d::vector3_t viewUp) { cam.setViewUp(viewUp); })
     .property("viewAngle",
       static_cast<f3d::angle_deg_t (f3d::camera::*)() const>(&f3d::camera::getViewAngle),
       &f3d::camera::setViewAngle)
+    .property(
+      "state", +[](const f3d::camera& cam) -> f3d::camera_state_t { return cam.getState(); },
+      +[](f3d::camera& cam, const f3d::camera_state_t& state) -> f3d::camera&
+      { return cam.setState(state); })
     .function("dolly", &f3d::camera::dolly, emscripten::return_value_policy::reference())
     .function("pan", &f3d::camera::pan, emscripten::return_value_policy::reference())
     .function("zoom", &f3d::camera::zoom, emscripten::return_value_policy::reference())
@@ -440,15 +525,54 @@ EMSCRIPTEN_BINDINGS(f3d)
       })
     .function("getDPIScale", &f3d::window::getDPIScale);
 
+  // f3d::interaction_bind_t
+  emscripten::enum_<f3d::interaction_bind_t::ModifierKeys>("InteractionBindModifierKeys")
+    .value("ANY", f3d::interaction_bind_t::ModifierKeys::ANY)
+    .value("NONE", f3d::interaction_bind_t::ModifierKeys::NONE)
+    .value("CTRL", f3d::interaction_bind_t::ModifierKeys::CTRL)
+    .value("SHIFT", f3d::interaction_bind_t::ModifierKeys::SHIFT)
+    .value("CTRL_SHIFT", f3d::interaction_bind_t::ModifierKeys::CTRL_SHIFT);
+
+  emscripten::class_<f3d::interaction_bind_t>("InteractionBind")
+    .constructor<>()
+    .property("mod", &f3d::interaction_bind_t::mod)
+    .property("inter", &f3d::interaction_bind_t::inter);
+
   // f3d::interactor
   emscripten::enum_<f3d::interactor::AnimationDirection>("InteractorAnimationDirection")
     .value("FORWARD", f3d::interactor::AnimationDirection::FORWARD)
     .value("BACKWARD", f3d::interactor::AnimationDirection::BACKWARD);
 
-  // Not bound on purpose because usually used for external interactors:
-  // trigger*
-  // TODO:
-  // - bindings
+  emscripten::enum_<f3d::interactor::BindingType>("InteractorBindingType")
+    .value("CYCLIC", f3d::interactor::BindingType::CYCLIC)
+    .value("NUMERICAL", f3d::interactor::BindingType::NUMERICAL)
+    .value("TOGGLE", f3d::interactor::BindingType::TOGGLE)
+    .value("OTHER", f3d::interactor::BindingType::OTHER);
+
+  emscripten::enum_<f3d::interactor::MouseButton>("InteractorMouseButton")
+    .value("LEFT", f3d::interactor::MouseButton::LEFT)
+    .value("RIGHT", f3d::interactor::MouseButton::RIGHT)
+    .value("MIDDLE", f3d::interactor::MouseButton::MIDDLE);
+
+  emscripten::enum_<f3d::interactor::WheelDirection>("InteractorWheelDirection")
+    .value("FORWARD", f3d::interactor::WheelDirection::FORWARD)
+    .value("BACKWARD", f3d::interactor::WheelDirection::BACKWARD)
+    .value("LEFT", f3d::interactor::WheelDirection::LEFT)
+    .value("RIGHT", f3d::interactor::WheelDirection::RIGHT);
+
+  emscripten::enum_<f3d::interactor::InputAction>("InteractorInputAction")
+    .value("PRESS", f3d::interactor::InputAction::PRESS)
+    .value("RELEASE", f3d::interactor::InputAction::RELEASE);
+
+  emscripten::enum_<f3d::interactor::InputModifier>("InteractorInputModifier")
+    .value("NONE", f3d::interactor::InputModifier::NONE)
+    .value("CTRL", f3d::interactor::InputModifier::CTRL)
+    .value("SHIFT", f3d::interactor::InputModifier::SHIFT)
+    .value("CTRL_SHIFT", f3d::interactor::InputModifier::CTRL_SHIFT);
+
+  emscripten::class_<f3d::interactor_state_t>("InteractorState")
+    .property("animationTime", &f3d::interactor_state_t::animationTime);
+
   emscripten::class_<f3d::interactor>("Interactor")
     .function(
       "initCommands", &f3d::interactor::initCommands, emscripten::return_value_policy::reference())
@@ -472,22 +596,71 @@ EMSCRIPTEN_BINDINGS(f3d)
       +[](f3d::interactor& interactor, const std::string& command, bool keepComments) -> bool
       { return interactor.triggerCommand(command, keepComments); })
     .function(
-      "toggleAnimation",
-      +[](f3d::interactor& interactor, emscripten::val direction) -> f3d::interactor&
+      "initBindings", &f3d::interactor::initBindings, emscripten::return_value_policy::reference())
+    .function(
+      "addBinding",
+      +[](f3d::interactor& interactor, const f3d::interaction_bind_t& bind,
+         const emscripten::val& commands) -> f3d::interactor&
       {
-        return direction.isUndefined()
-          ? interactor.toggleAnimation()
-          : interactor.toggleAnimation(direction.as<f3d::interactor::AnimationDirection>());
+        const std::vector<std::string> commandList =
+          emscripten::vecFromJSArray<std::string>(commands);
+        return interactor.addBinding(bind, commandList);
       },
       emscripten::return_value_policy::reference())
     .function(
+      "addBinding",
+      +[](f3d::interactor& interactor, const f3d::interaction_bind_t& bind,
+         const emscripten::val& commands, std::string group, const emscripten::val& callback,
+         f3d::interactor::BindingType type, bool notify) -> f3d::interactor&
+      {
+        auto wrapCallback = [=]() -> std::pair<std::string, std::string>
+        {
+          emscripten::val result = callback();
+          if (!result.isArray() || result["length"].as<unsigned int>() != 2)
+          {
+            throw std::runtime_error("Callback must return an array of two strings");
+          }
+          return { result[0].as<std::string>(), result[1].as<std::string>() };
+        };
+        const std::vector<std::string> commandList =
+          emscripten::vecFromJSArray<std::string>(commands);
+        return interactor.addBinding(bind, commandList, group, wrapCallback, type, notify);
+      },
+      emscripten::return_value_policy::reference())
+    .function("removeBinding", &f3d::interactor::removeBinding,
+      emscripten::return_value_policy::reference())
+    .function(
+      "getBindGroups", +[](const f3d::interactor& interactor) -> emscripten::val
+      { return containerToJSArray(interactor.getBindGroups()); })
+    .function(
+      "getBinds", +[](const f3d::interactor& interactor) -> emscripten::val
+      { return containerToJSArray(interactor.getBinds()); })
+    .function(
+      "getBindingDocumentation",
+      +[](const f3d::interactor& interactor, const f3d::interaction_bind_t& bind) -> emscripten::val
+      {
+        auto bindingDoc = interactor.getBindingDocumentation(bind);
+        std::vector<std::string> docStrings;
+        docStrings.emplace_back(bindingDoc.first);
+        docStrings.emplace_back(bindingDoc.second);
+        return containerToJSArray(docStrings);
+      })
+    .function("getBindingType", &f3d::interactor::getBindingType)
+    .function(
+      "toggleAnimation", +[](f3d::interactor& interactor) -> f3d::interactor&
+      { return interactor.toggleAnimation(); }, emscripten::return_value_policy::reference())
+    .function(
+      "toggleAnimation",
+      +[](f3d::interactor& interactor, emscripten::val direction) -> f3d::interactor&
+      { return interactor.toggleAnimation(direction.as<f3d::interactor::AnimationDirection>()); },
+      emscripten::return_value_policy::reference())
+    .function(
+      "startAnimation", +[](f3d::interactor& interactor) -> f3d::interactor&
+      { return interactor.startAnimation(); }, emscripten::return_value_policy::reference())
+    .function(
       "startAnimation",
       +[](f3d::interactor& interactor, emscripten::val direction) -> f3d::interactor&
-      {
-        return direction.isUndefined()
-          ? interactor.startAnimation()
-          : interactor.startAnimation(direction.as<f3d::interactor::AnimationDirection>());
-      },
+      { return interactor.startAnimation(direction.as<f3d::interactor::AnimationDirection>()); },
       emscripten::return_value_policy::reference())
     .function("stopAnimation", &f3d::interactor::stopAnimation,
       emscripten::return_value_policy::reference())
@@ -497,14 +670,25 @@ EMSCRIPTEN_BINDINGS(f3d)
       emscripten::return_value_policy::reference())
     .function("disableCameraMovement", &f3d::interactor::disableCameraMovement,
       emscripten::return_value_policy::reference())
-    .function(
-      "start", +[](f3d::interactor& interactor) -> f3d::interactor& { return interactor.start(); },
+
+    .function("triggerModUpdate", &f3d::interactor::triggerModUpdate,
       emscripten::return_value_policy::reference())
-    .function("stop", &f3d::interactor::stop, emscripten::return_value_policy::reference())
-    .function("requestRender", &f3d::interactor::requestRender,
+    .function("triggerMouseButton", &f3d::interactor::triggerMouseButton,
+      emscripten::return_value_policy::reference())
+    .function("triggerMousePosition", &f3d::interactor::triggerMousePosition,
+      emscripten::return_value_policy::reference())
+    .function("triggerMouseWheel", &f3d::interactor::triggerMouseWheel,
       emscripten::return_value_policy::reference())
     .function(
-      "requestStop", &f3d::interactor::requestStop, emscripten::return_value_policy::reference())
+      "triggerKeyboardKey",
+      +[](f3d::interactor& interactor, f3d::interactor::InputAction action,
+         std::string keySym) -> f3d::interactor&
+      { return interactor.triggerKeyboardKey(action, keySym); },
+      emscripten::return_value_policy::reference())
+    .function("triggerTextCharacter", &f3d::interactor::triggerTextCharacter,
+      emscripten::return_value_policy::reference())
+    .function("triggerEventLoop", &f3d::interactor::triggerEventLoop,
+      emscripten::return_value_policy::reference())
     .function("triggerNotification", &f3d::interactor::triggerNotification,
       emscripten::return_value_policy::reference())
     .function(
@@ -522,7 +706,35 @@ EMSCRIPTEN_BINDINGS(f3d)
         { return callback(desc, value, bind, duration).as<bool>(); };
 
         interactor.setNotificationCallback(cb);
-      });
+      })
+    .function(
+      "playInteraction",
+      +[](f3d::interactor& interactor, const std::string& path, double deltaTime) -> bool
+      { return interactor.playInteraction(path, deltaTime); })
+    .function(
+      "recordInteraction", +[](f3d::interactor& interactor, const std::string& path) -> bool
+      { return interactor.recordInteraction(path); })
+    .function(
+      "setEventLoopUserCallback",
+      +[](f3d::interactor& interactor, const emscripten::val& callback) -> f3d::interactor&
+      {
+        if (callback.isUndefined() || callback.isNull())
+        {
+          return interactor.setEventLoopUserCallback(nullptr);
+        }
+
+        return interactor.setEventLoopUserCallback(
+          [=](f3d::interactor_state_t state) { callback(state); });
+      },
+      emscripten::return_value_policy::reference())
+    .function(
+      "start", +[](f3d::interactor& interactor) -> f3d::interactor& { return interactor.start(); },
+      emscripten::return_value_policy::reference())
+    .function("stop", &f3d::interactor::stop, emscripten::return_value_policy::reference())
+    .function("requestRender", &f3d::interactor::requestRender,
+      emscripten::return_value_policy::reference())
+    .function(
+      "requestStop", &f3d::interactor::requestStop, emscripten::return_value_policy::reference());
 
   // f3d::engine
   // Not bound on purpose because only one engine is supported:

--- a/webassembly/testing/CMakeLists.txt
+++ b/webassembly/testing/CMakeLists.txt
@@ -4,6 +4,7 @@ set(f3djsTests_list
   "test_engine"
   "test_image"
   "test_interactor"
+  "test_memory_view"
   "test_options"
   "test_render"
   "test_scene"

--- a/webassembly/testing/test_camera.js
+++ b/webassembly/testing/test_camera.js
@@ -15,6 +15,8 @@ const settings = {
   runAfter: (Module) => {
     const camera = Module.engineInstance.getWindow().getCamera();
 
+    const state = camera.state;
+
     utils.assert(
       utils.numArrayEquals(camera.position, [0, -0.016, 7.059], 0.01),
     );
@@ -48,6 +50,12 @@ const settings = {
       .yaw(-20)
       .elevation(25)
       .pitch(-30);
+
+    camera.state = state;
+
+    utils.assert(
+      utils.numArrayEquals(camera.position, [0, -0.016, 7.059], 0.01),
+    );
 
     camera.resetToDefault();
   },

--- a/webassembly/testing/test_interactor.js
+++ b/webassembly/testing/test_interactor.js
@@ -89,6 +89,102 @@ const settings = {
     );
     interactor.stopAnimation();
 
+    // bindings
+    interactor.initBindings();
+
+    const initialBinds = interactor.getBinds();
+    utils.assert(
+      Array.isArray(initialBinds) && initialBinds.length > 0,
+      "bindings should be returned",
+    );
+
+    const bind = new Module.InteractionBind();
+    bind.mod = Module.InteractionBindModifierKeys.NONE;
+    bind.inter = "R";
+
+    interactor.addBinding(
+      bind,
+      ["set render.grid.reflection .8"],
+      "test-group",
+      () => ["foo", "bar"],
+      Module.InteractorBindingType.OTHER,
+      false,
+    );
+
+    const updatedBinds = interactor.getBinds();
+    utils.assert(
+      updatedBinds.length === initialBinds.length + 1,
+      "new binding should be registered",
+    );
+
+    const bindGroups = interactor.getBindGroups();
+    utils.assert(
+      bindGroups.includes("test-group"),
+      "new bind group should be registered",
+    );
+
+    const docs = interactor.getBindingDocumentation(bind);
+    utils.assert(
+      Array.isArray(docs) && docs[0] === "foo" && docs[1] === "bar",
+      "binding documentation should be returned",
+    );
+
+    const bindingType = interactor.getBindingType(bind);
+    utils.assert(
+      bindingType === Module.InteractorBindingType.OTHER,
+      "binding type should round-trip",
+    );
+
+    // start recording
+    interactor.recordInteraction("/test_interaction.txt");
+
+    // input events coverage, just check we do not throw
+    // all these calls have no effect on the resulting image
+    let inputEventError = false;
+    try {
+      interactor.triggerModUpdate(Module.InteractionBindModifierKeys.NONE);
+      interactor.triggerMousePosition(0, 0);
+      interactor.triggerMouseButton(
+        Module.InteractorInputAction.PRESS,
+        Module.InteractorMouseButton.LEFT,
+      );
+      interactor.triggerMouseButton(
+        Module.InteractorInputAction.RELEASE,
+        Module.InteractorMouseButton.LEFT,
+      );
+      interactor.triggerTextCharacter(0x42);
+    } catch {
+      inputEventError = true;
+    }
+    utils.assert(!inputEventError, "input event bindings should not throw");
+
+    // check file content
+    const interactionFileContent = Module.FS.readFile("/test_interaction.txt", {
+      encoding: "utf8",
+    });
+    utils.assert(
+      interactionFileContent.includes("MouseMoveEvent 0 299 0 0 0 0 0"),
+      "interaction file should contain the expected command",
+    );
+
+    // play it (no effect on the resulting image, just check we do not throw)
+    interactor.playInteraction("/test_interaction.txt", 0.1);
+
+    // zoom out
+    interactor.triggerMouseWheel(Module.InteractorWheelDirection.BACKWARD);
+
+    // trigger "set render.grid.reflection .8"
+    interactor.triggerKeyboardKey(Module.InteractorInputAction.PRESS, "R");
+    interactor.triggerKeyboardKey(Module.InteractorInputAction.RELEASE, "R");
+
+    let bindingRemoved = false;
+    try {
+      interactor.removeBinding(bind);
+    } catch {
+      bindingRemoved = true;
+    }
+    utils.assert(!bindingRemoved, "binding should be removable");
+
     // notifications
     let notifCount = 0;
 
@@ -99,6 +195,16 @@ const settings = {
 
     interactor.triggerNotification("Test notification", "value", 1.0);
     utils.assert(notifCount === 1, "notification callback not called");
+
+    let eventLoopState = null;
+    interactor.setEventLoopUserCallback((state) => {
+      eventLoopState = state;
+    });
+    interactor.triggerEventLoop(0.1);
+    utils.assert(
+      eventLoopState && typeof eventLoopState.animationTime === "number",
+      "event loop state should expose animation time",
+    );
 
     // only for coverage, do not test the actual feature yet
     interactor.disableCameraMovement();

--- a/webassembly/testing/test_memory_view.js
+++ b/webassembly/testing/test_memory_view.js
@@ -1,0 +1,19 @@
+import utils from "./utils.js";
+
+const settings = {
+  runBefore: (Module) => {
+    Module.engineInstance.getScene().addMeshView({
+      name: "mesh_view",
+      pointCount: 4,
+      points: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]),
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      textureCoordinates: new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]),
+      polygonOffsets: new Uint32Array([0, 4]),
+      polygonIndices: new Uint32Array([0, 1, 2, 3]),
+    });
+  },
+};
+
+utils.runRenderTest(settings, {
+  baseline: "TestWasmMeshView.png",
+});

--- a/webassembly/testing/test_scene.js
+++ b/webassembly/testing/test_scene.js
@@ -143,6 +143,48 @@ const settings = {
       info.numberOfPoints > 0n && info.numberOfCells > 0n,
       "scene info should count points and cells",
     );
+
+    // add a custom mesh
+    let mesh = new Module.Mesh();
+    mesh.points = new Float32Array([0, 0, 0, 30, 0, 0, 0, 30, 0]);
+    mesh.normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+    mesh.textureCoordinates = new Float32Array([0, 0, 1, 0, 0, 1]);
+    mesh.faceSides = new Uint32Array([3]);
+    mesh.faceIndices = new Uint32Array([0, 1, 2]);
+    scene.addMesh(mesh);
+
+    const newInfo = scene.getSceneInfo();
+
+    utils.assert(
+      newInfo.numberOfFiles === 2 && newInfo.numberOfActors > 0,
+      "scene info should count the added file and its actors",
+    );
+
+    // check lights
+    utils.assert(scene.getLightCount() === 5, "scene should have five lights");
+
+    let light0 = scene.getLight(0);
+    utils.assert(
+      light0.type === Module.LightType.HEADLIGHT,
+      "first light should be headlight",
+    );
+
+    // modify first light color / intensity
+    light0.color = new Module.Color(1.0, 0.0, 0.0);
+    light0.intensity *= 3.0;
+    scene.updateLight(0, light0);
+
+    // remove last light
+    scene.removeLight(4);
+    utils.assert(scene.getLightCount() === 4, "scene should have four lights");
+
+    // remove all lights
+    scene.removeAllLights();
+    utils.assert(scene.getLightCount() === 0, "scene should have no lights");
+
+    // restore first headlight
+    scene.addLight(light0);
+    utils.assert(scene.getLightCount() === 1, "scene should have one light");
   },
 };
 

--- a/webassembly/testing/utils.js
+++ b/webassembly/testing/utils.js
@@ -68,11 +68,13 @@ const utils = {
     f3d(settings)
       .then(async (Module) => {
         // write in the wasm filesystem
-        await utils.copyLocalFileToWasmFS(
-          Module,
-          "/src/testing/data/" + args.data,
-          args.data,
-        );
+        if (args.data) {
+          await utils.copyLocalFileToWasmFS(
+            Module,
+            "/src/testing/data/" + args.data,
+            args.data,
+          );
+        }
 
         for (const extraData of args.extraData ?? []) {
           await utils.copyLocalFileToWasmFS(
@@ -121,14 +123,18 @@ const utils = {
 
         const scene = Module.engineInstance.getScene();
 
-        utils.assert(
-          scene.supports(args.data) === Module.FileAvailability.SUPPORTED,
-          args.data + " is not supported",
-        );
+        if (args.data) {
+          utils.assert(
+            scene.supports(args.data) === Module.FileAvailability.SUPPORTED,
+            args.data + " is not supported",
+          );
+        }
 
         Module.runBefore?.(Module);
 
-        scene.add(args.data);
+        if (args.data) {
+          scene.add(args.data);
+        }
 
         Module.runAfter?.(Module);
 


### PR DESCRIPTION
### Describe your changes

Add missing bindings:
- camera state
- lights
- mesh_t
- types (point, vector, color)
- command binds
- trigger inputs API
- record/play interaction

Also add a missing option update in the event loop.

### Issue ticket number and link if any

Fix https://github.com/f3d-app/f3d/issues/1573

### Checklist for finalizing the PR

- [x] I have performed a [self-review](https://f3d.app/dev/CODING_STYLE) of my code
- [ ] I have added [tests](https://f3d.app/dev/TESTING) for new features and bugfixes
- [ ] I have added [documentation](https://f3d.app/docs/next/user/QUICKSTART) for new features
- [ ] If it is a modifying the libf3d API, I have updated bindings
- [ ] If it is a modifying the `.github/workflows/versions.json`, I have updated `docker_timestamp`

### AI Disclosure

- [ ] I have not used AI to generate any of the content of this pull request
- [x] I have used AI to generate code in this pull request:
  - [x] I have carefully read and understood the [AI policy](https://f3d.app/dev/AI_POLICY).
  - [x] I have carefully reviewed and completely understood every generated line.
  - [x] I disclose below which parts of the code were generated and with which AI model:

I've used VSCode autocompletion (MAI-Code-1-Flash model).

### Continuous integration

Please write a comment to run CI, eg: `\ci fast`.
See [here](https://f3d.app/dev/CONTRIBUTING#continuous-integration) for more info.
